### PR TITLE
fix(portal): cya attachments row now shows after amending attachments

### DIFF
--- a/packages/lib/forms/custom-components/representation-attachments/question.js
+++ b/packages/lib/forms/custom-components/representation-attachments/question.js
@@ -1,6 +1,5 @@
 import { Question } from '@pins/dynamic-forms/src/questions/question.js';
 import { nl2br } from '@pins/dynamic-forms/src/lib/utils.js';
-import { clearSessionData } from '../../../util/session.js';
 import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
 
 /**
@@ -11,19 +10,21 @@ import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-
  * @property {string} [errorMessage]
  */
 
-const REDACTED_FLAG = 'Redacted';
-
 /**
  * @class
  */
+
+/**
+ * @param {import('@pins/dynamic-forms/src/questions/question-types.js').QuestionParameters} params
+ * @param {Array<string>} allowedFileExtensions
+ * @param {Array<string>} allowedMimeTypes
+ * @param {number} maxFileSizeValue
+ * @param {number} maxFileSizeString
+ */
+
+const REDACTED_FLAG = 'Redacted';
+
 export default class RepresentationAttachments extends Question {
-	/**
-	 * @param {import('@pins/dynamic-forms/src/questions/question-types.js').QuestionParameters} params
-	 * @param {Array<string>} allowedFileExtensions
-	 * @param {Array<string>} allowedMimeTypes
-	 * @param {number} maxFileSizeValue
-	 * @param {number} maxFileSizeString
-	 */
 	constructor({ allowedFileExtensions, allowedMimeTypes, maxFileSizeValue, maxFileSizeString, ...params }) {
 		super({
 			...params,
@@ -129,10 +130,14 @@ export default class RepresentationAttachments extends Question {
 		const applicationId = req.params.id || req.params.applicationId;
 		const submittedForId = journeyResponse.answers?.submittedForId;
 
-		responseToSave.answers[this.fieldName] = req.session.files?.[applicationId]?.[submittedForId]?.uploadedFiles;
-		journeyResponse.answers[this.fieldName] = responseToSave.answers[this.fieldName];
+		let uploadedFiles = req.session.files?.[applicationId]?.[submittedForId]?.uploadedFiles;
 
-		clearSessionData(req, applicationId, [submittedForId], 'files');
+		if (uploadedFiles === undefined) {
+			uploadedFiles = journeyResponse.answers[this.fieldName] || [];
+		}
+
+		responseToSave.answers[this.fieldName] = uploadedFiles;
+		journeyResponse.answers[this.fieldName] = uploadedFiles;
 
 		return responseToSave;
 	}


### PR DESCRIPTION
## Describe your changes

bug with attachments on the have your say journey fix. When on the check your answers page, if the user went to amend the attachment but decided to continue without making any amendments. The attachments row would no longer show on the check your answers page. The row now shows 

https://github.com/user-attachments/assets/1baf8051-e5fe-4921-846a-28ccbd25d291


## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-916

