### PR TITLE
feat(manage): use date-period component for representations period

### DIFF
--- a/apps/manage/src/app/views/cases/view/journey.js
+++ b/apps/manage/src/app/views/cases/view/journey.js
@@ -75,8 +75,7 @@ export function createJourney(questions, response, req) {
 				.addQuestion(questions.originalDecisionDate)
 				.addQuestion(questions.turnedAwayDate),
 			new Section('Representations Period', 'representations')
-				.addQuestion(questions.representationsPeriodStartDate)
-				.addQuestion(questions.representationsPeriodEndDate)
+				.addQuestion(questions.representationsPeriod)
 				.addQuestion(questions.representationsPublishDate),
 			new Section('Case Involvement', 'case-involvement')
 				.addQuestion(questions.inspector)

--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -24,6 +24,7 @@ import {
 } from './question-utils.js';
 import { ENVIRONMENT_NAME, loadEnvironmentConfig } from '../../../config.js';
 import AddressValidator from '@pins/dynamic-forms/src/validator/address-validator.js';
+import DatePeriodValidator from '@pins/dynamic-forms/src/validator/date-period-validator.js';
 
 export function getQuestions() {
 	const env = loadEnvironmentConfig();
@@ -287,8 +288,16 @@ export function getQuestions() {
 		originalDecisionDate: dateQuestion('originalDecisionDate'),
 		turnedAwayDate: dateQuestion('turnedAwayDate'),
 
-		representationsPeriodStartDate: dateQuestion('representationsPeriodStartDate'),
-		representationsPeriodEndDate: dateQuestion('representationsPeriodEndDate'),
+		representationsPeriod: {
+			type: COMPONENT_TYPES.DATE_PERIOD,
+			title: 'Representations Period',
+			question: `What is the Representations Period?`,
+			fieldName: 'representationsPeriod',
+			url: 'representations-period',
+			validators: [new DatePeriodValidator('Representations period')],
+			labels: { start: 'Open', end: 'Close' },
+			endTime: { hour: 23, minute: 59 }
+		},
 		representationsPublishDate: dateQuestion('representationsPublishDate'),
 
 		// todo: needs to be autocomplete with options loaded from Entra

--- a/apps/manage/src/app/views/cases/view/types.d.ts
+++ b/apps/manage/src/app/views/cases/view/types.d.ts
@@ -59,8 +59,10 @@ export interface CrownDevelopmentViewModel {
 	originalDecisionDate?: Date | string;
 	turnedAwayDate?: Date | string;
 
-	representationsPeriodStartDate?: Date | string;
-	representationsPeriodEndDate?: Date | string;
+	representationsPeriod?: {
+		start?: Date | string;
+		end?: Date | string;
+	};
 	representationsPublishDate?: Date | string;
 
 	inspectorId?: string;

--- a/apps/manage/src/app/views/cases/view/view-model.js
+++ b/apps/manage/src/app/views/cases/view/view-model.js
@@ -41,8 +41,6 @@ const UNMAPPED_VIEW_MODEL_FIELDS = Object.freeze([
 	'originalDecisionDate',
 	'turnedAwayDate',
 	'representationsPublishDate',
-	'representationsPeriodStartDate',
-	'representationsPeriodEndDate',
 	'inspectorId',
 	'assessorInspectorId',
 	'caseOfficerId',
@@ -76,6 +74,12 @@ export function crownDevelopmentToViewModel(crownDevelopment) {
 	const viewModel = {};
 	for (const field of UNMAPPED_VIEW_MODEL_FIELDS) {
 		viewModel[field] = crownDevelopment[field];
+	}
+	if (crownDevelopment.representationsPeriodStartDate || crownDevelopment.representationsPeriodEndDate) {
+		viewModel.representationsPeriod = {
+			start: crownDevelopment.representationsPeriodStartDate,
+			end: crownDevelopment.representationsPeriodEndDate
+		};
 	}
 	viewModel.siteArea = crownDevelopment.siteArea?.toNumber();
 	if (!viewModel.updatedDate) {
@@ -121,6 +125,11 @@ export function editsToDatabaseUpdates(edits, viewModel) {
 	// don't support updating these fields
 	delete crownDevelopmentUpdateInput.reference;
 	delete crownDevelopmentUpdateInput.updatedDate;
+
+	if (edits.representationsPeriod) {
+		crownDevelopmentUpdateInput.representationsPeriodStartDate = edits.representationsPeriod.start;
+		crownDevelopmentUpdateInput.representationsPeriodEndDate = edits.representationsPeriod.end;
+	}
 
 	// update relations
 

--- a/apps/manage/src/app/views/cases/view/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/view-model.test.js
@@ -20,6 +20,21 @@ describe('view-model', () => {
 			const result = crownDevelopmentToViewModel(input);
 			assert.strictEqual(result.updatedDate, input.createdDate);
 		});
+		it(`should map reps period`, () => {
+			/** @type {CrownDevelopment} */
+			const input = {
+				id: 'id-1',
+				referenceId: 'reference-id-1',
+				createdDate: new Date(),
+				representationsPeriodStartDate: 'date-1',
+				representationsPeriodEndDate: 'date-2'
+			};
+			const result = crownDevelopmentToViewModel(input);
+			assert.deepStrictEqual(result.representationsPeriod, {
+				start: 'date-1',
+				end: 'date-2'
+			});
+		});
 		it(`should map site address if present`, () => {
 			/** @type {CrownDevelopment} */
 			const input = {
@@ -257,6 +272,19 @@ describe('view-model', () => {
 			assert.ok(updates);
 			assert.strictEqual(updates.reference, undefined);
 			assert.strictEqual(updates.updatedDate, undefined);
+		});
+
+		it(`should map reps period`, () => {
+			/** @type {CrownDevelopmentViewModel} */
+			const toSave = {
+				representationsPeriod: {
+					start: 'date-1',
+					end: 'date-2'
+				}
+			};
+			const result = editsToDatabaseUpdates(toSave, {});
+			assert.deepStrictEqual(result.representationsPeriodStartDate, 'date-1');
+			assert.deepStrictEqual(result.representationsPeriodEndDate, 'date-2');
 		});
 		it('should map category relation', () => {
 			/** @type {CrownDevelopmentViewModel} */

--- a/packages/dynamic-forms/src/components/date-period/index.njk
+++ b/packages/dynamic-forms/src/components/date-period/index.njk
@@ -1,0 +1,140 @@
+{% extends layoutTemplate %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+
+{% set title = question.pageTitle + " - " + journeyTitle + " - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
+
+{% set startFieldName = question.fieldName + "_start" %}
+{% set startDayFieldName = question.fieldName + "_start_day" %}
+{% set startMonthFieldName = question.fieldName + "_start_month" %}
+{% set startYearFieldName = question.fieldName + "_start_year" %}
+{% set endFieldName = question.fieldName + "_end" %}
+{% set endDayFieldName = question.fieldName + "_end_day" %}
+{% set endMonthFieldName = question.fieldName + "_end_month" %}
+{% set endYearFieldName = question.fieldName + "_end_year" %}
+
+{% if question.html %}
+    {% set htmlHint %}
+        {% include question.html ignore missing %}
+    {% endset %}
+{% endif %}
+
+{% block before_content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {% if errorSummary %}
+                {{ govukErrorSummary({
+                    titleText: "There is a problem",
+                    errorList: errorSummary,
+                    attributes: {"data-cy": "error-wrapper"}
+                }) }}
+            {% endif %}
+        </div>
+    </div>
+
+    {{ super() }}
+{% endblock before_content %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate>
+                <input type="hidden" name="_csrf" value="{{ _csrf }}">
+
+                {{ govukFieldset({
+                    legend: {
+                        text: question.question,
+                        classes: "govuk-fieldset__legend--l",
+                        isPageHeading: true
+                    }
+                }) }}
+
+                {{ govukDateInput({
+                    id: startFieldName,
+                    fieldset: {
+                        legend: {
+                            text: labels.start
+                        }
+                    },
+                    hint: {
+                        text: question.hint
+                    },
+                    errorMessage: errorSummary and {
+                        text: errors[question.fieldName].msg or errors[startFieldName].msg or errors[startDayFieldName].msg or errors[startMonthFieldName].msg or errors[startYearFieldName].msg
+                    },
+                    items: [
+                        {
+                            classes: "govuk-input--width-2 govuk-input--error" if errors[startFieldName] or errors[startDayFieldName] else "govuk-input--width-2",
+                            name: startDayFieldName,
+                            label: "Day",
+                            id: startDayFieldName,
+                            value: question.value[startDayFieldName]
+                        },
+                        {
+                            classes: "govuk-input--width-2 govuk-input--error" if errors[startFieldName] or errors[startMonthFieldName] else "govuk-input--width-2",
+                            name: startMonthFieldName,
+                            label: "Month",
+                            id: startMonthFieldName,
+                            value: question.value[startMonthFieldName]
+                        },
+                        {
+                            classes: "govuk-input--width-4 govuk-input--error" if errors[startFieldName] or errors[startYearFieldName] else "govuk-input--width-4",
+                            name: startYearFieldName,
+                            label: "Year",
+                            id: startYearFieldName,
+                            value: question.value[startYearFieldName]
+                        }
+                    ]
+                }) }}
+
+                {{ govukDateInput({
+                    id: endFieldName,
+                    fieldset: {
+                        legend: {
+                            text: labels.end
+                        }
+                    },
+                    hint: {
+                        text: question.hint
+                    },
+                    errorMessage: errorSummary and {
+                        text: errors[question.fieldName].msg or errors[endFieldName].msg or errors[endDayFieldName].msg or errors[endMonthFieldName].msg or errors[endYearFieldName].msg
+                    },
+                    items: [
+                        {
+                            classes: "govuk-input--width-2 govuk-input--error" if errors[endFieldName] or errors[endDayFieldName] else "govuk-input--width-2",
+                            name: endDayFieldName,
+                            label: "Day",
+                            id: endDayFieldName,
+                            value: question.value[endDayFieldName]
+                        },
+                        {
+                            classes: "govuk-input--width-2 govuk-input--error" if errors[endFieldName] or errors[endMonthFieldName] else "govuk-input--width-2",
+                            name: endMonthFieldName,
+                            label: "Month",
+                            id: endMonthFieldName,
+                            value: question.value[endMonthFieldName]
+                        },
+                        {
+                            classes: "govuk-input--width-4 govuk-input--error" if errors[endFieldName] or errors[endYearFieldName] else "govuk-input--width-4",
+                            name: endYearFieldName,
+                            label: "Year",
+                            id: endYearFieldName,
+                            value: question.value[endYearFieldName]
+                        }
+                    ]
+                }) }}
+
+                {{ govukButton({
+                    text: continueButtonText,
+                    type: "submit",
+                    attributes: { "data-cy":"button-save-and-continue"}
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/packages/dynamic-forms/src/components/date-period/question.js
+++ b/packages/dynamic-forms/src/components/date-period/question.js
@@ -1,0 +1,188 @@
+import { formatDateForDisplay, parseDateInput } from '../../lib/date-utils.js';
+import { Question } from '../../questions/question.js';
+import { nl2br } from '../../lib/utils.js';
+import escape from 'escape-html';
+
+/**
+ * @typedef {import('../../questions/question.js').QuestionViewModel} QuestionViewModel
+ * @typedef {import('../../journey/journey.js').Journey} Journey
+ * @typedef {import('../../journey/journey-response.js').JourneyResponse} JourneyResponse
+ * @typedef {import('../../section').Section} Section
+ */
+
+const DEFAULT_DATE_FORMAT = 'HH:mm d MMMM yyyy';
+
+/**
+ * Represents a date period, two dates which make up a period or range
+ * @class
+ */
+export default class DatePeriodQuestion extends Question {
+	/**
+	 * @param {Object} params
+	 * @param {string} params.title
+	 * @param {string} params.question
+	 * @param {string} params.fieldName
+	 * @param {string} params.hint
+	 * @param {string} [params.url]
+	 * @param {Array.<import('../../validator/base-validator')>} [params.validators]
+	 * @param {boolean} [params.editable]
+	 * @param {string} [params.dateFormat]
+	 * @param {{start: string, end: string}} [params.labels]
+	 * @param {{hour: number, minute: number}} [params.startTime]
+	 * @param {{hour: number, minute: number}} [params.endTime]
+	 */
+	constructor({
+		title,
+		question,
+		fieldName,
+		validators,
+		hint,
+		url,
+		editable,
+		dateFormat = DEFAULT_DATE_FORMAT,
+		labels,
+		startTime,
+		endTime
+	}) {
+		super({
+			title,
+			viewFolder: 'date-period',
+			fieldName,
+			question,
+			validators,
+			hint,
+			url,
+			editable
+		});
+		this.dateFormat = dateFormat;
+		this.labels = labels || { start: 'Start', end: 'End' };
+		this.startTime = startTime || { hour: 0, minute: 0 };
+		this.endTime = endTime || { hour: 0, minute: 0 };
+	}
+
+	/**
+	 * returns the data to send to the DB
+	 * side effect: modifies journeyResponse with the new answers
+	 * @param {import('express').Request} req
+	 * @param {JourneyResponse} journeyResponse - current journey response, modified with the new answers
+	 * @returns {Promise.<Object>}
+	 */
+	async getDataToSave(req, journeyResponse) {
+		// set answer on response
+		let responseToSave = { answers: {} };
+
+		const startDayInput = req.body[`${this.fieldName}_start_day`];
+		const startMonthInput = req.body[`${this.fieldName}_start_month`];
+		const startYearInput = req.body[`${this.fieldName}_start_year`];
+		const endDayInput = req.body[`${this.fieldName}_end_day`];
+		const endMonthInput = req.body[`${this.fieldName}_end_month`];
+		const endYearInput = req.body[`${this.fieldName}_end_year`];
+
+		const startDate = parseDateInput({
+			minute: this.startTime.minute,
+			hour: this.startTime.hour,
+			day: startDayInput,
+			month: startMonthInput,
+			year: startYearInput
+		});
+		const endDate = parseDateInput({
+			minute: this.endTime.minute,
+			hour: this.endTime.hour,
+			day: endDayInput,
+			month: endMonthInput,
+			year: endYearInput
+		});
+
+		responseToSave.answers[this.fieldName] = { start: startDate, end: endDate };
+
+		journeyResponse.answers[this.fieldName] = responseToSave.answers[this.fieldName];
+
+		return responseToSave;
+	}
+
+	/**
+	 * gets the view model for this question
+	 * @param {Section} section - the current section
+	 * @param {Journey} journey - the journey we are in
+	 * @param {Object|undefined} [customViewData] additional data to send to view
+	 * @returns {QuestionViewModel & { answer: Record<string, unknown> }}
+	 */
+	prepQuestionForRendering(section, journey, customViewData, payload) {
+		let viewModel = super.prepQuestionForRendering(section, journey, customViewData);
+		viewModel.labels = this.labels;
+
+		/** @type {Record<string, unknown>} */
+		let answer = {};
+		let startDay;
+		let startMonth;
+		let startYear;
+		let endDay;
+		let endMonth;
+		let endYear;
+
+		if (payload) {
+			startDay = payload[`${this.fieldName}_start_day`];
+			startMonth = payload[`${this.fieldName}_start_month`];
+			startYear = payload[`${this.fieldName}_start_year`];
+			endDay = payload[`${this.fieldName}_end_day`];
+			endMonth = payload[`${this.fieldName}_end_month`];
+			endYear = payload[`${this.fieldName}_end_year`];
+		} else {
+			const answerPeriod = journey.response.answers[this.fieldName];
+			if (answerPeriod && answerPeriod.start) {
+				const startDate = new Date(answerPeriod.start);
+				startDay = formatDateForDisplay(startDate, { format: 'd' });
+				startMonth = formatDateForDisplay(startDate, { format: 'M' });
+				startYear = formatDateForDisplay(startDate, { format: 'yyyy' });
+			}
+			if (answerPeriod && answerPeriod.end) {
+				const endDate = new Date(answerPeriod.end);
+				endDay = formatDateForDisplay(endDate, { format: 'd' });
+				endMonth = formatDateForDisplay(endDate, { format: 'M' });
+				endYear = formatDateForDisplay(endDate, { format: 'yyyy' });
+			}
+		}
+
+		answer = {
+			[`${this.fieldName}_start_day`]: startDay,
+			[`${this.fieldName}_start_month`]: startMonth,
+			[`${this.fieldName}_start_year`]: startYear,
+			[`${this.fieldName}_end_day`]: endDay,
+			[`${this.fieldName}_end_month`]: endMonth,
+			[`${this.fieldName}_end_year`]: endYear
+		};
+
+		return { ...viewModel, answer, question: { ...viewModel.question, value: answer } };
+	}
+
+	/**
+	 * returns the formatted answers values to be used to build task list elements
+	 * @type {Question['formatAnswerForSummary']}
+	 */
+	formatAnswerForSummary(sectionSegment, journey, answer) {
+		let formattedAnswer;
+
+		if (answer) {
+			const start = answer.start && formatDateForDisplay(answer.start, { format: this.dateFormat });
+			const end = answer.end && formatDateForDisplay(answer.end, { format: this.dateFormat });
+			formattedAnswer = '';
+			if (start) {
+				formattedAnswer += `${this.labels.start}: ${start}`;
+				if (end) {
+					formattedAnswer += `\n`;
+				}
+			}
+			if (end) {
+				formattedAnswer += `${this.labels.end}: ${end}`;
+			}
+			formattedAnswer = nl2br(escape(formattedAnswer));
+		} else {
+			formattedAnswer = this.notStartedText;
+		}
+
+		const action = this.getAction(sectionSegment, journey, answer);
+		const key = this.title ?? this.question;
+
+		return [{ key: key, value: formattedAnswer, action: action }];
+	}
+}

--- a/packages/dynamic-forms/src/components/date-period/question.test.js
+++ b/packages/dynamic-forms/src/components/date-period/question.test.js
@@ -1,0 +1,345 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { Question } from '../../questions/question.js';
+import DatePeriodQuestion from './question.js';
+
+describe('DatePeriodQuestion', () => {
+	const TITLE = 'title';
+	const QUESTION = 'question';
+	const FIELDNAME = 'fieldName';
+	const HINT = 'hint hint';
+	const VALIDATORS = [];
+
+	describe('constructor', () => {
+		it('should instantiate and inherit from Question', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+			assert.strictEqual(dateQuestion instanceof DatePeriodQuestion, true);
+			assert.strictEqual(dateQuestion instanceof Question, true);
+			assert.strictEqual(dateQuestion.viewFolder, 'date-period');
+		});
+	});
+
+	describe('getDataToSave', () => {
+		it('should return data correctly', async () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+
+			const req = {
+				body: {
+					[`${FIELDNAME}_start_day`]: '1',
+					[`${FIELDNAME}_start_month`]: '2',
+					[`${FIELDNAME}_start_year`]: '2023',
+					[`${FIELDNAME}_end_day`]: '1',
+					[`${FIELDNAME}_end_month`]: '2',
+					[`${FIELDNAME}_end_year`]: '2024'
+				}
+			};
+
+			const journeyResponse = {
+				answers: {}
+			};
+
+			const result = await dateQuestion.getDataToSave(req, journeyResponse);
+			assert.deepStrictEqual(result.answers[FIELDNAME], {
+				start: new Date('2023-02-01T00:00:00.000Z'),
+				end: new Date('2024-02-01T00:00:00.000Z')
+			});
+		});
+		it('should use start and end time parameters', async () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS,
+				startTime: { hour: 3, minute: 24 },
+				endTime: { hour: 23, minute: 59 }
+			});
+
+			const req = {
+				body: {
+					[`${FIELDNAME}_start_day`]: '1',
+					[`${FIELDNAME}_start_month`]: '2',
+					[`${FIELDNAME}_start_year`]: '2023',
+					[`${FIELDNAME}_end_day`]: '1',
+					[`${FIELDNAME}_end_month`]: '2',
+					[`${FIELDNAME}_end_year`]: '2024'
+				}
+			};
+
+			const journeyResponse = {
+				answers: {}
+			};
+
+			const result = await dateQuestion.getDataToSave(req, journeyResponse);
+			assert.deepStrictEqual(result.answers[FIELDNAME], {
+				start: new Date('2023-02-01T03:24:00.000Z'),
+				end: new Date('2024-02-01T23:59:00.000Z')
+			});
+		});
+	});
+
+	describe('prepQuestionForRendering', () => {
+		it('should add answer data to viewmodel if it exists and no payload', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+
+			const start = new Date('2024-02-01T00:00:00.000Z');
+			const end = new Date('2024-02-05T23:59:00.000Z');
+
+			const formattedDate = {
+				[`${[FIELDNAME]}_start_day`]: '1',
+				[`${[FIELDNAME]}_start_month`]: '2',
+				[`${[FIELDNAME]}_start_year`]: '2024',
+				[`${[FIELDNAME]}_end_day`]: '5',
+				[`${[FIELDNAME]}_end_month`]: '2',
+				[`${[FIELDNAME]}_end_year`]: '2024'
+			};
+
+			const section = {
+				name: 'section-name'
+			};
+
+			const journey = {
+				baseUrl: '',
+				taskListUrl: 'list',
+				journeyTemplate: 'template',
+				journeyTitle: 'title',
+				response: {
+					answers: {
+						[FIELDNAME]: { start, end }
+					}
+				},
+				getBackLink: () => {
+					return 'back';
+				}
+			};
+
+			const preppedQuestionViewModel = dateQuestion.prepQuestionForRendering(section, journey);
+			assert.deepStrictEqual(preppedQuestionViewModel?.answer, formattedDate);
+		});
+
+		it('should add payload data to viewmodel (precedence over saved answer)', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+
+			const formattedDate = {
+				[`${[FIELDNAME]}_start_day`]: '99',
+				[`${[FIELDNAME]}_start_month`]: '99',
+				[`${[FIELDNAME]}_start_year`]: '202',
+				[`${[FIELDNAME]}_end_day`]: '88',
+				[`${[FIELDNAME]}_end_month`]: '77',
+				[`${[FIELDNAME]}_end_year`]: '101'
+			};
+
+			const section = {
+				name: 'section-name'
+			};
+
+			const journey = {
+				baseUrl: '',
+				taskListUrl: 'list',
+				journeyTemplate: 'template',
+				journeyTitle: 'title',
+				response: {
+					answers: {
+						[`${[FIELDNAME]}_start_day`]: '01',
+						[`${[FIELDNAME]}_start_month`]: '05',
+						[`${[FIELDNAME]}_start_year`]: '2024',
+						[`${[FIELDNAME]}_end_day`]: '02',
+						[`${[FIELDNAME]}_end_month`]: '06',
+						[`${[FIELDNAME]}_end_year`]: '2025'
+					}
+				},
+				getBackLink: () => {
+					return 'back';
+				}
+			};
+
+			const preppedQuestionViewModel = dateQuestion.prepQuestionForRendering(section, journey, {}, formattedDate);
+
+			assert.deepStrictEqual(preppedQuestionViewModel?.answer, formattedDate);
+		});
+
+		it('should not add any data to viewmodel if saved or payload data does not exist', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+
+			const section = {
+				name: 'section-name'
+			};
+
+			const journey = {
+				baseUrl: '',
+				taskListUrl: 'list',
+				journeyTemplate: 'template',
+				journeyTitle: 'title',
+				response: {
+					answers: {}
+				},
+				getBackLink: () => {
+					return 'back';
+				}
+			};
+
+			const formattedDate = {
+				[`${[FIELDNAME]}_start_day`]: undefined,
+				[`${[FIELDNAME]}_start_month`]: undefined,
+				[`${[FIELDNAME]}_start_year`]: undefined,
+				[`${[FIELDNAME]}_end_day`]: undefined,
+				[`${[FIELDNAME]}_end_month`]: undefined,
+				[`${[FIELDNAME]}_end_year`]: undefined
+			};
+
+			const preppedQuestionViewModel = dateQuestion.prepQuestionForRendering(section, journey);
+
+			assert.deepStrictEqual(preppedQuestionViewModel?.answer, formattedDate);
+		});
+	});
+
+	describe('formatAnswerForSummary', () => {
+		it('should return correctly formatted answer if it exists', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+
+			const answer = {
+				start: new Date('2023-01-01T00:00:00.000Z'),
+				end: new Date('2023-01-10T00:00:00.000Z')
+			};
+			const href = 'fake href';
+
+			const journey = {
+				getCurrentQuestionUrl: () => {
+					return href;
+				}
+			};
+
+			const result = dateQuestion.formatAnswerForSummary('segment', journey, answer);
+
+			assert.strictEqual(result[0].value, 'Start: 00:00 1 January 2023<br>End: 00:00 10 January 2023');
+			assert.strictEqual(result[0].action.href, href);
+			assert.strictEqual(result[0].action.text, 'Change');
+			assert.strictEqual(result[0].action.visuallyHiddenText, QUESTION);
+			assert.strictEqual(result[0].key, TITLE);
+		});
+		it('should return start only if set', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+
+			const answer = {
+				start: new Date('2023-01-01T00:00:00.000Z')
+			};
+			const href = 'fake href';
+
+			const journey = {
+				getCurrentQuestionUrl: () => {
+					return href;
+				}
+			};
+
+			const result = dateQuestion.formatAnswerForSummary('segment', journey, answer);
+
+			assert.strictEqual(result[0].value, 'Start: 00:00 1 January 2023');
+			assert.strictEqual(result[0].action.href, href);
+			assert.strictEqual(result[0].action.text, 'Change');
+			assert.strictEqual(result[0].action.visuallyHiddenText, QUESTION);
+			assert.strictEqual(result[0].key, TITLE);
+		});
+
+		it('should use custom labels if set', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS,
+				labels: { start: 'Open', end: 'Close' }
+			});
+
+			const answer = {
+				start: new Date('2023-01-01T00:00:00.000Z'),
+				end: new Date('2023-01-10T00:00:00.000Z')
+			};
+			const href = 'fake href';
+
+			const journey = {
+				getCurrentQuestionUrl: () => {
+					return href;
+				}
+			};
+
+			const result = dateQuestion.formatAnswerForSummary('segment', journey, answer);
+
+			assert.strictEqual(result[0].value, 'Open: 00:00 1 January 2023<br>Close: 00:00 10 January 2023');
+			assert.strictEqual(result[0].action.href, href);
+			assert.strictEqual(result[0].action.text, 'Change');
+			assert.strictEqual(result[0].action.visuallyHiddenText, QUESTION);
+			assert.strictEqual(result[0].key, TITLE);
+		});
+
+		it('should return not started if answer does not exist', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+
+			const answer = null;
+
+			const href = 'fake href';
+
+			const journey = {
+				getCurrentQuestionUrl: () => {
+					return href;
+				}
+			};
+
+			const result = dateQuestion.formatAnswerForSummary('segment', journey, answer);
+
+			assert.strictEqual(result[0].value, 'Not started');
+			assert.strictEqual(result[0].action.href, href);
+			assert.strictEqual(result[0].action.text, 'Answer');
+			assert.strictEqual(result[0].action.visuallyHiddenText, QUESTION);
+			assert.strictEqual(result[0].key, TITLE);
+		});
+	});
+});

--- a/packages/dynamic-forms/src/components/date/question.test.js
+++ b/packages/dynamic-forms/src/components/date/question.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert';
 import { Question } from '../../questions/question.js';
 import DateQuestion from './question.js';
 
-describe('DataQuestion', () => {
+describe('DateQuestion', () => {
 	const TITLE = 'title';
 	const QUESTION = 'question';
 	const FIELDNAME = 'fieldName';

--- a/packages/dynamic-forms/src/index.js
+++ b/packages/dynamic-forms/src/index.js
@@ -3,6 +3,7 @@ export const COMPONENT_TYPES = Object.freeze({
 	BOOLEAN: 'boolean',
 	RADIO: 'radio',
 	DATE: 'date',
+	DATE_PERIOD: 'date-period',
 	TEXT_ENTRY: 'text-entry',
 	SELECT: 'select',
 	SINGLE_LINE_INPUT: 'single-line-input',

--- a/packages/dynamic-forms/src/questions/questions.js
+++ b/packages/dynamic-forms/src/questions/questions.js
@@ -3,6 +3,7 @@ import CheckboxQuestion from '../components/checkbox/question.js';
 import BooleanQuestion from '../components/boolean/question.js';
 import RadioQuestion from '../components/radio/question.js';
 import DateQuestion from '../components/date/question.js';
+import DatePeriodQuestion from '../components/date-period/question.js';
 import TextEntryQuestion from '../components/text-entry/question.js';
 import SelectQuestion from '../components/select/question.js';
 import SingleLineInputQuestion from '../components/single-line-input/question.js';
@@ -22,6 +23,7 @@ export const questionClasses = Object.freeze({
 	[COMPONENT_TYPES.BOOLEAN]: BooleanQuestion,
 	[COMPONENT_TYPES.RADIO]: RadioQuestion,
 	[COMPONENT_TYPES.DATE]: DateQuestion,
+	[COMPONENT_TYPES.DATE_PERIOD]: DatePeriodQuestion,
 	[COMPONENT_TYPES.TEXT_ENTRY]: TextEntryQuestion,
 	[COMPONENT_TYPES.SELECT]: SelectQuestion,
 	[COMPONENT_TYPES.SINGLE_LINE_INPUT]: SingleLineInputQuestion,

--- a/packages/dynamic-forms/src/validator/date-period-validator.js
+++ b/packages/dynamic-forms/src/validator/date-period-validator.js
@@ -1,0 +1,183 @@
+import { body } from 'express-validator';
+
+import { isValid, parse } from 'date-fns';
+import { enGB } from 'date-fns/locale';
+
+import BaseValidator from './base-validator.js';
+
+/**
+ * @typedef {import('../components/date/question.js')} DateQuestion
+ */
+
+/**
+ * @typedef {Object} DateValidationSettings
+ * @property {Boolean} ensureFuture
+ * @property {Boolean} ensurePast
+ */
+
+/**
+ * enforces a user has entered a valid date period
+ * @class
+ */
+export default class DatePeriodValidator extends BaseValidator {
+	/** @type {DateValidationSettings} */
+	dateValidationSettings;
+
+	/**
+	 * creates an instance of a DateValidator
+	 * @param {string} inputLabel - string representing the field as displayed on the UI as part of an error message
+	 * @param {DateValidationSettings} [dateValidationSettings] - object containing rules to apply
+	 * @param {Object} [errorMessages] - object containing custom error messages to show on validation failure
+	 */
+	constructor(
+		inputLabel,
+		dateValidationSettings = {
+			ensureFuture: false,
+			ensurePast: false
+		},
+		errorMessages
+	) {
+		super();
+
+		const defaultErrorMessages = this.#getDefaultErrorMessages(inputLabel);
+
+		this.emptyErrorMessage = errorMessages?.emptyErrorMessage ?? defaultErrorMessages.emptyErrorMessage;
+		this.noDayErrorMessage = errorMessages?.noDayErrorMessage ?? defaultErrorMessages.noDayErrorMessage;
+		this.noMonthErrorMessage = errorMessages?.noMonthErrorMessage ?? defaultErrorMessages.noMonthErrorMessage;
+		this.noYearErrorMessage = errorMessages?.noYearErrorMessage ?? defaultErrorMessages.noYearErrorMessage;
+		this.noDayMonthErrorMessage = errorMessages?.noDayMonthErrorMessage ?? defaultErrorMessages.noDayMonthErrorMessage;
+		this.noDayYearErrorMessage = errorMessages?.noDayYearErrorMessage ?? defaultErrorMessages.noDayYearErrorMessage;
+		this.noMonthYearErrorMessage =
+			errorMessages?.noMonthYearErrorMessage ?? defaultErrorMessages.noMonthYearErrorMessage;
+		this.invalidDateErrorMessage =
+			errorMessages?.invalidDateErrorMessage ?? defaultErrorMessages.invalidDateErrorMessage;
+		this.invalidMonthErrorMessage =
+			errorMessages?.invalidMonthErrorMessage ?? defaultErrorMessages.invalidMonthErrorMessage;
+		this.invalidYearErrorMessage =
+			errorMessages?.invalidYearErrorMessage ?? defaultErrorMessages.invalidYearErrorMessage;
+		this.futureDateErrorMessage = errorMessages?.futureDateErrorMessage ?? defaultErrorMessages.futureDateErrorMessage;
+		this.pastDateErrorMessage = errorMessages?.pastDateErrorMessage ?? defaultErrorMessages.pastDateErrorMessage;
+
+		this.dateValidationSettings = dateValidationSettings;
+	}
+
+	/**
+	 * validates the response body, checking the values sent for the date are valid
+	 * @param {DateQuestion} questionObj
+	 */
+	validate(questionObj) {
+		const fieldName = questionObj.fieldName;
+		const startDayInput = `${fieldName}_start_day`;
+		const startMonthInput = `${fieldName}_start_month`;
+		const startYearInput = `${fieldName}_start_year`;
+		const endDayInput = `${fieldName}_end_day`;
+		const endMonthInput = `${fieldName}_end_month`;
+		const endYearInput = `${fieldName}_end_year`;
+
+		return [
+			...this.rulesForNotEmptyInput({
+				dayInput: startDayInput,
+				monthInput: startMonthInput,
+				yearInput: startYearInput
+			}),
+			...this.rulesForNotEmptyInput({ dayInput: endDayInput, monthInput: endMonthInput, yearInput: endYearInput }),
+			...this.rulesForValidInput({ dayInput: startDayInput, monthInput: startMonthInput, yearInput: startYearInput }),
+			...this.rulesForValidInput({ dayInput: endDayInput, monthInput: endMonthInput, yearInput: endYearInput })
+		];
+	}
+
+	rulesForNotEmptyInput({ dayInput, monthInput, yearInput }) {
+		return [
+			body(dayInput)
+				.notEmpty()
+				.withMessage((_, { req }) => {
+					if (!req.body[monthInput] && !req.body[yearInput]) {
+						return this.emptyErrorMessage;
+					}
+
+					if (!req.body[monthInput] && req.body[yearInput]) {
+						return this.noDayMonthErrorMessage;
+					}
+
+					if (req.body[monthInput] && !req.body[yearInput]) {
+						return this.noDayYearErrorMessage;
+					}
+
+					return this.noDayErrorMessage;
+				}),
+			body(monthInput)
+				.notEmpty()
+				.withMessage((_, { req }) => {
+					if (req.body[dayInput] && !req.body[yearInput]) {
+						return this.noMonthYearErrorMessage;
+					}
+					if (req.body[dayInput]) {
+						return this.noMonthErrorMessage;
+					}
+
+					// empty error message returned
+				}),
+			body(yearInput)
+				.notEmpty()
+				.withMessage((_, { req }) => {
+					if (req.body[dayInput] && req.body[monthInput]) return this.noYearErrorMessage;
+
+					// empty error message returned
+				})
+		];
+	}
+
+	rulesForValidInput({ dayInput, monthInput, yearInput }) {
+		return [
+			body(dayInput)
+				.isInt({ min: 1, max: 31 })
+				.withMessage(this.invalidDateErrorMessage)
+				.bail()
+				.toInt()
+				.custom((value, { req }) => {
+					const year = req.body[yearInput];
+					const month = req.body[monthInput];
+
+					if (
+						this.#isValidWrapper(year) &&
+						this.#isValidWrapper(year, month) &&
+						!this.#isValidWrapper(year, month, value)
+					) {
+						throw new Error(this.invalidDateErrorMessage);
+					}
+
+					return true;
+				}),
+			body(monthInput).isInt({ min: 1, max: 12 }).withMessage(this.invalidMonthErrorMessage),
+			body(yearInput).isInt({ min: 1000, max: 9999 }).withMessage(this.invalidYearErrorMessage)
+		];
+	}
+
+	/**
+	 * generates default error messages based on GDS guidelines
+	 * @param {string} inputLabel
+	 */
+	#getDefaultErrorMessages(inputLabel) {
+		const capitalisedInputLabel = inputLabel.charAt(0).toUpperCase() + inputLabel.slice(1);
+
+		return {
+			emptyErrorMessage: `Enter ${inputLabel}`,
+			noDayErrorMessage: `${capitalisedInputLabel} must include a day`,
+			noMonthErrorMessage: `${capitalisedInputLabel} must include a month`,
+			noYearErrorMessage: `${capitalisedInputLabel} must include a year`,
+			noDayMonthErrorMessage: `${capitalisedInputLabel} must include a day and month`,
+			noDayYearErrorMessage: `${capitalisedInputLabel} must include a day and year`,
+			noMonthYearErrorMessage: `${capitalisedInputLabel} must include a month and year`,
+			invalidDateErrorMessage: `${capitalisedInputLabel} must be a real date`,
+			invalidMonthErrorMessage: `${capitalisedInputLabel} month must be a real month`,
+			invalidYearErrorMessage: `${capitalisedInputLabel} year must include 4 numbers`,
+			futureDateErrorMessage: `${capitalisedInputLabel} must be today or in the past`,
+			pastDateErrorMessage: `${capitalisedInputLabel} must be today or in the future`
+		};
+	}
+
+	#isValidWrapper(year = 2000, month = 1, day = 1) {
+		const parsedDate = parse(`${day}/${month}/${year}`, 'P', new Date(), { locale: enGB });
+		return isValid(parsedDate);
+	}
+}

--- a/packages/dynamic-forms/src/validator/date-period-validator.test.js
+++ b/packages/dynamic-forms/src/validator/date-period-validator.test.js
@@ -1,0 +1,352 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { validationResult } from 'express-validator';
+import DatePeriodValidator from './date-period-validator.js';
+
+describe('./src/dynamic-forms/validator/date-period-validator.js', () => {
+	describe('validator', () => {
+		it('validates a valid date: leap year', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '29',
+					['date-question_start_month']: '2',
+					['date-question_start_year']: '2020',
+					['date-question_end_day']: '5',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: '2020'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 0);
+		});
+
+		it('validates a valid date', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '10',
+					['date-question_start_month']: '10',
+					['date-question_start_year']: '2025',
+					['date-question_end_day']: '15',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 0);
+		});
+
+		it('throws error if no day, month or year provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: undefined,
+					['date-question_start_month']: undefined,
+					['date-question_start_year']: undefined,
+					['date-question_end_day']: undefined,
+					['date-question_end_month']: undefined,
+					['date-question_end_year']: undefined
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 6);
+			assert.strictEqual(errors[`${question.fieldName}_start_day`].msg, 'Enter the required date');
+			assert.strictEqual(errors[`${question.fieldName}_start_month`].msg, undefined);
+			assert.strictEqual(errors[`${question.fieldName}_start_year`].msg, undefined);
+		});
+
+		it('throws error if no day provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: undefined,
+					['date-question_start_month']: '10',
+					['date-question_start_year']: '2025',
+					['date-question_end_day']: '15',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 1);
+			assert.strictEqual(errors[`${question.fieldName}_start_day`].msg, 'The required date must include a day');
+		});
+
+		it('throws error if no month provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '10',
+					['date-question_start_month']: undefined,
+					['date-question_start_year']: '2025',
+					['date-question_end_day']: '15',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 1);
+			assert.strictEqual(errors[`${question.fieldName}_start_month`].msg, 'The required date must include a month');
+		});
+
+		it('throws error if no year provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '10',
+					['date-question_start_month']: '5',
+					['date-question_start_year']: '2025',
+					['date-question_end_day']: '15',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: undefined
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 1);
+			assert.strictEqual(errors[`${question.fieldName}_end_year`].msg, 'The required date must include a year');
+		});
+
+		it('throws error if no day or month provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '10',
+					['date-question_start_month']: '5',
+					['date-question_start_year']: '2025',
+					['date-question_end_day']: undefined,
+					['date-question_end_month']: undefined,
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 2);
+			assert.strictEqual(errors[`${question.fieldName}_end_day`].msg, 'The required date must include a day and month');
+			assert.strictEqual(errors[`${question.fieldName}_end_month`].msg, undefined);
+		});
+
+		it('throws error if no day or year provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: undefined,
+					['date-question_start_month']: '5',
+					['date-question_start_year']: undefined,
+					['date-question_end_day']: '6',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 2);
+			assert.strictEqual(
+				errors[`${question.fieldName}_start_day`].msg,
+				'The required date must include a day and year'
+			);
+			assert.strictEqual(errors[`${question.fieldName}_start_year`].msg, undefined);
+		});
+
+		it('throws error if no month or year provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '25',
+					['date-question_start_month']: undefined,
+					['date-question_start_year']: undefined,
+					['date-question_end_day']: '6',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 2);
+			assert.strictEqual(
+				errors[`${question.fieldName}_start_month`].msg,
+				'The required date must include a month and year'
+			);
+			assert.strictEqual(errors[`${question.fieldName}_start_year`].msg, undefined);
+		});
+
+		it('throws error if invalid day provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '52',
+					['date-question_start_month']: '5',
+					['date-question_start_year']: '2023',
+					['date-question_end_day']: '6',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 1);
+			assert.strictEqual(errors[`${question.fieldName}_start_day`].msg, 'The required date must be a real date');
+		});
+
+		it('throws error if invalid month provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '13',
+					['date-question_start_month']: '5',
+					['date-question_start_year']: '2024',
+					['date-question_end_day']: '6',
+					['date-question_end_month']: '15',
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 1);
+			assert.strictEqual(errors[`${question.fieldName}_end_month`].msg, 'The required date month must be a real month');
+		});
+
+		it('throws error if invalid year provided', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '2',
+					['date-question_start_month']: '5',
+					['date-question_start_year']: '24',
+					['date-question_end_day']: '6',
+					['date-question_end_month']: '3',
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 1);
+			assert.strictEqual(
+				errors[`${question.fieldName}_start_year`].msg,
+				'The required date year must include 4 numbers'
+			);
+		});
+		it('throws multiple errors if date has multiple missing/invalid components', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: '2',
+					['date-question_start_month']: '15',
+					['date-question_start_year']: '24',
+					['date-question_end_day']: '6',
+					['date-question_end_month']: undefined,
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 3);
+			assert.strictEqual(
+				errors[`${question.fieldName}_start_month`].msg,
+				'The required date month must be a real month'
+			);
+			assert.strictEqual(
+				errors[`${question.fieldName}_start_year`].msg,
+				'The required date year must include 4 numbers'
+			);
+			assert.strictEqual(errors[`${question.fieldName}_end_month`].msg, 'The required date must include a month');
+		});
+
+		it('throws errors if inputs are not numbers', async () => {
+			const req = {
+				body: {
+					['date-question_start_day']: true,
+					['date-question_start_month']: '12',
+					['date-question_start_year']: 'not a number',
+					['date-question_end_day']: '6',
+					['date-question_end_month']: { obj: 'one' },
+					['date-question_end_year']: '2026'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date');
+
+			assert.strictEqual(Object.keys(errors).length, 3);
+			assert.strictEqual(errors[`${question.fieldName}_start_day`].msg, 'The required date must be a real date');
+			assert.strictEqual(
+				errors[`${question.fieldName}_start_year`].msg,
+				'The required date year must include 4 numbers'
+			);
+			assert.strictEqual(errors[`${question.fieldName}_end_month`].msg, 'The required date month must be a real month');
+		});
+	});
+});
+
+const _validationMappedErrors = async (req, question, inputLabel) => {
+	const dateValidator = new DatePeriodValidator(inputLabel);
+
+	const validationRules = dateValidator.validate(question);
+
+	await Promise.all(validationRules.map((validator) => validator.run(req)));
+
+	const errors = validationResult(req);
+
+	return errors.mapped();
+};


### PR DESCRIPTION
## Describe your changes

Use a new date period component for the reps period, so both dates can be edited on one page.

![image](https://github.com/user-attachments/assets/fe2bdc55-a23f-4bcd-b14d-70b5b5bedd25)
![image](https://github.com/user-attachments/assets/dde51cf6-7893-4814-b79f-307ce8a767fb)

## Issue ticket number and link

Relates to: https://pins-ds.atlassian.net/browse/CROWN-6