### PR TITLE
fix(manage): trim user inputs to avoid issues with whitespaces

### DIFF
--- a/packages/dynamic-forms/src/validator/validator.js
+++ b/packages/dynamic-forms/src/validator/validator.js
@@ -10,6 +10,13 @@ const validate = async (req, res, next) => {
 	if (!questionObj) {
 		throw new Error('unknown question type');
 	}
+	if (req.body && typeof req.body === 'object' && req.body.constructor === Object) {
+		for (const key of Object.keys(req.body)) {
+			req.body[key] = req.body[key].trim();
+		}
+	} else {
+		throw new Error(`req.body is not an object: ${req.body} :: ${typeof req.body}`);
+	}
 
 	for (const validation of questionObj.validators) {
 		const validationRules = validation.validate(questionObj, journeyResponse);

--- a/packages/dynamic-forms/src/validator/validator.test.js
+++ b/packages/dynamic-forms/src/validator/validator.test.js
@@ -65,6 +65,34 @@ describe('./src/dynamic-forms/validator/validator.js', () => {
 		assert.strictEqual(next.mock.callCount(), 1);
 	});
 
+	it('should trim leading and trailing whitespaces', async () => {
+		const req = {
+			params: {
+				section: 1,
+				question: 1,
+				referenceId: 'abc'
+			},
+			body: {
+				field1: ' bananas '
+			}
+		};
+
+		mockRes.locals.journey = {
+			getQuestionBySectionAndName: function () {
+				return {
+					validators: [new RequiredValidator()],
+					fieldName: 'field1'
+				};
+			}
+		};
+
+		const next = mock.fn();
+		await validate(req, mockRes, next);
+
+		assert.strictEqual(req.body.field1, 'bananas');
+		assert.strictEqual(next.mock.callCount(), 1);
+	});
+
 	it('should invalidate a single validator', async () => {
 		const req = {
 			params: {


### PR DESCRIPTION
## Describe your changes
Validator now trims input prior to validation, this assures that no inputs will fail validation because of whitespace. Additionally, this avoid whitespaces in submissions to database.
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-128