### PR TITLE
fix(apps): Inline error message missing from upload page

### DIFF
--- a/packages/lib/forms/custom-components/representation-attachments/index.njk
+++ b/packages/lib/forms/custom-components/representation-attachments/index.njk
@@ -93,6 +93,8 @@
                     },
                     errorMessage: errors[uploadForm] and {
                         text: errors[uploadForm].msg
+                    } or errors[question.fieldName] and {
+                        text: errors[question.fieldName].msg
                     }
                 }) }}
                 <noscript>


### PR DESCRIPTION
## Describe your changes
Severity: Minor: Inline error message missing from upload page

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-848

<img width="872" height="962" alt="Screenshot 2025-07-17 at 12 23 48" src="https://github.com/user-attachments/assets/bcf63401-16b5-4344-b47e-7fc252ca6e5b" />
