### PR TITLE
fix(manage): fileuploads no longer persist across uploadpages representations or once saved

### DIFF
--- a/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
@@ -115,7 +115,7 @@ export function buildUpdateRepresentation(
 				logParams: { id, representationRef }
 			});
 		}
-
+		clearSessionData(req, representationRef, req.params.section, 'files');
 		addRepUpdatedSession(req, representationRef);
 	};
 }

--- a/packages/lib/forms/custom-components/representation-attachments/question.js
+++ b/packages/lib/forms/custom-components/representation-attachments/question.js
@@ -133,7 +133,7 @@ export default class RepresentationAttachments extends Question {
 
 	async getDataToSave(req, journeyResponse) {
 		let responseToSave = { answers: {} };
-		const applicationId = req.params.id || req.params.applicationId;
+		const applicationId = req.params.representationRef || req.params.id || req.params.applicationId;
 		const submittedForId = journeyResponse.answers?.submittedForId;
 
 		responseToSave.answers[this.fieldName] = req.session.files?.[applicationId]?.[submittedForId]?.uploadedFiles;

--- a/packages/lib/forms/custom-components/representation-attachments/upload-document-middleware.js
+++ b/packages/lib/forms/custom-components/representation-attachments/upload-document-middleware.js
@@ -15,7 +15,7 @@ export async function uploadDocumentQuestion(req, res, next) {
 		const viewModel = hasSessionErrors
 			? questionObj.checkForValidationErrors(req, sectionObj, journey)
 			: questionObj.prepQuestionForRendering(sectionObj, journey, {
-					id: req.params.id || req.params.applicationId,
+					id: req.params.representationRef || req.params.id || req.params.applicationId,
 					currentUrl: req.originalUrl,
 					files: req.session?.files
 				});

--- a/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
+++ b/packages/lib/forms/custom-components/representation-attachments/upload-documents.js
@@ -44,12 +44,12 @@ export function uploadDocumentsController(
 		const journeyResponse = res.locals?.journeyResponse;
 
 		const isManageRepsJourney = isManageRepsJourneyId(journeyId);
-
+		const isEditRepsJourney = isEditRepsJourneyId(journeyId);
 		const submittedForId = isManageRepsJourney ? undefined : getSubmittedForId(journeyResponse?.answers);
 
 		const leafFolderName = isManageRepsJourney
 			? req.params.itemId
-			: isEditRepsJourneyId(journeyId)
+			: isEditRepsJourney
 				? req.params.representationRef
 				: submittedForId;
 
@@ -136,7 +136,7 @@ export function uploadDocumentsController(
 				});
 			});
 
-			const sessionIdKey = isManageRepsJourney ? req.params.representationRef : applicationId;
+			const sessionIdKey = isManageRepsJourney || isEditRepsJourney ? req.params.representationRef : applicationId;
 			const sessionKey = isManageRepsJourney ? req.params.itemId : submittedForId;
 			addSessionData(req, sessionIdKey, { [sessionKey]: { uploadedFiles } }, 'files');
 		}
@@ -161,12 +161,13 @@ export function deleteDocumentsController({ logger, appName, sharePointDrive, ge
 
 		const journeyResponse = res.locals?.journeyResponse;
 		const isManageRepsJourney = isManageRepsJourneyId(journeyId);
+		const isEditRepsJourney = isEditRepsJourneyId(journeyId);
 		let submittedForId;
 		if (!isManageRepsJourney) {
 			submittedForId = getSubmittedForId(journeyResponse?.answers);
 		}
 
-		const sessionIdKey = isManageRepsJourney ? req.params.representationRef : applicationId;
+		const sessionIdKey = isManageRepsJourney || isEditRepsJourney ? req.params.representationRef : applicationId;
 		const sessionKey = isManageRepsJourney ? req.params.itemId : submittedForId;
 
 		let uploadedFiles = req.session?.files?.[sessionIdKey]?.[sessionKey]?.uploadedFiles || [];


### PR DESCRIPTION
## Describe your changes
Files uploaded are now contained to the representation they are attached to, users can still move back and forth between and it stores them until the session is cleared, it's deleted or saved.
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-944