### PR TITLE
fix(manage): allow both ' and ’ type apostrophes in names

### DIFF
--- a/apps/manage/src/app/views/cases/create-a-case/question-utils.js
+++ b/apps/manage/src/app/views/cases/create-a-case/question-utils.js
@@ -34,7 +34,7 @@ export function contactQuestions({ prefix, title, addressRequired }) {
 					maxLengthMessage: `${title} name must be less than 250 characters`
 				},
 				regex: {
-					regex: "^[A-Za-z '-]+$",
+					regex: "^[A-Za-z '’-]+$",
 					regexMessage: 'Full name must only include letters, spaces, hyphens, or apostrophes'
 				}
 			})


### PR DESCRIPTION
## Describe your changes
allow both ' and ’ type apostrophes in names

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/browse/CROWN-36
https://pins-ds.atlassian.net.mcas.ms/browse/CROWN-51