### PR TITLE
fix(manage): If coordinates not populated leave blank on CYA

### DIFF
--- a/apps/manage/src/app/views/cases/view/question-utils.js
+++ b/apps/manage/src/app/views/cases/view/question-utils.js
@@ -49,7 +49,7 @@ export function contactQuestions({ prefix, title, addressRequired }) {
 							maxLengthMessage: `${title} name must be less than 250 characters`
 						},
 						regex: {
-							regex: "^[A-Za-z0-9 '’-]+$",
+							regex: "^[A-Za-z0-9 '’-]*$",
 							regexMessage: 'Full name must only include letters, spaces, hyphens, apostrophes or numbers'
 						}
 					},

--- a/packages/dynamic-forms/src/components/multi-field-input/question.js
+++ b/packages/dynamic-forms/src/components/multi-field-input/question.js
@@ -132,7 +132,14 @@ export default class MultiFieldInputQuestion extends Question {
 			return answer ? acc + (field.formatPrefix || '') + answer + (field.formatJoinString || '\n') : acc;
 		}, '');
 
-		const formattedAnswer = summaryDetails || this.notStartedText;
+		let formattedAnswer;
+		if (summaryDetails) {
+			formattedAnswer = summaryDetails;
+		} else if (!summaryDetails && this.#isInputFieldNorthingEasting()) {
+			formattedAnswer = '';
+		} else {
+			formattedAnswer = this.notStartedText;
+		}
 
 		return [
 			{
@@ -141,5 +148,9 @@ export default class MultiFieldInputQuestion extends Question {
 				action: this.getAction(sectionSegment, journey, summaryDetails)
 			}
 		];
+	}
+
+	#isInputFieldNorthingEasting() {
+		return this.inputFields.some((field) => field.fieldName === 'siteNorthing' || field.fieldName === 'siteEasting');
 	}
 }

--- a/packages/dynamic-forms/src/components/multi-field-input/question.test.js
+++ b/packages/dynamic-forms/src/components/multi-field-input/question.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import MultiFieldInputQuestion from './question.js';
+import { Journey } from '../../journey/journey.js';
 
 const TITLE = 'title';
 const QUESTION = 'Question?';
@@ -104,6 +105,119 @@ describe('./src/dynamic-forms/components/single-line-input/question.js', () => {
 			const result = await question.getDataToSave(testRequest, journeyResponse);
 
 			assert.deepStrictEqual(result, expectedResponseToSave);
+		});
+	});
+
+	describe('formatAnswerForSummary', () => {
+		it('should return formatted answer', async () => {
+			const question = createMultiFieldInputQuestion();
+			const journey = new Journey({
+				journeyId: 'TEST',
+				makeBaseUrl: () => 'base',
+				taskListUrl: 'cases/create-a-case/check-your-answers',
+				response: {
+					answers: {
+						testField1: 'planning-permission',
+						testField2: 'Test User'
+					}
+				},
+				journeyTemplate: 'mock template',
+				listingPageViewPath: 'mock path',
+				journeyTitle: 'mock title',
+				sections: []
+			});
+
+			const expectedResult = [
+				{
+					action: {
+						href: 'base/cases/create-a-case/check-your-answers',
+						text: 'Change',
+						visuallyHiddenText: 'Question?'
+					},
+					key: 'title',
+					value: 'planning-permission<br>Test User<br>'
+				}
+			];
+
+			const result = question.formatAnswerForSummary('questions', journey);
+
+			assert.deepStrictEqual(result, expectedResult);
+		});
+		it('should return not started text for non coordinates question not answered', async () => {
+			const question = createMultiFieldInputQuestion();
+			const journey = new Journey({
+				journeyId: 'TEST',
+				makeBaseUrl: () => 'base',
+				taskListUrl: 'cases/create-a-case/check-your-answers',
+				response: {
+					answers: {
+						testField1: null,
+						testField2: null
+					}
+				},
+				journeyTemplate: 'mock template',
+				listingPageViewPath: 'mock path',
+				journeyTitle: 'mock title',
+				sections: []
+			});
+
+			const expectedResult = [
+				{
+					action: {
+						href: 'base/cases/create-a-case/check-your-answers',
+						text: 'Answer',
+						visuallyHiddenText: 'Question?'
+					},
+					key: 'title',
+					value: 'Not started'
+				}
+			];
+
+			const result = question.formatAnswerForSummary('questions', journey);
+
+			assert.deepStrictEqual(result, expectedResult);
+		});
+		it('should return empty string as formatted answer if empty coordinates provided', async () => {
+			const question = createMultiFieldInputQuestion();
+			question.inputFields = [
+				{ fieldName: 'siteNorthing', label: 'Northing', formatPrefix: 'Northing: ', hint: 'Optional' },
+				{ fieldName: 'siteEasting', label: 'Easting', formatPrefix: 'Easting: ', hint: 'Optional' }
+			];
+
+			const journey = new Journey({
+				journeyId: 'TEST',
+				makeBaseUrl: () => 'base',
+				taskListUrl: 'cases/create-a-case/check-your-answers',
+				response: {
+					answers: {
+						typeOfApplication: 'planning-permission',
+						applicantName: "Test O'Neill",
+						siteAddress: null,
+						siteNorthing: '',
+						siteEasting: ''
+					}
+				},
+				journeyTemplate: 'mock template',
+				listingPageViewPath: 'mock path',
+				journeyTitle: 'mock title',
+				sections: []
+			});
+
+			const expectedResult = [
+				{
+					action: {
+						href: 'base/cases/create-a-case/check-your-answers',
+						text: 'Answer',
+						visuallyHiddenText: 'Question?'
+					},
+					key: 'title',
+					value: ''
+				}
+			];
+
+			const result = question.formatAnswerForSummary('questions', journey);
+
+			assert.deepStrictEqual(result, expectedResult);
 		});
 	});
 });


### PR DESCRIPTION
## Describe your changes
Fix: Coordinates Check your answers says 'not started' instead of being blank
If coordinates not populated leave blank on CYA

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-141