### PR TITLE
ci: use git commit hash for deployments

### DIFF
--- a/.azure/pipelines/azure-pipelines-build.yml
+++ b/.azure/pipelines/azure-pipelines-build.yml
@@ -8,7 +8,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.18.2
+      ref: refs/tags/release/3.20.0
   pipelines:
     - pipeline: pr
       source: PR

--- a/.azure/pipelines/azure-pipelines-deploy.yml
+++ b/.azure/pipelines/azure-pipelines-deploy.yml
@@ -13,7 +13,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.18.2
+      ref: refs/tags/release/3.20.0
   pipelines:
     - pipeline: build
       source: Build
@@ -70,18 +70,20 @@ extends:
           - name: Deploy Portal
             steps:
               - checkout: self
-              - template: ../steps/azure_web_app_deploy.yml@templates
+              - template: ../steps/azure_web_app_deploy_slot.yml@templates
                 parameters:
                   appName: pins-app-crown-portal-$(ENVIRONMENT)
                   appResourceGroup: $(resourceGroup)
                   azurecrName: $(azurecrName)
                   repository: crown/portal
+                  slot: default
           - name: Deploy Manage
             steps:
               - checkout: self
-              - template: ../steps/azure_web_app_deploy.yml@templates
+              - template: ../steps/azure_web_app_deploy_slot.yml@templates
                 parameters:
                   appName: pins-app-crown-manage-$(ENVIRONMENT)
                   appResourceGroup: $(resourceGroup)
                   azurecrName: $(azurecrName)
                   repository: crown/manage
+                  slot: default


### PR DESCRIPTION
## Describe your changes

We are moving to using git commit hashes for Docker image tagging and deployments. This should help deployments be more robust, see the [documentation](https://pins-ds.atlassian.net/wiki/spaces/CS/pages/1719861253/App+Service+Deployments)

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/DEV-337
