### PR TITLE
fix(manage): switched coordinates so easting appears before northing

### DIFF
--- a/apps/manage/src/app/views/cases/create-a-case/questions.js
+++ b/apps/manage/src/app/views/cases/create-a-case/questions.js
@@ -80,22 +80,22 @@ export function getQuestions() {
 			url: 'site-coordinates',
 			inputFields: [
 				{
-					fieldName: 'siteNorthing',
-					label: 'Northing',
-					formatPrefix: 'Northing: ',
-					hint: 'Optional'
-				},
-				{
 					fieldName: 'siteEasting',
 					label: 'Easting',
 					formatPrefix: 'Easting: ',
+					hint: 'Optional'
+				},
+				{
+					fieldName: 'siteNorthing',
+					label: 'Northing',
+					formatPrefix: 'Northing: ',
 					hint: 'Optional'
 				}
 			],
 			validators: [
 				new CoordinatesValidator(
-					{ title: 'Northing', fieldName: 'siteNorthing' },
-					{ title: 'Easting', fieldName: 'siteEasting' }
+					{ title: 'Easting', fieldName: 'siteEasting' },
+					{ title: 'Northing', fieldName: 'siteNorthing' }
 				)
 			]
 		},

--- a/apps/manage/src/app/views/cases/list/controller.js
+++ b/apps/manage/src/app/views/cases/list/controller.js
@@ -48,9 +48,9 @@ export function crownDevelopmentToViewModel(crownDevelopment) {
 	};
 	if (crownDevelopment.SiteAddress) {
 		fields.location = addressToViewModel(crownDevelopment.SiteAddress);
-	} else if (crownDevelopment.siteNorthing || crownDevelopment.siteEasting) {
-		fields.location = `Northing: ${crownDevelopment.siteNorthing?.toString().padStart(6, '0') || '-'}\n`;
-		fields.location += `Easting: ${crownDevelopment.siteEasting?.toString().padStart(6, '0') || '-'}`;
+	} else if (crownDevelopment.siteEasting || crownDevelopment.siteNorthing) {
+		fields.location = `Easting: ${crownDevelopment.siteEasting?.toString().padStart(6, '0') || '-'}\n`;
+		fields.location += `Northing: ${crownDevelopment.siteNorthing?.toString().padStart(6, '0') || '-'}`;
 	}
 
 	return fields;

--- a/apps/manage/src/app/views/cases/list/controller.test.js
+++ b/apps/manage/src/app/views/cases/list/controller.test.js
@@ -39,8 +39,8 @@ describe('case list', () => {
 				id: 'id-1',
 				reference: 'case/ref',
 				SiteAddress: { id: 'address-id-1', postcode: 'B11 ABC' },
-				siteNorthing: 12435,
-				siteEasting: 12435
+				siteEasting: 12435,
+				siteNorthing: 12435
 			};
 			const result = crownDevelopmentToViewModel(input);
 			assert.strictEqual(result.location, 'B11 ABC');
@@ -58,39 +58,39 @@ describe('case list', () => {
 					county: 'County',
 					postcode: 'B11 ABC'
 				},
-				siteNorthing: 12435,
-				siteEasting: 12435
+				siteEasting: 12435,
+				siteNorthing: 12435
 			};
 			const result = crownDevelopmentToViewModel(input);
 			assert.strictEqual(result.location, 'House, Street, Town, County, B11 ABC');
 		});
