### PR TITLE
feat: wrap prisma errors so they aren't shown to users

### DIFF
--- a/.azure/pipelines/azure-pipelines-pr.yml
+++ b/.azure/pipelines/azure-pipelines-pr.yml
@@ -35,6 +35,12 @@ extends:
               script: npm ci
           - template: ../steps/node_script.yml
             parameters:
+              nodeVersion: 22
+              # ensure @prisma/client is generated for tests that use it
+              # this will also catch schema validation errors
+              script: npm run db-generate
+          - template: ../steps/node_script.yml
+            parameters:
               # only run commitlint on branches, not main
               condition: ne(variables['Build.SourceBranchName'], 'main')
               nodeVersion: 22

--- a/package-lock.json
+++ b/package-lock.json
@@ -5667,6 +5667,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "*",
+        "@prisma/client": "*",
         "connect-redis": "*",
         "express-session": "*",
         "pino": "*",

--- a/packages/lib/middleware/errors.test.js
+++ b/packages/lib/middleware/errors.test.js
@@ -1,38 +1,85 @@
-import { test, describe } from 'node:test';
+import { test, describe, mock } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { buildDefaultErrorHandlerMiddleware, notFoundHandler } from './errors.js';
+import { buildDefaultErrorHandlerMiddleware, notFoundHandler, wrapPrismaErrors } from './errors.js';
+import { Prisma } from '@prisma/client';
 
 describe('errors', () => {
 	describe('buildDefaultErrorHandlerMiddleware', () => {
-		test('uses error status code', (t) => {
+		test('uses error status code', () => {
 			const logger = {
-				error() {}
+				error: mock.fn()
 			};
-			t.mock.method(logger, 'error');
 			const handler = buildDefaultErrorHandlerMiddleware(logger);
 			const err = {
 				statusCode: 502
 			};
 			const res = {
-				status() {},
-				render() {}
+				status: mock.fn(),
+				render: mock.fn()
 			};
-			t.mock.method(res, 'status');
-			t.mock.method(res, 'render');
 
 			handler(err, {}, res, () => {});
 			assert.strictEqual(res.status.mock.callCount(), 1);
 			assert.deepStrictEqual(res.status.mock.calls[0].arguments, [err.statusCode]);
 		});
 	});
+	describe('wrapPrismaErrors', () => {
+		test('ignores non-prisma errors', () => {
+			const error = new Error('Some error');
+			const wrapped = wrapPrismaErrors(error);
+			assert.strictEqual(error, wrapped);
+		});
+		test('wraps known request errors', () => {
+			const error = new Prisma.PrismaClientKnownRequestError('Known error', {
+				code: 'Code101'
+			});
+			const wrapped = wrapPrismaErrors(error);
+			assert.notStrictEqual(error, wrapped);
+			assert.strictEqual(wrapped.message.startsWith('Request could not be handled'), true);
+			assert.strictEqual(wrapped.message.endsWith('(code: Code101)'), true);
+		});
+		test('wraps unknown request errors', () => {
+			const error = new Prisma.PrismaClientUnknownRequestError('Unknown error', {});
+			const wrapped = wrapPrismaErrors(error);
+			assert.notStrictEqual(error, wrapped);
+			assert.strictEqual(wrapped.message.startsWith('Request could not be handled'), true);
+			assert.strictEqual(wrapped.message.endsWith('(code: unknown)'), true);
+		});
+		test('wraps validation errors', () => {
+			const error = new Prisma.PrismaClientValidationError('Validation error', {});
+			const wrapped = wrapPrismaErrors(error);
+			assert.notStrictEqual(error, wrapped);
+			assert.strictEqual(wrapped.message.startsWith('Request could not be handled'), true);
+			assert.strictEqual(wrapped.message.endsWith('(code: validation)'), true);
+		});
+		test('wraps initialisation errors', () => {
+			const error = new Prisma.PrismaClientInitializationError('Init error', '');
+			const wrapped = wrapPrismaErrors(error);
+			assert.notStrictEqual(error, wrapped);
+			assert.strictEqual(wrapped.message.startsWith('Connection error'), true);
+			assert.strictEqual(wrapped.message.endsWith('(code: unknown)'), true);
+		});
+		test('wraps initialisation errors and includes errorCode', () => {
+			const error = new Prisma.PrismaClientInitializationError('Init error', '', 'InitCode1');
+			const wrapped = wrapPrismaErrors(error);
+			assert.notStrictEqual(error, wrapped);
+			assert.strictEqual(wrapped.message.startsWith('Connection error'), true);
+			assert.strictEqual(wrapped.message.endsWith('(code: InitCode1)'), true);
+		});
+		test('wraps initialisation errors and add P1001 error code', () => {
+			const error = new Prisma.PrismaClientInitializationError(`Can't reach database server at localhost:1433`, '');
+			const wrapped = wrapPrismaErrors(error);
+			assert.notStrictEqual(error, wrapped);
+			assert.strictEqual(wrapped.message.startsWith('Connection error'), true);
+			assert.strictEqual(wrapped.message.endsWith('(code: P1001)'), true);
+		});
+	});
 	describe('notFound', () => {
-		test('returns 404', (t) => {
+		test('returns 404', () => {
 			const res = {
-				status() {},
-				render() {}
+				status: mock.fn(),
+				render: mock.fn()
 			};
-			t.mock.method(res, 'status');
-			t.mock.method(res, 'render');
 
 			notFoundHandler({}, res);
 			assert.strictEqual(res.status.mock.callCount(), 1);

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/msal-node": "*",
+    "@prisma/client": "*",
     "connect-redis": "*",
     "express-session": "*",
     "pino": "*",


### PR DESCRIPTION
## Describe your changes

Change to the shared default error handler to check for Prisma errors. Prisma errors are logged, but not shown directly to users. Instead new and simplified error messages are returned, with a Prisma code is present.

This is only a fallback.

## Issue ticket number and link

N/A
