### PR TITLE
refactor(dynamic-forms): add common question parameters into a type

### DIFF
--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -11,5 +11,8 @@
     "escape-html": "*",
     "express-validator": "*",
     "nunjucks": "*"
+  },
+  "imports": {
+    "#question-types": "./src/questions/question-types.d.ts"
   }
 }

--- a/packages/dynamic-forms/src/components/address/question.js
+++ b/packages/dynamic-forms/src/components/address/question.js
@@ -16,32 +16,15 @@ import AddressValidator from '../../validator/address-validator.js';
 
 export default class AddressQuestion extends Question {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.hint]
-	 * @param {string} [params.html]
-	 * @param {Array.<import('../../validator/base-validator.js')>} [params.validators]
-	 * @param {boolean} [params.editable]
-	 * @param {Object<string, any>} [params.viewData]
+	 * @param {import('#question-types').QuestionParameters} params
 	 */
-	constructor({ title, question, fieldName, validators, url, hint, html, editable, viewData }) {
+	constructor(params) {
 		super({
-			title: title,
-			viewFolder: 'address',
-			fieldName: fieldName,
-			question: question,
-			validators: validators,
-			hint: hint,
-			html: html,
-			editable,
-			viewData
+			...params,
+			viewFolder: 'address'
 		});
-		this.url = url;
 
-		for (const validator of validators) {
+		for (const validator of params.validators) {
 			if (validator instanceof AddressValidator) {
 				this.requiredFields = validator.requiredFields;
 			}

--- a/packages/dynamic-forms/src/components/date-period/question.js
+++ b/packages/dynamic-forms/src/components/date-period/question.js
@@ -18,44 +18,16 @@ const DEFAULT_DATE_FORMAT = 'HH:mm d MMMM yyyy';
  */
 export default class DatePeriodQuestion extends Question {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} params.hint
-	 * @param {string} [params.url]
-	 * @param {Array.<import('../../validator/base-validator')>} [params.validators]
-	 * @param {boolean} [params.editable]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string} [params.dateFormat]
 	 * @param {{start: string, end: string}} [params.labels]
 	 * @param {{hour: number, minute: number, second: number}} [params.startTime]
 	 * @param {{hour: number, minute: number, second: number}} [params.endTime]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({
-		title,
-		question,
-		fieldName,
-		validators,
-		hint,
-		url,
-		editable,
-		dateFormat = DEFAULT_DATE_FORMAT,
-		labels,
-		startTime,
-		endTime,
-		viewData
-	}) {
+	constructor({ dateFormat = DEFAULT_DATE_FORMAT, labels, startTime, endTime, ...params }) {
 		super({
-			title,
-			viewFolder: 'date-period',
-			fieldName,
-			question,
-			validators,
-			hint,
-			url,
-			editable,
-			viewData
+			...params,
+			viewFolder: 'date-period'
 		});
 		this.dateFormat = dateFormat;
 		this.labels = labels || { start: 'Start', end: 'End' };

--- a/packages/dynamic-forms/src/components/date/question.js
+++ b/packages/dynamic-forms/src/components/date/question.js
@@ -15,38 +15,13 @@ const DEFAULT_DATE_FORMAT = 'd MMMM yyyy';
  */
 export default class DateQuestion extends Question {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} params.hint
-	 * @param {string} [params.url]
-	 * @param {Array.<import('../../validator/base-validator')>} [params.validators]
-	 * @param {boolean} [params.editable]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string} [params.dateFormat]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({
-		title,
-		question,
-		fieldName,
-		validators,
-		hint,
-		url,
-		editable,
-		dateFormat = DEFAULT_DATE_FORMAT,
-		viewData
-	}) {
+	constructor({ dateFormat = DEFAULT_DATE_FORMAT, ...params }) {
 		super({
-			title,
-			viewFolder: 'date',
-			fieldName,
-			question,
-			validators,
-			hint,
-			url,
-			editable,
-			viewData
+			...params,
+			viewFolder: 'date'
 		});
 		this.dateFormat = dateFormat;
 	}

--- a/packages/dynamic-forms/src/components/identifier/question.js
+++ b/packages/dynamic-forms/src/components/identifier/question.js
@@ -7,46 +7,14 @@ export default class IdentifierQuestion extends Question {
 	inputClasses;
 
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.pageTitle]
-	 * @param {string} [params.description]
-	 * @param {string} [params.html]
-	 * @param {string} [params.hint]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string} [params.inputClasses] css class string to be added to the input
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Array.<import('../../questions/question.js').BaseValidator>} [params.validators]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({
-		title,
-		question,
-		fieldName,
-		url,
-		pageTitle,
-		description,
-		validators,
-		html,
-		hint,
-		inputClasses = 'govuk-input--width-10',
-		label,
-		viewData
-	}) {
+	constructor({ inputClasses = 'govuk-input--width-10', label, ...params }) {
 		super({
-			title,
-			question,
-			viewFolder: 'identifier',
-			fieldName,
-			url,
-			pageTitle,
-			description,
-			validators,
-			html,
-			hint,
-			viewData
+			...params,
+			viewFolder: 'identifier'
 		});
 
 		this.inputClasses = inputClasses;

--- a/packages/dynamic-forms/src/components/multi-field-input/question.js
+++ b/packages/dynamic-forms/src/components/multi-field-input/question.js
@@ -27,47 +27,15 @@ export default class MultiFieldInputQuestion extends Question {
 	inputAttributes;
 
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.description]
-	 * @param {string} [params.url]
-	 * @param {string} [params.html]
-	 * @param {string} [params.hint]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Array.<BaseValidator>} [params.validators]
 	 * @param {Record<string, string>} [params.inputAttributes] html attributes to add to the input
 	 * @param {InputField[]} params.inputFields input fields
-	 * @param {'contactDetails' | 'standard' | null} [params.formatType] optional type field used for formatting for task list
-	 * @param {boolean} [params.editable]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({
-		title,
-		question,
-		fieldName,
-		url,
-		hint,
-		validators,
-		html,
-		label,
-		inputAttributes = {},
-		inputFields,
-		editable,
-		viewData
-	}) {
+	constructor({ label, inputAttributes = {}, inputFields, ...params }) {
 		super({
-			title,
-			viewFolder: 'multi-field-input',
-			fieldName,
-			url,
-			question,
-			validators,
-			hint,
-			html,
-			editable,
-			viewData
+			...params,
+			viewFolder: 'multi-field-input'
 		});
 		this.label = label;
 		this.inputAttributes = inputAttributes;

--- a/packages/dynamic-forms/src/components/number-entry/question.js
+++ b/packages/dynamic-forms/src/components/number-entry/question.js
@@ -7,29 +7,14 @@ import { getPersistedNumberAnswer } from '../utils/persisted-number-answer.js';
 
 export default class NumberEntryQuestion extends Question {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.html]
-	 * @param {string} [params.hint]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string} [params.suffix]
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Array.<import('../../questions/question.js').BaseValidator>} [params.validators]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({ title, question, fieldName, url, hint, label, html, validators, suffix, viewData }) {
+	constructor({ label, suffix, ...params }) {
 		super({
-			title,
-			question,
-			viewFolder: 'number-entry',
-			fieldName,
-			url,
-			hint,
-			validators,
-			html,
-			viewData
+			...params,
+			viewFolder: 'number-entry'
 		});
 
 		this.suffix = suffix;

--- a/packages/dynamic-forms/src/components/single-line-input/question.js
+++ b/packages/dynamic-forms/src/components/single-line-input/question.js
@@ -16,19 +16,10 @@ export default class SingleLineInputQuestion extends Question {
 	inputAttributes;
 
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.description]
-	 * @param {string} [params.url]
-	 * @param {string} [params.html]
-	 * @param {string} [params.hint]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Array.<BaseValidator>} [params.validators]
 	 * @param {Record<string, string>} [params.inputAttributes] html attributes to add to the input
 	 * @param {string} [params.classes] html classes to add to the input
-	 * @param {Object<string, any>} [params.viewData]
 	 */
 	constructor(params) {
 		super({

--- a/packages/dynamic-forms/src/components/text-entry-redact/question.js
+++ b/packages/dynamic-forms/src/components/text-entry-redact/question.js
@@ -22,44 +22,16 @@ export const REDACT_CHARACTER = '█';
  */
 export default class TextEntryRedactQuestion extends Question {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.html]
-	 * @param {string} [params.hint]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {TextEntryCheckbox} [params.textEntryCheckbox]
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
 	 * @param {boolean} [params.onlyShowRedactedValueForSummary] whether to only show redacted value for summary
 	 * @param {boolean} [params.useRedactedFieldNameForSave] whether to use the redacted field name when saving answers
-	 * @param {Array.<import('../../validator/base-validator')>} [params.validators]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({
-		title,
-		question,
-		fieldName,
-		url,
-		hint,
-		validators,
-		html,
-		textEntryCheckbox,
-		label,
-		onlyShowRedactedValueForSummary,
-		useRedactedFieldNameForSave,
-		viewData
-	}) {
+	constructor({ textEntryCheckbox, label, onlyShowRedactedValueForSummary, useRedactedFieldNameForSave, ...params }) {
 		super({
-			title,
-			viewFolder: 'text-entry-redact',
-			fieldName,
-			url,
-			question,
-			validators,
-			hint,
-			html,
-			viewData
+			...params,
+			viewFolder: 'text-entry-redact'
 		});
 
 		this.textEntryCheckbox = textEntryCheckbox;

--- a/packages/dynamic-forms/src/components/text-entry/question.js
+++ b/packages/dynamic-forms/src/components/text-entry/question.js
@@ -19,29 +19,14 @@ import { Question } from '../../questions/question.js';
  */
 export default class TextEntryQuestion extends Question {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.html]
-	 * @param {string} [params.hint]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {TextEntryCheckbox} [params.textEntryCheckbox]
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Array.<import('../../validator/base-validator')>} [params.validators]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({ title, question, fieldName, url, hint, validators, html, textEntryCheckbox, label, viewData }) {
+	constructor({ textEntryCheckbox, label, ...params }) {
 		super({
-			title,
-			viewFolder: 'text-entry',
-			fieldName,
-			url,
-			question,
-			validators,
-			hint,
-			html,
-			viewData
+			...params,
+			viewFolder: 'text-entry'
 		});
 
 		this.textEntryCheckbox = textEntryCheckbox;

--- a/packages/dynamic-forms/src/components/unit-option-entry/question.js
+++ b/packages/dynamic-forms/src/components/unit-option-entry/question.js
@@ -41,54 +41,17 @@ export default class UnitOptionEntryQuestion extends Question {
 	options;
 
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName // will be the unit type eg square metres, hectares
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string} [params.conditionalFieldName] // will be the quantity and is captured by the conditional in the options
-	 * @param {string} [params.viewFolder]
-	 * @param {string} [params.url]
-	 * @param {string} [params.hint]
-	 * @param {string} [params.pageTitle]
-	 * @param {string} [params.description]
 	 * @param {string} [params.label]
-	 * @param {string} [params.html]
 	 * @param {Array.<UnitOption>} [params.options]
-	 * @param {Array.<import('../../questions/question.js').BaseValidator>} [params.validators]
-	 * @param {Object<string, any>} [params.viewData]
-	 *
 	 * @param {Record<string, Function>} [methodOverrides]
-	 */ constructor(
-		{
-			title,
-			question,
-			fieldName,
-			conditionalFieldName,
-			viewFolder,
-			url,
-			hint,
-			pageTitle,
-			description,
-			label,
-			html,
-			options,
-			validators,
-			viewData
-		},
-		methodOverrides
-	) {
+	 */
+	constructor({ conditionalFieldName, options, label, ...params }, methodOverrides) {
 		super(
 			{
-				title,
-				question,
-				viewFolder: !viewFolder ? 'unit-option-entry' : viewFolder,
-				fieldName,
-				url,
-				hint,
-				pageTitle,
-				description,
-				validators,
-				viewData
+				...params,
+				viewFolder: 'unit-option-entry'
 			},
 			methodOverrides
 		);
@@ -98,7 +61,6 @@ export default class UnitOptionEntryQuestion extends Question {
 
 		this.conditionalFieldName = conditionalFieldName;
 		this.options = options;
-		this.html = html;
 		this.label = label;
 		this.optionJoinString = defaultOptionJoinString;
 	}

--- a/packages/dynamic-forms/src/questions/options-question.js
+++ b/packages/dynamic-forms/src/questions/options-question.js
@@ -45,55 +45,21 @@ export default class OptionsQuestion extends Question {
 	options;
 
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.viewFolder
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.hint]
-	 * @param {string} [params.pageTitle]
-	 * @param {string} [params.description]
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {Array<Option>} params.options
-	 * @param {Array<import('./question').BaseValidator>} [params.validators]
-	 * @param {boolean} [params.editable]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({
-		title,
-		question,
-		viewFolder,
-		fieldName,
-		url,
-		hint,
-		pageTitle,
-		description,
-		options,
-		validators,
-		editable,
-		viewData
-	}) {
+	constructor(params) {
 		// add default valid options validator to all options questions
 		let optionsValidators = [new ValidOptionValidator()];
-		if (validators && Array.isArray(validators)) {
-			optionsValidators = validators.concat(optionsValidators);
+		if (params.validators && Array.isArray(params.validators)) {
+			optionsValidators = params.validators.concat(optionsValidators);
 		}
 
 		super({
-			title,
-			question,
-			viewFolder,
-			fieldName,
-			url,
-			hint,
-			pageTitle,
-			description,
-			validators: optionsValidators,
-			editable,
-			viewData
+			...params,
+			validators: optionsValidators
 		});
-		this.hint = hint;
-		this.options = options;
+		this.options = params.options;
 		this.optionJoinString = defaultOptionJoinString;
 	}
 

--- a/packages/dynamic-forms/src/questions/question-types.d.ts
+++ b/packages/dynamic-forms/src/questions/question-types.d.ts
@@ -1,0 +1,22 @@
+import BaseValidator from '../validator/base-validator';
+import { JourneyResponse } from '../journey/journey-response';
+
+export interface QuestionParameters {
+	title: string;
+	question: string;
+	viewFolder: string;
+	fieldName: string;
+	url?: string;
+	pageTitle?: string;
+	description?: string;
+	validators?: BaseValidator[];
+	html?: string;
+	hint?: string;
+	interfaceType?: string;
+	shouldDisplay?: (response: JourneyResponse) => boolean;
+	autocomplete?: string;
+	// is this question editable? defaults to true
+	editable?: boolean;
+	// static view data for this question
+	viewData?: Object<string, any>;
+}

--- a/packages/dynamic-forms/src/questions/question.js
+++ b/packages/dynamic-forms/src/questions/question.js
@@ -86,23 +86,7 @@ export class Question {
 	};
 
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.viewFolder
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.pageTitle]
-	 * @param {string} [params.description]
-	 * @param {Array.<BaseValidator>} [params.validators]
-	 * @param {string} [params.html]
-	 * @param {string} [params.hint]
-	 * @param {string} [params.interfaceType]
-	 * @param {(response: JourneyResponse) => boolean} [params.shouldDisplay]
-	 * @param {string} [params.autocomplete]
-	 * @param {boolean} [params.editable] - defaults to true
-	 * @param {Object<string, any>} [params.viewData]
-	 *
+	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {Record<string, Function>} [methodOverrides]
 	 */
 	constructor(

--- a/packages/lib/forms/custom-components/representation-comment/question.js
+++ b/packages/lib/forms/custom-components/representation-comment/question.js
@@ -13,29 +13,14 @@ import { Question } from '@pins/dynamic-forms/src/questions/question.js';
  */
 export default class RepresentationComment extends Question {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.html]
-	 * @param {string} [params.hint]
+	 * @param {import('@pins/dynamic-forms/src/questions/question-types.js').QuestionParameters} params
 	 * @param {TextEntryCheckbox} [params.textEntryCheckbox]
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Array.<import('../../validator/base-validator')>} [params.validators]
-	 * @param {Object<string, any>} [params.viewData]
 	 */
-	constructor({ title, question, fieldName, url, hint, validators, html, textEntryCheckbox, label, viewData }) {
+	constructor({ textEntryCheckbox, label, ...params }) {
 		super({
-			title,
-			viewFolder: 'custom-components/representation-comment',
-			fieldName,
-			url,
-			question,
-			validators,
-			hint,
-			html,
-			viewData
+			...params,
+			viewFolder: 'custom-components/representation-comment'
 		});
 
 		this.textEntryCheckbox = textEntryCheckbox;


### PR DESCRIPTION
## Describe your changes

- [refactor(dynamic-forms): add common question parameters into a type](https://github.com/Planning-Inspectorate/crown-developments/commit/3d222efbc60e046635675a2fff0ca2dfd1bb7929)
To avoid the need to add props to each question definition when it applies to the root Question class.

## Issue ticket number and link

N/A