-		it(`should use northing/easting as location if no address`, () => {
+		it(`should use easting/northing as location if no address`, () => {
 			/** @type {import('./types.js').CrownDevelopmentListFields} */
 			const input = {
 				id: 'id-1',
 				reference: 'case/ref',
-				siteNorthing: 124356,
-				siteEasting: 654321
+				siteEasting: 654321,
+				siteNorthing: 123456
 			};
 			const result = crownDevelopmentToViewModel(input);
+			assert.strictEqual(result.location.includes(`Easting`), true);
 			assert.strictEqual(result.location.includes(`Northing`), true);
-			assert.strictEqual(result.location.includes(`Easting`), true);
-			assert.strictEqual(result.location.includes('124356'), true);
+			assert.strictEqual(result.location.includes('123456'), true);
 			assert.strictEqual(result.location.includes('654321'), true);
 		});
-		it(`should use - as placeholder for easting/northing if not provided`, () => {
+		it(`should use - as placeholder for northing/easting if not provided`, () => {
 			/** @type {import('./types.js').CrownDevelopmentListFields} */
 			const input = {
 				id: 'id-1',
 				reference: 'case/ref',
-				siteEasting: 654321
+				siteNorthing: 123456
 			};
 			const result = crownDevelopmentToViewModel(input);
-			assert.strictEqual(result.location.includes(`Northing: -`), true);
-			assert.strictEqual(result.location.includes(`Easting`), true);
-			assert.strictEqual(result.location.includes('654321'), true);
+			assert.strictEqual(result.location.includes(`Easting: -`), true);
+			assert.strictEqual(result.location.includes(`Northing`), true);
+			assert.strictEqual(result.location.includes('123456'), true);
 		});
-		it('should format northing/easting to 6 digits by padding zeros to the start', () => {
+		it('should format easting/northing to 6 digits by padding zeros to the start', () => {
 			/** @type {import('./types.js').CrownDevelopmentListFields} */
 			const input = {
 				id: 'id-1',

--- a/apps/manage/src/app/views/cases/view/notification.js
+++ b/apps/manage/src/app/views/cases/view/notification.js
@@ -139,10 +139,10 @@ function getRecipientEmail(crownDevelopmentFields) {
 function formatSiteLocation(crownDevelopment) {
 	if (crownDevelopment.siteAddressId) {
 		return addressToViewModel(crownDevelopment.SiteAddress);
-	} else if (crownDevelopment.siteNorthing || crownDevelopment.siteEasting) {
+	} else if (crownDevelopment.siteEasting || crownDevelopment.siteNorthing) {
 		return [
-			`Northing: ${crownDevelopment.siteNorthing || '-'}`,
-			`Easting: ${crownDevelopment.siteEasting || '-'}`
+			`Easting: ${crownDevelopment.siteEasting || '-'}`,
+			`Northing: ${crownDevelopment.siteNorthing || '-'}`
 		].join(' , ');
 	} else {
 		return 'Site location not provided';

--- a/apps/manage/src/app/views/cases/view/notification.test.js
+++ b/apps/manage/src/app/views/cases/view/notification.test.js
@@ -50,7 +50,7 @@ describe('notification', () => {
 				{
 					reference: 'CROWN/2025/0000001',
 					applicationDescription: 'a big project',
-					siteAddress: 'Northing: 123456 , Easting: 654321',
+					siteAddress: 'Easting: 654321 , Northing: 123456',
 					lpaQuestionnaireReceivedDate: '2 Jan 2025',
 					frontOfficeLink: 'https://test.com/applications'
 				}
@@ -263,7 +263,7 @@ describe('notification', () => {
 					{
 						reference: 'CROWN/2025/0000001',
 						applicationDescription: 'a big project',
-						siteAddress: 'Northing: 123456 , Easting: 654321'
+						siteAddress: 'Easting: 654321 , Northing: 123456'
 					}
 				]
 			);

--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -102,24 +102,24 @@ export function getQuestions(groupMembers = { caseOfficers: [], inspectors: [] }
 			url: 'site-coordinates',
 			inputFields: [
 				{
-					fieldName: 'siteNorthing',
-					label: 'Northing',
-					formatPrefix: 'Northing: ',
+					fieldName: 'siteEasting',
+					label: 'Easting',
+					formatPrefix: 'Easting: ',
 					hint: 'Optional',
 					formatTextFunction: (string) => string.toString().padStart(6, '0')
 				},
 				{
-					fieldName: 'siteEasting',
-					label: 'Easting',
-					formatPrefix: 'Easting: ',
+					fieldName: 'siteNorthing',
+					label: 'Northing',
+					formatPrefix: 'Northing: ',
 					hint: 'Optional',
 					formatTextFunction: (string) => string.toString().padStart(6, '0')
 				}
 			],
 			validators: [
 				new CoordinatesValidator(
-					{ title: 'Northing', fieldName: 'siteNorthing' },
-					{ title: 'Easting', fieldName: 'siteEasting' }
+					{ title: 'Easting', fieldName: 'siteEasting' },
+					{ title: 'Northing', fieldName: 'siteNorthing' }
 				)
 			]
 		},

--- a/apps/manage/src/app/views/cases/view/update-case.test.js
+++ b/apps/manage/src/app/views/cases/view/update-case.test.js
@@ -219,7 +219,7 @@ describe('case details', () => {
 				{
 					reference: 'CROWN/2025/0000001',
 					applicationDescription: 'a big project',
-					siteAddress: 'Northing: 123456 , Easting: 654321',
+					siteAddress: 'Easting: 654321 , Northing: 123456',
 					lpaQuestionnaireReceivedDate: '2 Jan 2025',
 					frontOfficeLink: 'https://test.com/applications'
 				}
@@ -411,7 +411,7 @@ describe('case details', () => {
 				{
 					reference: 'CROWN/2025/0000001',
 					applicationDescription: 'a big project',
-					siteAddress: 'Northing: 123456 , Easting: 654321',
+					siteAddress: 'Easting: 654321 , Northing: 123456',
 					applicationReceivedDate: '2 Jan 2025',
 					fee: ''
 				},
@@ -675,7 +675,7 @@ describe('case details', () => {
 					{
 						reference: 'CROWN/2025/0000001',
 						applicationDescription: 'a big project',
-						siteAddress: 'Northing: 123456 , Easting: 654321'
+						siteAddress: 'Easting: 654321 , Northing: 123456'
 					}
 				]
 			);

--- a/apps/portal/src/app/views/applications/view/view-model.js
+++ b/apps/portal/src/app/views/applications/view/view-model.js
@@ -53,10 +53,10 @@ export function crownDevelopmentToViewModel(crownDevelopment, contactEmail) {
 	if (crownDevelopment.SiteAddress) {
 		fields.siteAddress = addressToViewModel(crownDevelopment.SiteAddress);
 	}
-	if (crownDevelopment.siteNorthing && crownDevelopment.siteEasting) {
+	if (crownDevelopment.siteEasting && crownDevelopment.siteNorthing) {
 		fields.siteCoordinates = {
-			northing: crownDevelopment.siteNorthing.toString().padStart(6, '0'),
-			easting: crownDevelopment.siteEasting.toString().padStart(6, '0')
+			easting: crownDevelopment.siteEasting.toString().padStart(6, '0'),
+			northing: crownDevelopment.siteNorthing.toString().padStart(6, '0')
 		};
 	}
 

--- a/packages/dynamic-forms/src/validator/coordinates-validator.test.js
+++ b/packages/dynamic-forms/src/validator/coordinates-validator.test.js
@@ -53,26 +53,11 @@ describe('./src/dynamic-forms/validator/coordinates-validator.js', () => {
 		assert.strictEqual(errors[easting.fieldName].msg, `Enter 6 digits for the Grid reference ${easting.title}`);
 	});
 
-	it('should return an error message if northing is populated but easting is not', async () => {
-		const req = {
-			body: {
-				siteNorthing: '123456',
-				siteEasting: ''
-			}
-		};
-		const coordinatesValidator = new CoordinatesValidator(northing, easting);
-
-		const errors = await _validationMappedErrors(req, coordinatesValidator);
-
-		assert.strictEqual(Object.keys(errors).length, 1);
-		assert.strictEqual(errors[easting.fieldName].msg, `Enter 6 digits for the Grid reference ${easting.title}`);
-	});
-
 	it('should return an error message if easting is populated but northing is not', async () => {
 		const req = {
 			body: {
-				siteNorthing: '',
-				siteEasting: '123456'
+				siteEasting: '123456',
+				siteNorthing: ''
 			}
 		};
 		const coordinatesValidator = new CoordinatesValidator(northing, easting);
@@ -83,10 +68,25 @@ describe('./src/dynamic-forms/validator/coordinates-validator.js', () => {
 		assert.strictEqual(errors[northing.fieldName].msg, `Enter 6 digits for the Grid reference ${northing.title}`);
 	});
 
+	it('should return an error message if northing is populated but easting is not', async () => {
+		const req = {
+			body: {
+				siteEasting: '',
+				siteNorthing: '123456'
+			}
+		};
+		const coordinatesValidator = new CoordinatesValidator(northing, easting);
+
+		const errors = await _validationMappedErrors(req, coordinatesValidator);
+
+		assert.strictEqual(Object.keys(errors).length, 1);
+		assert.strictEqual(errors[easting.fieldName].msg, `Enter 6 digits for the Grid reference ${easting.title}`);
+	});
+
 	it('should return an error message if northing is populated but not required length and easting is not populated', async () => {
 		const req = {
 			body: {
-				siteNorthing: '1234',
+				siteNorthing: '12',
 				siteEasting: ''
 			}
 		};


### PR DESCRIPTION
## Describe your changes
Changes to the site location coordinates so Easting appears before Northing when creating a new case, editing a new case and overview 
 
## Issue ticket number and link
https://pins-ds.atlassian.net/jira/software/projects/CROWN/boards/267?selectedIssue=CROWN-630
![Screenshot 2025-06-12 112537](https://github.com/user-attachments/assets/9becabbd-1e6a-458c-84ef-1fe8f3d00e2b)
![Screenshot 2025-06-12 112516](https://github.com/user-attachments/assets/fba64cf3-0aa2-4fe7-b85f-a30460ae0445)
![Screenshot 2025-06-12 112452](https://github.com/user-attachments/assets/7c9aa1e8-276b-463a-80ba-0cf6c8c73184)
![Screenshot 2025-06-12 112412](https://github.com/user-attachments/assets/fb941cd3-3e65-4ad9-bfe2-7ad23b1bbdc6)
