### PR TITLE
fix(tooling): updating common pipeline tag and node app module version 

### DIFF
--- a/.azure/pipelines/azure-pipelines-deploy.yml
+++ b/.azure/pipelines/azure-pipelines-deploy.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.18.1
+      ref: refs/tags/release/3.18.2
   pipelines:
     - pipeline: build
       source: Build

--- a/infrastructure/app-manage.tf
+++ b/infrastructure/app-manage.tf
@@ -1,6 +1,6 @@
 module "app_manage" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.29"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
 
   resource_group_name = azurerm_resource_group.primary.name
   location            = module.primary_region.location

--- a/infrastructure/app-portal.tf
+++ b/infrastructure/app-portal.tf
@@ -1,6 +1,6 @@
 module "app_portal" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.29"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
 
   resource_group_name = azurerm_resource_group.primary.name
   location            = module.primary_region.location


### PR DESCRIPTION
## Describe your changes

To disable continuous deployment, deploy pipeline is updated with v3.18.2 for application deploy pipeline 

with tag 1.31 of node app service modules, DOCKER_ENABLE_CI is set to false

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
