### PR TITLE
fix(app): add inline error to doc upload form

### DIFF
--- a/apps/portal/src/app/views/applications/view/have-your-say/index.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/index.js
@@ -69,7 +69,7 @@ export function createHaveYourSayRoutes(service) {
 		'/:section/:question/upload-documents',
 		getJourneyResponse,
 		getJourney,
-		handleUploads.array('files[]', 3),
+		handleUploads.array('files[]'),
 		uploadDocuments
 	);
 

--- a/packages/lib/forms/custom-components/representation-attachments/index.njk
+++ b/packages/lib/forms/custom-components/representation-attachments/index.njk
@@ -123,79 +123,37 @@
             {% endfor %}
 
             <script {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>
-							document.addEventListener('DOMContentLoaded', function () {
-								document.querySelectorAll('.js-remove-link').forEach(function (link) {
-									link.addEventListener('click', function (event) {
-										event.preventDefault();
-										const formId = link.getAttribute('data-form-id');
-										const form = document.getElementById(formId);
-										if (form) form.submit();
-									});
-								});
-							});
+                document.addEventListener('DOMContentLoaded', function () {
+                    document.querySelectorAll('.js-remove-link').forEach(function (link) {
+                        link.addEventListener('click', function (event) {
+                            event.preventDefault();
+                            const formId = link.getAttribute('data-form-id');
+                            const form = document.getElementById(formId);
+                            if (form) form.submit();
+                        });
+                    });
+                });
 
-							document.addEventListener('DOMContentLoaded', function () {
-								const fileInput = document.querySelector('#{{ question.fieldName }}-input');
-								const form = document.querySelector('#upload-form');
+                document.addEventListener('DOMContentLoaded', function () {
+                    const fileInput = document.querySelector('#{{ question.fieldName }}-input');
+                    const form = document.querySelector('#upload-form');
 
-								const allowedTypes = {{ question.allowedMimeTypes | dump | safe }};
-								const maxFileSize = {{ question.maxFileSizeValue }};
-								const maxFiles = 3;
+                    if (fileInput && form) {
+                        fileInput.addEventListener('change', function () {
+                            const files = fileInput.files;
+                            if (files.length === 0) return;
 
-								function showError(message) {
-									let errorDiv = document.querySelector('#file-upload-error');
-									if (!errorDiv) {
-										errorDiv = document.createElement('div');
-										errorDiv.id = 'file-upload-error';
-										errorDiv.className = 'govuk-error-message';
-										fileInput.closest('.govuk-form-group').appendChild(errorDiv);
-									}
-									errorDiv.textContent = message;
-								}
+                            form.submit();
+                        });
+                    }
+                });
 
-								function clearError() {
-									const errorDiv = document.querySelector('#file-upload-error');
-									if (errorDiv) errorDiv.remove();
-								}
-
-								if (fileInput && form) {
-									fileInput.addEventListener('change', function () {
-										clearError();
-
-										const files = fileInput.files;
-										if (files.length === 0) return;
-
-										if (files.length > maxFiles) {
-											showError(`You can only upload up to ${maxFiles} files.`);
-											fileInput.value = '';
-											return;
-										}
-
-										for (const file of files) {
-											if (!allowedTypes.includes(file.type)) {
-												const formattedTypes = "{{ formattedTypes | escape | safe }}";
-												showError(`The attachment must be ${formattedTypes}`);
-												fileInput.value = '';
-												return;
-											}
-
-											if (file.size > maxFileSize) {
-												showError(`Each file must be smaller than {{ question.maxFileSizeString }}.`);
-												fileInput.value = '';
-												return;
-											}
-										}
-										form.submit();
-									});
-								}
-							});
-
-							window.addEventListener("DOMContentLoaded", () => {
-								const links = document.querySelectorAll(".js-enabled-link");
-								links.forEach(link => {
-									link.style.display = "inline";
-								});
-							});
+                window.addEventListener("DOMContentLoaded", () => {
+                    const links = document.querySelectorAll(".js-enabled-link");
+                    links.forEach(link => {
+                        link.style.display = "inline";
+                    });
+                });
             </script>
         </div>
     </div>

--- a/packages/lib/forms/custom-components/representation-attachments/index.njk
+++ b/packages/lib/forms/custom-components/representation-attachments/index.njk
@@ -41,6 +41,7 @@
             <ul class="govuk-list govuk-list--bullet">
                 <li>Files must not be compressed (e.g. no ZIP files)</li>
                 <li>Each file must be under {{ question.maxFileSizeString }}</li>
+                <li>Only 3 files can be uploaded at a time</li>
                 <li>Total upload size must be under 1GB</li>
             </ul>
 

--- a/packages/lib/forms/custom-components/representation-attachments/index.njk
+++ b/packages/lib/forms/custom-components/representation-attachments/index.njk
@@ -72,7 +72,9 @@
                 </dl>
             {% endif %}
 
-            <form id="upload-form" method="post" enctype="multipart/form-data" action="{{ currentUrl }}/upload-documents">
+            {% set uploadForm = "upload-form" %}
+
+            <form id={{ uploadForm }} method="post" enctype="multipart/form-data" action="{{ currentUrl }}/upload-documents">
                 <input type="hidden" name="_csrf" value="{{ _csrf }}">
                 {{ govukFileUpload({
                     id: question.fieldName,
@@ -87,6 +89,9 @@
                     attributes: {
                         multiple: true,
                         accept: question.allowedMimeTypes | join(", ")
+                    },
+                    errorMessage: errors[uploadForm] and {
+                        text: errors[uploadForm].msg
                     }
                 }) }}
                 <noscript>

--- a/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
+++ b/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
@@ -51,7 +51,16 @@ export function uploadDocumentsController(
 		);
 		const documents = await fetchDocumentsInFolderPath(drive, folderPath);
 		const totalSize = documents.reduce((sum, item) => sum + (item.size || 0), 0);
-		const fileErrors = (
+		const fileErrors = [];
+
+		if (req.files.length > 3) {
+			fileErrors.push({
+				text: 'You can only upload up to 3 files',
+				href: '#upload-form'
+			});
+		}
+
+		const fileValidationErrors = (
 			await Promise.all(
 				req.files.map((file) =>
 					validateUploadedFile(file, logger, allowedFileExtensions, allowedMimeTypes, maxFileSize)
@@ -60,6 +69,8 @@ export function uploadDocumentsController(
 		)
 			.flat()
 			.filter(Boolean);
+
+		fileErrors.push(...fileValidationErrors);
 
 		if (fileAlreadyExistsInFolder(documents, req.files)) {
 			fileErrors.push({

--- a/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
+++ b/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
@@ -77,7 +77,7 @@ export function uploadDocumentsController(
 
 		if (fileErrors.length > 0) {
 			req.session.errors = {
-				'upload-form': { msg: 'Errors encountered during file upload.' }
+				'upload-form': { msg: 'Errors encountered during file upload' }
 			};
 			req.session.errorSummary = fileErrors;
 		} else {

--- a/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
+++ b/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
@@ -55,7 +55,7 @@ export function uploadDocumentsController(
 
 		if (Array.isArray(req.files) && req.files.length > 3) {
 			fileErrors.push({
-				text: 'You can only upload up to 3 files',
+				text: 'You can only upload up to 3 files at a time',
 				href: '#upload-form'
 			});
 		}

--- a/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
+++ b/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
@@ -53,7 +53,7 @@ export function uploadDocumentsController(
 		const totalSize = documents.reduce((sum, item) => sum + (item.size || 0), 0);
 		const fileErrors = [];
 
-		if (req.files.length > 3) {
+		if (Array.isArray(req.files) && req.files.length > 3) {
 			fileErrors.push({
 				text: 'You can only upload up to 3 files',
 				href: '#upload-form'

--- a/packages/lib/forms/custom-components/representation-attachments/upload-documents.test.js
+++ b/packages/lib/forms/custom-components/representation-attachments/upload-documents.test.js
@@ -274,7 +274,7 @@ describe('upload-documents.js', () => {
 			assert.deepStrictEqual(req.session.errors, { 'upload-form': { msg: 'Errors encountered during file upload' } });
 			assert.deepStrictEqual(req.session.errorSummary, [
 				{
-					text: 'You can only upload up to 3 files',
+					text: 'You can only upload up to 3 files at a time',
 					href: '#upload-form'
 				}
 			]);

--- a/packages/lib/forms/custom-components/representation-attachments/upload-documents.test.js
+++ b/packages/lib/forms/custom-components/representation-attachments/upload-documents.test.js
@@ -197,7 +197,7 @@ describe('upload-documents.js', () => {
 				redirectCalledWith,
 				'/applications/166c1754-f7dd-440a-b6f1-0f535ea008d5/have-your-say/myself/select-attachments'
 			);
-			assert.deepStrictEqual(req.session.errors, { 'upload-form': { msg: 'Errors encountered during file upload.' } });
+			assert.deepStrictEqual(req.session.errors, { 'upload-form': { msg: 'Errors encountered during file upload' } });
 			assert.deepStrictEqual(req.session.errorSummary, [
 				{
 					text: 'Attachment with this name has already been uploaded',


### PR DESCRIPTION
## Describe your changes
Severity: Minor; Inline error message missing from upload page
Severity: Minor: Inline messages should appear above the control
Severity: Minor: Error message summary does not refresh
Severity: Minor: Upload page cannot upload 4 files or more

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-848
https://pins-ds.atlassian.net/browse/CROWN-854
https://pins-ds.atlassian.net/browse/CROWN-850
https://pins-ds.atlassian.net/browse/CROWN-855

<img width="1065" alt="Screenshot 2025-06-04 at 14 21 36" src="https://github.com/user-attachments/assets/fb040803-9745-4534-9975-e549b8817953" />

<img width="940" alt="Screenshot 2025-06-04 at 14 22 18" src="https://github.com/user-attachments/assets/21968f1b-cdae-41f4-b969-6043c80aa6c3" />

<img width="1028" alt="Screenshot 2025-06-04 at 15 21 14" src="https://github.com/user-attachments/assets/dde606bf-0f29-4c7f-a90d-83ddf49e9aca" />

<img width="895" alt="Screenshot 2025-06-04 at 15 59 32" src="https://github.com/user-attachments/assets/4fad2afb-6ef8-4da1-830d-b23d194211ac" />