### PR TITLE
fix/session-storage

### DIFF
--- a/apps/portal/src/app/views/applications/view/have-your-say/index.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/index.js
@@ -5,12 +5,14 @@ import { list, question, buildSave } from '@pins/dynamic-forms/src/controller.js
 import validate from '@pins/dynamic-forms/src/validator/validator.js';
 import { validationErrorHandler } from '@pins/dynamic-forms/src/validator/validation-error-handler.js';
 import {
-	saveDataToSession,
+	buildSaveDataToSession,
 	buildGetJourneyResponseFromSession
 } from '@pins/dynamic-forms/src/lib/session-answer-store.js';
 import { JOURNEY_ID, createJourney } from './journey.js';
 import { getQuestions } from '@pins/crowndev-lib/forms/representations/questions.js';
 import { buildHaveYourSayPage } from './controller.js';
+
+const applicationIdParam = 'applicationId';
 
 /**
  * @param {Object} opts
@@ -23,8 +25,9 @@ export function createHaveYourSayRoutes({ db, logger, config }) {
 	const router = createRouter({ mergeParams: true });
 	const questions = getQuestions();
 	const getJourney = buildGetJourney((req, journeyResponse) => createJourney(questions, journeyResponse, req));
-	const getJourneyResponse = buildGetJourneyResponseFromSession(JOURNEY_ID);
+	const getJourneyResponse = buildGetJourneyResponseFromSession(JOURNEY_ID, applicationIdParam);
 	const viewHaveYourSayPage = buildHaveYourSayPage({ db, logger, config });
+	const saveDataToSession = buildSaveDataToSession({ reqParam: applicationIdParam });
 
 	router.get('/', asyncHandler(viewHaveYourSayPage));
 

--- a/packages/dynamic-forms/src/lib/session-answer-store.test.js
+++ b/packages/dynamic-forms/src/lib/session-answer-store.test.js
@@ -1,6 +1,10 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
-import { buildGetJourneyResponseFromSession, clearDataFromSession, saveDataToSession } from './session-answer-store.js';
+import {
+	buildGetJourneyResponseFromSession,
+	clearDataFromSession,
+	buildSaveDataToSession
+} from './session-answer-store.js';
 import { mockReq, mockRes } from './test-utils.js';
 import { BOOLEAN_OPTIONS } from '../components/boolean/question.js';
 
@@ -10,6 +14,7 @@ describe('session-answer-store', () => {
 			const req = mockReq();
 			const journeyId = 'j-1';
 			const data = { answers: { q1: 'a1' } };
+			const saveDataToSession = buildSaveDataToSession();
 			await assert.rejects(async () => await saveDataToSession({ req, journeyId, data }));
 		});
 		it('should handle empty session', async () => {
@@ -17,6 +22,7 @@ describe('session-answer-store', () => {
 			req.session = {};
 			const journeyId = 'j-1';
 			const data = { answers: { q1: 'a1' } };
+			const saveDataToSession = buildSaveDataToSession();
 			await assert.doesNotReject(async () => await saveDataToSession({ req, journeyId, data }));
 		});
 		it('should save data by journeyId session', async () => {
@@ -24,6 +30,7 @@ describe('session-answer-store', () => {
 			req.session = {};
 			const journeyId = 'j-1';
 			const data = { answers: { q1: 'a1' } };
+			const saveDataToSession = buildSaveDataToSession();
 			await saveDataToSession({ req, journeyId, data });
 			assert.deepStrictEqual(req.session, {
 				forms: {
@@ -44,12 +51,59 @@ describe('session-answer-store', () => {
 			};
 			const journeyId = 'j-1';
 			const data = { answers: { q1: 'a2', q2: true } };
+			const saveDataToSession = buildSaveDataToSession();
 			await saveDataToSession({ req, journeyId, data });
 			assert.deepStrictEqual(req.session, {
 				forms: {
 					'j-1': {
 						q1: 'a2',
 						q2: true
+					}
+				}
+			});
+		});
+		it('should save data by reqParam & journeyId session', async () => {
+			const req = mockReq();
+			req.params = { myParam: 'req-1' };
+			req.session = {};
+			const journeyId = 'j-1';
+			const data = { answers: { q1: 'a1' } };
+			const saveDataToSession = buildSaveDataToSession({ reqParam: 'myParam' });
+			await saveDataToSession({ req, journeyId, data });
+			assert.deepStrictEqual(req.session, {
+				forms: {
+					'req-1': {
+						'j-1': {
+							q1: 'a1'
+						}
+					}
+				}
+			});
+		});
+
+		it('should overwrite existing data by reqParam & journeyId', async () => {
+			const req = mockReq();
+			req.params = { myParam: 'req-1' };
+			req.session = {
+				forms: {
+					'req-1': {
+						'j-1': {
+							q1: 'a1'
+						}
+					}
+				}
+			};
+			const journeyId = 'j-1';
+			const data = { answers: { q1: 'a2', q2: true } };
+			const saveDataToSession = buildSaveDataToSession({ reqParam: 'myParam' });
+			await saveDataToSession({ req, journeyId, data });
+			assert.deepStrictEqual(req.session, {
+				forms: {
+					'req-1': {
+						'j-1': {
+							q1: 'a2',
+							q2: true
+						}
 					}
 				}
 			});
@@ -86,6 +140,27 @@ describe('session-answer-store', () => {
 			const newData = { myField: 'value1' };
 			clearDataFromSession({ req, journeyId, replaceWith: newData });
 			assert.strictEqual(req.session.forms[journeyId], newData);
+		});
+		it('should clear session data for journey with reqParam key', async () => {
+			const journeyId = 'j-1';
+			const req = mockReq();
+			req.params = { myParam: 'req-1' };
+			req.session = {
+				forms: { 'req-1': { [journeyId]: { q1: 'a1', q2: false } } }
+			};
+			clearDataFromSession({ req, journeyId, reqParam: 'myParam' });
+			assert.strictEqual(journeyId in req.session.forms['req-1'], false);
+		});
+		it('should replace session data for journey with reqParam', async () => {
+			const journeyId = 'j-1';
+			const req = mockReq();
+			req.params = { myParam: 'req-1' };
+			req.session = {
+				forms: { 'req-1': { [journeyId]: { q1: 'a1', q2: false } } }
+			};
+			const newData = { myField: 'value1' };
+			clearDataFromSession({ req, journeyId, replaceWith: newData, reqParam: 'myParam' });
+			assert.strictEqual(req.session.forms['req-1'][journeyId], newData);
 		});
 	});
 
@@ -139,6 +214,52 @@ describe('session-answer-store', () => {
 			assert.ok(res.locals.journeyResponse);
 			assert.deepStrictEqual(res.locals.journeyResponse.answers, answers);
 			assert.notDeepStrictEqual(res.locals.journeyResponse.answers, otherAnswers);
+		});
+
+		it('should fetch answers by reqParam & journeyId from session', async () => {
+			const answers = { q1: 'a1' };
+			const req = mockReq();
+			req.params = { myParam: 'req-1' };
+			req.session = {
+				forms: {
+					'req-1': { [journeyId]: answers }
+				}
+			};
+			const res = mockRes();
+			const next = mock.fn();
+			const handler = buildGetJourneyResponseFromSession(journeyId, 'myParam');
+			handler(req, res, next);
+			assert.ok(res.locals.journeyResponse);
+			assert.deepStrictEqual(res.locals.journeyResponse.answers, answers);
+		});
+		it(`shouldn't fetch answers for other journeys or requests from session`, async () => {
+			const answers = { q1: 'a1' };
+			const otherAnswers = { q2: 'a3' };
+			const answers2 = { q1: 'a2' };
+			const otherAnswers2 = { q2: 'a4' };
+			const req = mockReq();
+			req.params = { myParam: 'req-1' };
+			req.session = {
+				forms: {
+					'req-1': {
+						[journeyId]: answers,
+						[journeyId + '_other']: otherAnswers
+					},
+					'req-2': {
+						[journeyId]: answers2,
+						[journeyId + '_other']: otherAnswers2
+					}
+				}
+			};
+			const res = mockRes();
+			const next = mock.fn();
+			const handler = buildGetJourneyResponseFromSession(journeyId, 'myParam');
+			handler(req, res, next);
+			assert.ok(res.locals.journeyResponse);
+			assert.deepStrictEqual(res.locals.journeyResponse.answers, answers);
+			assert.notDeepStrictEqual(res.locals.journeyResponse.answers, otherAnswers);
+			assert.notDeepStrictEqual(res.locals.journeyResponse.answers, answers2);
+			assert.notDeepStrictEqual(res.locals.journeyResponse.answers, otherAnswers2);
 		});
 		it('should change boolean answers to yes/no', async () => {
 			const answers = { q1: true, q2: 'a2', q3: false };


### PR DESCRIPTION
## Describe your changes

- Add the option to save journey answers to session keyed by a request param
- use applicationId param to say have-your-say answers, so that they aren't used across applications

## Issue ticket number and link

N/A but relates to https://pins-ds.atlassian.net/browse/CROWN-10
