### PR TITLE
feat(manage): create sharepoint folder for rep if required

### DIFF
--- a/apps/manage/src/app/views/cases/view/index.js
+++ b/apps/manage/src/app/views/cases/view/index.js
@@ -19,7 +19,7 @@ import { createRoutes as createRepsRoutes } from './manage-reps/index.js';
  */
 export function createRoutes({ db, logger, config, getEntraClient, getSharePointDrive }) {
 	const router = createRouter({ mergeParams: true });
-	const repsRoutes = createRepsRoutes({ db, logger, config });
+	const repsRoutes = createRepsRoutes({ db, logger, config, getSharePointDrive });
 	const getJourney = asyncHandler(
 		buildGetJourneyMiddleware({ db, logger, groupIds: config.entra.groupIds, getEntraClient })
 	);

--- a/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
@@ -2,14 +2,16 @@ import { editsToDatabaseUpdates } from '@pins/crowndev-lib/forms/representations
 import { wrapPrismaError } from '@pins/crowndev-lib/util/database.js';
 import { validateParams } from '../view/controller.js';
 import { addSessionData, clearSessionData, readSessionData } from '@pins/crowndev-lib/util/session.js';
+import { publishedRepresentationsAttachmentsRootFolderPath } from '@pins/crowndev-lib/util/sharepoint-path.js';
 
 /**
  * @param {Object} opts
  * @param {import('@prisma/client').PrismaClient} opts.db
  * @param {import('pino').BaseLogger} opts.logger
+ * @param {function(session): SharePointDrive} opts.getSharePointDrive
  * @returns {import('@pins/dynamic-forms/src/controller.js').SaveDataFn}
  */
-export function buildUpdateRepresentation({ db, logger }) {
+export function buildUpdateRepresentation({ db, logger, getSharePointDrive }) {
 	return async ({ res, req, data }) => {
 		const { id, representationRef } = validateParams(req.params);
 		const toSave = data?.answers || {};
@@ -19,6 +21,18 @@ export function buildUpdateRepresentation({ db, logger }) {
 		}
 		/** @type {import('@pins/crowndev-lib/forms/representations/types.js').HaveYourSayManageModel} */
 		const fullViewModel = res.locals?.journeyResponse?.answers || {};
+
+		if (toSave.containsAttachments && fullViewModel.sharePointFolderCreated !== 'yes') {
+			const sharePointDrive = getSharePointDrive(req.session);
+			await addRepresentationFolderToSharepoint(
+				sharePointDrive,
+				logger,
+				fullViewModel.applicationReference,
+				representationRef
+			);
+			toSave['sharePointFolderCreated'] = true;
+		}
+
 		/** @type {import('@prisma/client').Prisma.RepresentationUpdateInput} */
 		const updateInput = editsToDatabaseUpdates(toSave, fullViewModel);
 		logger.info({ id, representationRef, fields: Object.keys(toSave) }, 'update representation input');
@@ -39,6 +53,27 @@ export function buildUpdateRepresentation({ db, logger }) {
 
 		addRepUpdatedSession(req, representationRef);
 	};
+}
+
+/**
+ * Add folder to sharepoint for representation
+ *
+ * @param {SharePointDrive} sharePointDrive
+ * @param {import('pino').BaseLogger} logger
+ * @param {string} applicationReference
+ * @param {string} representationRef
+ */
+async function addRepresentationFolderToSharepoint(sharePointDrive, logger, applicationReference, representationRef) {
+	try {
+		const folderPath = publishedRepresentationsAttachmentsRootFolderPath(applicationReference);
+		await sharePointDrive.addNewFolder(folderPath, representationRef);
+	} catch (error) {
+		logger.error(
+			{ error, applicationReference, representationRef },
+			'error creating new sharepoint folder for representation'
+		);
+		throw new Error('Error encountered during sharepoint folder creation');
+	}
 }
 
 /**

--- a/apps/manage/src/app/views/cases/view/manage-reps/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/index.js
@@ -14,16 +14,17 @@ import { createRoutes as createAddRoutes } from './add/index.js';
  * @param {Object} opts
  * @param {import('@prisma/client').PrismaClient} opts.db
  * @param {import('pino').BaseLogger} opts.logger
+ * @param {function(session): SharePointDrive} opts.getSharePointDrive
  * @returns {import('express').Router}
  */
-export function createRoutes({ db, logger }) {
+export function createRoutes({ db, logger, getSharePointDrive }) {
 	const router = createRouter({ mergeParams: true });
 	const repsRouter = createRouter({ mergeParams: true });
 	const list = buildListReps({ db });
 	const reviewRoutes = createReviewRoutes({ db, logger });
 	const addRepRoutes = createAddRoutes({ db, logger });
 	const getJourney = asyncHandler(buildGetJourneyMiddleware({ db, logger }));
-	const updateRepFn = buildUpdateRepresentation({ db, logger });
+	const updateRepFn = buildUpdateRepresentation({ db, logger, getSharePointDrive });
 	const saveAnswer = buildSave(updateRepFn, true);
 
 	router.get('/', asyncHandler(list));

--- a/packages/database/src/migrations/20250327135519_sharepoint_folder_created/migration.sql
+++ b/packages/database/src/migrations/20250327135519_sharepoint_folder_created/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Representation] ADD [sharePointFolderCreated] BIT CONSTRAINT [Representation_sharePointFolderCreated_df] DEFAULT 0;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -217,7 +217,8 @@ model Representation {
   Category       RepresentationCategory? @relation(fields: [categoryId], references: [id])
   wantsToBeHeard Boolean?
 
-  containsAttachments Boolean? @default(false)
+  containsAttachments     Boolean? @default(false)
+  sharePointFolderCreated Boolean? @default(false)
 }
 
 // reference data

--- a/packages/lib/forms/representations/questions.js
+++ b/packages/lib/forms/representations/questions.js
@@ -230,6 +230,15 @@ export const questionProps = {
 		url: 'representation-type',
 		validators: [new RequiredValidator('Select a representation type')],
 		options: referenceDataToRadioOptions(REPRESENTATION_CATEGORY)
+	},
+	representationAttachments: {
+		type: COMPONENT_TYPES.BOOLEAN,
+		title: 'Representation Attachments',
+		question: 'Does the representation have attachments?',
+		hint: 'You can still submit a representation for them if they are under 18, but we will process their personal details in a different way.',
+		fieldName: 'containsAttachments',
+		url: 'representation-attachments',
+		validators: [new RequiredValidator('Select whether the representation has attachments')]
 	}
 };
 

--- a/packages/lib/forms/representations/sections.js
+++ b/packages/lib/forms/representations/sections.js
@@ -25,6 +25,7 @@ export function haveYourSayManageSections(questions) {
 		new Section('More Details', 'more-details')
 			.addQuestion(questions.commentRedacted)
 			.addQuestion(questions.wantsToBeHeard)
+			.addQuestion(questions.representationAttachments)
 	];
 }
 

--- a/packages/lib/forms/representations/types.d.ts
+++ b/packages/lib/forms/representations/types.d.ts
@@ -29,6 +29,7 @@ export namespace HaveYourSay {
 		categoryId?: string;
 		wantsToBeHeard?: boolean;
 		containsAttachments: boolean;
+		sharePointFolderCreated?: string;
 		commentRedacted?: string;
 
 		readonly applicationReference?: string;

--- a/packages/lib/forms/representations/view-model.js
+++ b/packages/lib/forms/representations/view-model.js
@@ -20,7 +20,9 @@ const UNMAPPED_VIEW_MODEL_FIELDS = Object.freeze([
 	'submittedByContactId',
 	'representedContactId',
 	'comment',
-	'commentRedacted'
+	'commentRedacted',
+	'containsAttachments',
+	'sharePointFolderCreated'
 ]);
 
 /**
@@ -93,6 +95,12 @@ export function editsToDatabaseUpdates(edits, viewModel) {
 
 	if ('wantsToBeHeard' in edits) {
 		representationUpdateInput.wantsToBeHeard = yesNoToBoolean(edits.wantsToBeHeard);
+	}
+	if ('containsAttachments' in edits) {
+		representationUpdateInput.wantsToBeHeard = yesNoToBoolean(edits.containsAttachments);
+	}
+	if ('sharePointFolderCreated' in edits) {
+		representationUpdateInput.sharePointFolderCreated = yesNoToBoolean(edits.sharePointFolderCreated);
 	}
 
 	// myself fields

--- a/packages/lib/forms/representations/view-model.test.js
+++ b/packages/lib/forms/representations/view-model.test.js
@@ -28,7 +28,9 @@ describe('view-model', () => {
 				wantsToBeHeard: true,
 				submittedForId: 'id-1',
 				comment: 'comment one',
-				commentRedacted: '███████ one'
+				commentRedacted: '███████ one',
+				containsAttachments: false,
+				sharePointFolderCreated: false
 			};
 			const viewModel = representationToManageViewModel(representation, applicationReference);
 			assert.deepStrictEqual(viewModel, {
@@ -39,7 +41,9 @@ describe('view-model', () => {
 				submittedByContactId: undefined,
 				representedContactId: undefined,
 				comment: 'comment one',
-				commentRedacted: '███████ one'
+				commentRedacted: '███████ one',
+				containsAttachments: 'no',
+				sharePointFolderCreated: 'no'
 			});
 		});
 		it('should map requires review', () => {
@@ -49,7 +53,9 @@ describe('view-model', () => {
 				submittedDate: new Date('2025-01-01T00:00:00Z'),
 				categoryId: 'c-id-1',
 				wantsToBeHeard: true,
-				submittedForId: 'id-1'
+				submittedForId: 'id-1',
+				containsAttachments: false,
+				sharePointFolderCreated: false
 			};
 			const viewModel = representationToManageViewModel(representation, applicationReference);
 			assert.deepStrictEqual(viewModel, {
@@ -60,7 +66,9 @@ describe('view-model', () => {
 				submittedByContactId: undefined,
 				representedContactId: undefined,
 				comment: undefined,
-				commentRedacted: undefined
+				commentRedacted: undefined,
+				containsAttachments: 'no',
+				sharePointFolderCreated: 'no'
 			});
 		});
 		it('should map the myself fields', () => {
@@ -72,6 +80,8 @@ describe('view-model', () => {
 				wantsToBeHeard: true,
 				submittedForId: REPRESENTATION_SUBMITTED_FOR_ID.MYSELF,
 				comment: 'my comments',
+				containsAttachments: true,
+				sharePointFolderCreated: true,
 				submittedByContactId: 'sub-id-1',
 				SubmittedByContact: {
 					isAdult: true,
@@ -96,7 +106,9 @@ describe('view-model', () => {
 				submittedByContactId: 'sub-id-1',
 				representedContactId: undefined,
 				comment: 'my comments',
-				commentRedacted: undefined
+				commentRedacted: undefined,
+				containsAttachments: 'yes',
+				sharePointFolderCreated: 'yes'
 			});
 		});
 		it('should map the on behalf of common fields', () => {
@@ -108,6 +120,8 @@ describe('view-model', () => {
 				wantsToBeHeard: true,
 				submittedForId: REPRESENTATION_SUBMITTED_FOR_ID.ON_BEHALF_OF,
 				comment: 'my comments',
+				containsAttachments: true,
+				sharePointFolderCreated: false,
 				submittedByContactId: 'sub-id-1',
 				SubmittedByContact: {
 					isAdult: true,
@@ -134,7 +148,9 @@ describe('view-model', () => {
 				submittedByContactId: 'sub-id-1',
 				representedContactId: undefined,
 				comment: 'my comments',
-				commentRedacted: undefined
+				commentRedacted: undefined,
+				containsAttachments: 'yes',
+				sharePointFolderCreated: 'no'
 			});
 		});
 		it('should map the on behalf of person fields', () => {
@@ -146,6 +162,8 @@ describe('view-model', () => {
 				wantsToBeHeard: true,
 				submittedForId: REPRESENTATION_SUBMITTED_FOR_ID.ON_BEHALF_OF,
 				comment: 'my comments',
+				containsAttachments: false,
+				sharePointFolderCreated: false,
 				submittedByContactId: 'sub-id-1',
 				SubmittedByContact: {
 					isAdult: true,
@@ -183,7 +201,9 @@ describe('view-model', () => {
 				submittedByContactId: 'sub-id-1',
 				representedContactId: 'rep-id-1',
 				comment: 'my comments',
-				commentRedacted: undefined
+				commentRedacted: undefined,
+				containsAttachments: 'no',
+				sharePointFolderCreated: 'no'
 			});
 		});
 		it('should map the on behalf of org fields', () => {
@@ -195,6 +215,8 @@ describe('view-model', () => {
 				wantsToBeHeard: true,
 				submittedForId: REPRESENTATION_SUBMITTED_FOR_ID.ON_BEHALF_OF,
 				comment: 'my comments',
+				containsAttachments: false,
+				sharePointFolderCreated: false,
 				submittedByContactId: 'sub-id-1',
 				SubmittedByContact: {
 					isAdult: true,
@@ -228,7 +250,9 @@ describe('view-model', () => {
 				submittedByContactId: 'sub-id-1',
 				representedContactId: 'rep-id-1',
 				comment: 'my comments',
-				commentRedacted: undefined
+				commentRedacted: undefined,
+				containsAttachments: 'no',
+				sharePointFolderCreated: 'no'
 			});
 		});
 		it(`should map the on behalf of org don't work for fields`, () => {
@@ -240,6 +264,8 @@ describe('view-model', () => {
 				wantsToBeHeard: true,
 				submittedForId: REPRESENTATION_SUBMITTED_FOR_ID.ON_BEHALF_OF,
 				comment: 'my comments',
+				containsAttachments: false,
+				sharePointFolderCreated: false,
 				submittedByContactId: 'sub-id-1',
 				SubmittedByContact: {
 					isAdult: true,
@@ -275,7 +301,9 @@ describe('view-model', () => {
 				submittedByContactId: 'sub-id-1',
 				representedContactId: 'rep-id-1',
 				comment: 'my comments',
-				commentRedacted: undefined
+				commentRedacted: undefined,
+				containsAttachments: 'no',
+				sharePointFolderCreated: 'no'
 			});
 		});
 	});

--- a/packages/lib/util/sharepoint-path.js
+++ b/packages/lib/util/sharepoint-path.js
@@ -15,6 +15,16 @@ export function publishedFolderPath(caseReference) {
 }
 
 /**
+ * Returns the published reps attachments folder root path for the given case reference
+ *
+ * @param {string} caseReference
+ * @returns {string}
+ */
+export function publishedRepresentationsAttachmentsRootFolderPath(caseReference) {
+	return buildPath(publishedFolderPath(caseReference), APPLICATION_FOLDERS.REPRESENTATION_ATTACHMENTS);
+}
+
+/**
  * Returns the published reps attachments folder path for the given case reference and representation reference
  *
  * @param {string} caseReference

--- a/packages/sharepoint/src/sharepoint/drives/drives.js
+++ b/packages/sharepoint/src/sharepoint/drives/drives.js
@@ -112,6 +112,29 @@ export class SharePointDrive {
 	}
 
 	/**
+	 * Create a new folder in SharePoint drive at path
+	 * @param {string} path - the relative path where the folder should be created
+	 * @param {string} folderName - the name of the folder to create
+	 * @returns {Promise<Object>} - response containing folder details
+	 */
+	async addNewFolder(path, folderName) {
+		const urlBuilder = new UrlBuilder('')
+			.addPathSegment('drives')
+			.addPathSegment(this.driveId)
+			.addPathSegment('root:')
+			.addPathSegment(path + ':')
+			.addPathSegment('children');
+
+		const folderRequest = {
+			name: folderName,
+			folder: {},
+			'@microsoft.graph.conflictBehavior': 'fail'
+		};
+
+		return await this.client.api(urlBuilder.toString()).post(folderRequest);
+	}
+
+	/**
 	 * Copies a sharepoint item to a location with a new name
 	 *
 	 * @param {CopyDriveInstructions} params

--- a/packages/sharepoint/src/sharepoint/drives/drives.test.js
+++ b/packages/sharepoint/src/sharepoint/drives/drives.test.js
@@ -162,6 +162,36 @@ describe('drives', () => {
 			assert.deepEqual(result, mockResponse.value);
 		});
 	});
+	describe('addNewFolder', () => {
+		test('should add new folder', async () => {
+			const path = 'testPath';
+			const folderName = 'folderName';
+			driveId = 'testDriveId';
+
+			const client = mockClient();
+			sharePointDrive = new SharePointDrive(client, driveId);
+
+			await sharePointDrive.addNewFolder(path, folderName);
+
+			console.log(client.api.mock.calls[0]);
+			assert.equal(client.api.mock.callCount(), 1);
+			assert.deepStrictEqual(client.post.mock.calls[0].arguments[0], {
+				name: folderName,
+				folder: {},
+				'@microsoft.graph.conflictBehavior': 'fail'
+			});
+			assert.equal(
+				client.api.mock.calls[0].arguments[0],
+				new UrlBuilder('')
+					.addPathSegment('drives')
+					.addPathSegment(driveId)
+					.addPathSegment('root:')
+					.addPathSegment(path + ':')
+					.addPathSegment('children')
+					.toString()
+			);
+		});
+	});
 	describe('getItemPermissions', () => {
 		test('should fetch an item permission', async () => {
 			const client = mockClient();


### PR DESCRIPTION
## Describe your changes
Enable Back office to set Attachments Flag
- create sharepoint folder for representation if one doesn't exist and the representation contains attachments

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-359