### PR TITLE
fix: trust proxy connections for secure cookies

### DIFF
--- a/apps/manage/src/server.js
+++ b/apps/manage/src/server.js
@@ -6,6 +6,12 @@ const config = loadConfig();
 const logger = getLogger(config);
 
 const app = getApp(config, logger);
+
+// Trust proxy, because our application is behind Front Door
+// required for secure session cookies
+// see https://expressjs.com/en/resources/middleware/session.html#cookiesecure
+app.set('trust proxy', true);
+
 // set the HTTP port to use from loaded config
 app.set('http-port', config.httpPort);
 

--- a/apps/portal/src/server.js
+++ b/apps/portal/src/server.js
@@ -6,6 +6,11 @@ const config = loadConfig();
 const logger = getLogger(config);
 
 const app = getApp(config, logger);
+// Trust proxy, because our application is behind Front Door
+// required for secure session cookies
+// see https://expressjs.com/en/resources/middleware/session.html#cookiesecure
+app.set('trust proxy', true);
+
 // set the HTTP port to use from loaded config
 app.set('http-port', config.httpPort);
 


### PR DESCRIPTION
## Describe your changes

Auth in the TEST environment was failing, because NODE_ENV has been set to production now, which in turn means secure cookies are used. This fails because the app is behind a proxy (Front Door), so express must be configured to trust it.

## Issue ticket number and link
