### PR TITLE
fix(portal): align logo and header and extend blue bg on nav

### DIFF
--- a/apps/portal/src/app/sass/components/pins-header.scss
+++ b/apps/portal/src/app/sass/components/pins-header.scss
@@ -9,8 +9,6 @@
 	font-family: govuk.$govuk-font-family;
 
 	&__container {
-		display: flex;
-		flex-wrap: wrap;
 		border-bottom: 0;
 		padding: 0;
 		margin-bottom: 0;

--- a/apps/portal/src/app/views/layouts/components/core/header.njk
+++ b/apps/portal/src/app/views/layouts/components/core/header.njk
@@ -18,11 +18,11 @@
 	{% if config.isLive %}
 		<div class="govuk-width-container">
 			{% include "views/layouts/components/core/banner.njk" %}
+		</div>
 
 			{{ govukServiceNavigation({
 				classes: 'pins-navigation',
 				navigation: config.primaryNavigationLinks
 			}) }}
-		</div>
 	{% endif %}
 </header>


### PR DESCRIPTION
## Describe your changes
Align the PINS logo with the header
extend blue background on main navigation to across full screen

## Issue ticket number and link
ticket 864 https://pins-ds.atlassian.net/jira/software/projects/CROWN/boards/267?selectedIssue=CROWN-864
![Screenshot 2025-06-17 095655](https://github.com/user-attachments/assets/5c06874d-fbdc-4099-b195-6f12f505b8e1)
