### PR TITLE
fix(manage): hint now displaying under what is your address

### DIFF
--- a/packages/dynamic-forms/src/components/address/index.njk
+++ b/packages/dynamic-forms/src/components/address/index.njk
@@ -39,6 +39,9 @@
                         isPageHeading: true
                     }
                 }) %}
+                    {% if question.hint %}
+                        <div class="govuk-hint">{{ question.hint }}</div>
+                    {% endif %}
 
                     {% if question.html %}
                         {% include question.html ignore missing %}

--- a/packages/dynamic-forms/src/components/address/question.test.js
+++ b/packages/dynamic-forms/src/components/address/question.test.js
@@ -124,12 +124,13 @@ describe('AddressQuestion', () => {
 
 		it('should include the hint under the h1 title', async () => {
 			const { question } = setup();
-			question.hint = 'We will not publish your address';
+			const hintText = 'We will not publish your address';
+			question.hint = hintText;
 
 			const response = { journeyId: 'testJourney', answers: { siteAddress: testAddress } };
 			const model = await question.prepQuestionForRendering({}, { getBackLink: mock.fn(), response });
 
-			assert.strictEqual(model.question.hint, question.hint);
+			assert.strictEqual(model.question.hint, hintText);
 		});
 
 		it('should set required labels when required', async () => {

--- a/packages/dynamic-forms/src/components/address/question.test.js
+++ b/packages/dynamic-forms/src/components/address/question.test.js
@@ -121,6 +121,17 @@ describe('AddressQuestion', () => {
 			assert.strictEqual(model.question.labels.county, 'County (optional)');
 			assert.strictEqual(model.question.labels.postcode, 'Postcode (optional)');
 		});
+
+		it('should include the hint under the h1 title', async () => {
+			const { question } = setup();
+			question.hint = 'We will not publish your address';
+
+			const response = { journeyId: 'testJourney', answers: { siteAddress: testAddress } };
+			const model = await question.prepQuestionForRendering({}, { getBackLink: mock.fn(), response });
+
+			assert.strictEqual(model.question.hint, question.hint);
+		});
+
 		it('should set required labels when required', async () => {
 			VALIDATORS.push(
 				new AddressValidator({

--- a/packages/lib/forms/representations/question-utils.js
+++ b/packages/lib/forms/representations/question-utils.js
@@ -152,6 +152,7 @@ export function representationsContactQuestions({ prefix }) {
 		type: COMPONENT_TYPES.ADDRESS,
 		title: 'What is your address',
 		question: 'What is your address?',
+		hint: 'We will not publish your address',
 		fieldName: `${prefix}Address`,
 		url: 'address',
 		validators: [


### PR DESCRIPTION
## Describe your changes

the hint for page add-representation/myself then option post selected has been added under the h1 title "We will not publish your address"

![image](https://github.com/user-attachments/assets/250d71ca-c0a9-4fdc-91aa-bc3d9376a40b)


## Issue ticket number and link
438 https://pins-ds.atlassian.net/browse/CROWN-438