### PR TITLE
fix(package): handle folder not found correctly when saving a representation with no attachments

### DIFF
--- a/packages/lib/util/handle-attachments.js
+++ b/packages/lib/util/handle-attachments.js
@@ -85,7 +85,24 @@ export async function deleteRepresentationAttachmentsFolder(
 	const sessionId = req.sessionID;
 
 	const folderPath = representationSessionFolderPathFn(applicationReference, applicationNameFolder, sessionId);
-	const representationFolder = await sharePointDrive.getDriveItemByPath(folderPath);
+	let representationFolder;
+	try {
+		representationFolder = await sharePointDrive.getDriveItemByPath(folderPath);
+	} catch (error) {
+		if (error.statusCode === 404) {
+			logger.warn(
+				{ applicationReference, representationReference, folderPath },
+				`Representation session folder not found for ${representationReference}`
+			);
+			return null; // Folder does not exist
+		} else {
+			logger.error(
+				{ error, applicationReference, representationReference, folderPath },
+				`Error retrieving representation session folder for ${representationReference}`
+			);
+			throw new Error(`Failed to retrieve representation session folder: ${error.message}`);
+		}
+	}
 	if (!representationFolder || !representationFolder.id) {
 		logger.warn(
 			{ applicationReference, representationReference },


### PR DESCRIPTION
## Describe your changes
Fix a bug introduced when deleting folders when saving a representation, if no folders existed (ie no attachments were uploaded) it would throw. It now handles correctly.
## Issue ticket number and link
