### PR TITLE
fix(portal): override pageHeading block so that empty h1 tag is omitted

### DIFF
--- a/apps/portal/src/app/views/applications/view/have-your-say/success.njk
+++ b/apps/portal/src/app/views/applications/view/have-your-say/success.njk
@@ -1,6 +1,7 @@
 {% extends "views/layouts/main.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
+{% block pageHeading %}{% endblock %}
 {% block pageContent %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Describe your changes
Info and Relationships - Semantic Markup Not Used Appropriately
- override pageHeading block so that empty h1 tag is omitted

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-386