### PR TITLE
fix(dynamic-forms): use a copy of session data for journey response

### DIFF
--- a/packages/dynamic-forms/src/lib/session-answer-store.js
+++ b/packages/dynamic-forms/src/lib/session-answer-store.js
@@ -84,7 +84,7 @@ export function buildGetJourneyResponseFromSession(journeyId) {
 		/** @type {Object<string, Record<string, unknown>>|undefined} */
 		const forms = req.session?.forms;
 		if (forms && journeyId in forms) {
-			answers = forms[journeyId];
+			answers = { ...forms[journeyId] }; // work with a copy, we don't want to edit session values
 		}
 		for (const [k, v] of Object.entries(answers)) {
 			if (typeof v === 'boolean') {

--- a/packages/dynamic-forms/src/lib/session-answer-store.test.js
+++ b/packages/dynamic-forms/src/lib/session-answer-store.test.js
@@ -159,5 +159,21 @@ describe('session-answer-store', () => {
 				q3: BOOLEAN_OPTIONS.NO
 			});
 		});
+		it('should not edit the session answers when changing boolean answers', async () => {
+			const answers = { q1: true, q2: 'a2', q3: false };
+			const req = mockReq();
+			req.session = {
+				forms: {
+					[journeyId]: answers
+				}
+			};
+			const res = mockRes();
+			const next = mock.fn();
+			const handler = buildGetJourneyResponseFromSession(journeyId);
+			handler(req, res, next);
+			assert.ok(res.locals.journeyResponse);
+			assert.notStrictEqual(res.locals.journeyResponse.answers, answers);
+			assert.strictEqual(answers.q1, true);
+		});
 	});
 });


### PR DESCRIPTION
This is to avoid bugs related to changing answers to yes/no from boolean values, this should apply to the journey response answers, but not to the session data.

Previously the answers object was a reference to the session answers object, so the session was unintentionally edited.

## Describe your changes

The symptom of this was when answering "Has agent" question with yes, the agent questions were not displayed as the answer value was "true" instead of "yes".

## Issue ticket number and link
