### PR TITLE
fix(app): remove unnecessary template id

### DIFF
--- a/apps/manage/src/app/config.js
+++ b/apps/manage/src/app/config.js
@@ -113,7 +113,6 @@ export function loadConfig() {
 	if (!govNotifyDisabled) {
 		const props = {
 			GOV_NOTIFY_API_KEY,
-			GOV_NOTIFY_TEST_TEMPLATE_ID,
 			GOV_NOTIFY_PRE_ACK_TEMPLATE_ID,
 			GOV_NOTIFY_ACK_REP_TEMPLATE_ID,
 			GOV_NOTIFY_LPA_QNR_TEMPLATE_ID,

--- a/apps/portal/src/app/config.js
+++ b/apps/portal/src/app/config.js
@@ -62,7 +62,6 @@ export function loadConfig() {
 	if (!govNotifyDisabled) {
 		const props = {
 			GOV_NOTIFY_API_KEY,
-			GOV_NOTIFY_TEST_TEMPLATE_ID,
 			GOV_NOTIFY_PRE_ACK_TEMPLATE_ID,
 			GOV_NOTIFY_ACK_REP_TEMPLATE_ID
 		};


### PR DESCRIPTION
## Describe your changes
Start-up required a test id template for notify which now fails on prod as there is no template and we have turned gov notify on
## Issue ticket number and link
