### PR TITLE
feat(manage): add duration fields for hearing and inquiry prep sitting and reporting

### DIFF
--- a/apps/manage/src/app/views/cases/view/question-utils.js
+++ b/apps/manage/src/app/views/cases/view/question-utils.js
@@ -134,19 +134,72 @@ export function eventQuestions(prefix) {
 			}
 		}),
 		[`${prefix}Duration`]: {
-			type: COMPONENT_TYPES.RADIO,
+			type: COMPONENT_TYPES.MULTI_FIELD_INPUT,
 			title: `${title} Duration`,
 			question: `What is the ${prefix} duration?`,
 			fieldName: `${prefix}Duration`,
 			url: `${prefix}-duration`,
-			validators: [new RequiredValidator()],
-			options: [
-				{ text: 'Prep', value: 'Prep' },
-				{ text: 'Sitting', value: 'Sitting' },
+			inputFields: [
 				{
-					text: 'Reporting',
-					value: 'Reporting'
+					fieldName: `${prefix}DurationPrep`,
+					label: 'Prep',
+					classes: 'govuk-input--width-5',
+					formatPrefix: 'Prep: ',
+					formatJoinString: ' days\r\n',
+					inputmode: 'numeric',
+					pattern: '[0-9]*',
+					suffix: { text: 'days' }
+				},
+				{
+					fieldName: `${prefix}DurationSitting`,
+					label: 'Sitting',
+					classes: 'govuk-input--width-5',
+					formatPrefix: 'Sitting: ',
+					formatJoinString: ' days\r\n',
+					inputmode: 'numeric',
+					pattern: '[0-9]*',
+					suffix: { text: 'days' }
+				},
+				{
+					fieldName: `${prefix}DurationReporting`,
+					label: 'Reporting',
+					classes: 'govuk-input--width-5',
+					formatPrefix: 'Reporting: ',
+					formatJoinString: ' days',
+					inputmode: 'numeric',
+					pattern: '[0-9]*',
+					suffix: { text: 'days' }
 				}
+			],
+			validators: [
+				new MultiFieldInputValidator({
+					fields: [
+						{
+							fieldName: `${prefix}DurationPrep`,
+							required: false,
+							regex: {
+								regex: '^$|^\\d+(\\.\\d+)?$', // Accepts empty or a decimal/integer
+								regexMessage: 'Prep must be a number'
+							}
+						},
+						{
+							fieldName: `${prefix}DurationSitting`,
+							required: false,
+							regex: {
+								regex: '^$|^\\d+(\\.\\d+)?$', // Accepts empty or a decimal/integer
+								regexMessage: 'Sitting must be a number'
+							}
+						},
+						{
+							fieldName: `${prefix}DurationReporting`,
+							required: false,
+							regex: {
+								regex: '^$|^\\d+(\\.\\d+)?$', // Accepts empty or a decimal/integer
+								regexMessage: 'Reporting must be a number'
+							}
+						}
+					]
+				})
 			]
 		},
 		[`${prefix}Venue`]: {

--- a/apps/manage/src/app/views/cases/view/question-utils.test.js
+++ b/apps/manage/src/app/views/cases/view/question-utils.test.js
@@ -64,5 +64,64 @@ describe('question-utils', () => {
 				assert.ok(question.url.startsWith(prefixHyphens));
 			}
 		});
+		it('should format user answer with formatPrefix and formatJoinString in duration', () => {
+			const prefix = 'hearing';
+			const questions = eventQuestions(prefix);
+			const durationQuestion = questions[`${prefix}Duration`];
+			const userAnswer = {
+				hearingDurationPrep: '2',
+				hearingDurationSitting: '3',
+				hearingDurationReporting: '1'
+			};
+			const formatted = durationQuestion.inputFields
+				.map((field) => {
+					const value = userAnswer[field.fieldName];
+					return value ? `${field.formatPrefix}${value}${field.formatJoinString}` : '';
+				})
+				.join('');
+
+			assert.ok(formatted.includes('Prep: 2 days'));
+			assert.ok(formatted.includes('Sitting: 3 days'));
+			assert.ok(formatted.includes('Reporting: 1 days'));
+		});
+
+		it('should format decimal values correctly in duration fields', () => {
+			const prefix = 'hearing';
+			const questions = eventQuestions(prefix);
+			const durationQuestion = questions[`${prefix}Duration`];
+			const userAnswer = {
+				hearingDurationPrep: '2.5',
+				hearingDurationSitting: '3.75',
+				hearingDurationReporting: '1.0'
+			};
+			const formatted = durationQuestion.inputFields
+				.map((field) => {
+					const value = userAnswer[field.fieldName];
+					return value ? `${field.formatPrefix}${value}${field.formatJoinString}` : '';
+				})
+				.join('');
+
+			assert.ok(formatted.includes('Prep: 2.5 days'));
+			assert.ok(formatted.includes('Sitting: 3.75 days'));
+			assert.ok(formatted.includes('Reporting: 1.0 days'));
+			assert.ok(!formatted.includes('Prep: 1.. days'));
+			assert.ok(!formatted.includes('Sitting: 1. days'));
+			assert.ok(!formatted.includes('Reporting: .0 days'));
+			assert.ok(!formatted.includes('Prep: 1.0. days'));
+			assert.ok(!formatted.includes('Sitting: 1.000 days'));
+			assert.ok(!formatted.includes('Reporting: 1000000.00 days'));
+		});
+	});
+	describe('duration regex validation', () => {
+		const regex = /^$|^\d+(\.\d+)?$/;
+		it('should validate allowed and disallowed values', () => {
+			assert.ok(regex.test('')); // blank
+			assert.ok(regex.test('5')); // integer
+			assert.ok(regex.test('5.5')); // decimal
+			assert.ok(!regex.test('abc')); // non-numeric
+			assert.ok(!regex.test('-5')); // negative
+			assert.ok(!regex.test('1.')); // malformed decimal
+			assert.ok(!regex.test('.0')); // malformed decimal
+		});
 	});
 });

--- a/apps/manage/src/app/views/cases/view/types.d.ts
+++ b/apps/manage/src/app/views/cases/view/types.d.ts
@@ -92,6 +92,9 @@ export interface CrownDevelopmentViewModel {
 	hearingIssuesReportPublishedDate?: Date | string;
 	hearingStatementsDate?: Date | string;
 	hearingCaseManagementConferenceDate?: Date | string;
+	hearingDurationPrep?: number | string;
+	hearingDurationSitting?: number | string;
+	hearingDurationReporting?: number | string;
 
 	inquiryProcedureNotificationDate?: Date | string;
 	inquiryStatementsDate?: Date | string;
@@ -101,11 +104,18 @@ export interface CrownDevelopmentViewModel {
 	inquiryNotificationDate?: Date | string;
 	inquiryCaseManagementConferenceDate?: Date | string;
 	inquiryProofsOfEvidenceDate?: Date | string;
+	inquiryDurationPrep?: number | string;
+	inquiryDurationSitting?: number | string;
+	inquiryDurationReporting?: number | string;
 
 	hasApplicationFee: string;
 	applicationFee: string;
 
 	siteVisitDate?: Date | string;
+
+	prepDuration?: number | string;
+	sittingDuration?: number | string;
+	reportingDuration?: number | string;
 }
 
 export type CrownDevelopmentViewModelFields = keyof CrownDevelopmentViewModel;

--- a/packages/database/src/migrations/20250731143131_add_event_prep_sitting_reporting_durations/migration.sql
+++ b/packages/database/src/migrations/20250731143131_add_event_prep_sitting_reporting_durations/migration.sql
@@ -1,0 +1,21 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Event] ADD [prepDuration] DECIMAL(6,2),
+[reportingDuration] DECIMAL(6,2),
+[sittingDuration] DECIMAL(6,2);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/migrations/20250731143309_remove_event_duration/migration.sql
+++ b/packages/database/src/migrations/20250731143309_remove_event_duration/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `duration` on the `Event` table. All the data in the column will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Event] DROP COLUMN [duration];
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -180,6 +180,9 @@ model Event {
   id                           String             @id @default(dbgenerated("newid()")) @db.UniqueIdentifier
   date                         DateTime?
   duration                     String?
+  prepDuration                 Decimal?           @db.Decimal(6, 2)
+  sittingDuration              Decimal?           @db.Decimal(6, 2)
+  reportingDuration            Decimal?           @db.Decimal(6, 2)
   venue                        String?
   notificationDate             DateTime?
   issuesReportPublishedDate    DateTime?

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -179,7 +179,6 @@ model Event {
   /// internal identifier
   id                           String             @id @default(dbgenerated("newid()")) @db.UniqueIdentifier
   date                         DateTime?
-  duration                     String?
   prepDuration                 Decimal?           @db.Decimal(6, 2)
   sittingDuration              Decimal?           @db.Decimal(6, 2)
   reportingDuration            Decimal?           @db.Decimal(6, 2)

--- a/packages/lib/util/numbers.js
+++ b/packages/lib/util/numbers.js
@@ -37,3 +37,15 @@ export function bytesToUnit(bytes, decimalPoints = 1) {
 
 	return parseFloat((bytes / Math.pow(K_UNIT, i)).toFixed(decimalPoints)) + ' ' + SIZES[i];
 }
+
+/**
+ * converts number strings to numbers or strings (for decimals), or returns null for empty strings
+ * @returns {*|number|string|null}
+ * @param value
+ */
+export function parseNumberStringToNumber(value) {
+	if (value === '' || value === null || value === undefined) return null;
+	if (Array.isArray(value)) return value;
+	const num = Number(value);
+	return isNaN(num) ? value : num;
+}

--- a/packages/lib/util/numbers.test.js
+++ b/packages/lib/util/numbers.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { bytesToUnit } from './numbers.js';
+import { bytesToUnit, parseNumberStringToNumber } from './numbers.js';
 
 describe('numbers', () => {
 	describe('bytesToUnit', () => {
@@ -20,6 +20,37 @@ describe('numbers', () => {
 			it(`should convert ${bytes} bytes to ${decimals || 1}dp`, () => {
 				const got = bytesToUnit(bytes, decimals);
 				assert.strictEqual(got, expected);
+			});
+		}
+	});
+	describe('parseNumberStringToNumber', () => {
+		const tests = [
+			{ input: '123', expected: 123 },
+			{ input: '0', expected: 0 },
+			{ input: '', expected: null },
+			{ input: null, expected: null },
+			{ input: undefined, expected: null },
+			{ input: 'abc', expected: 'abc' },
+			{ input: '12.34', expected: 12.34 },
+			{ input: '1e3', expected: 1000 },
+			{ input: ['1,234.56'], expected: ['1,234.56'] },
+			{ input: ['123', '345'], expected: ['123', '345'] },
+			{ input: '-123', expected: -123 },
+			{ input: '-12.34', expected: -12.34 },
+			{ input: '+123', expected: 123 },
+			{ input: '+12.34', expected: 12.34 },
+			{ input: '1..2', expected: '1..2' },
+			{ input: '1e-6', expected: 0.000001 },
+			{ input: '1e+6', expected: 1000000 },
+			{ input: {}, expected: {} },
+			{ input: [], expected: [] },
+			{ input: '0.0', expected: 0 },
+			{ input: '0.00', expected: 0 }
+		];
+		for (const { input, expected } of tests) {
+			it(`should convert "${input}" to ${expected}`, () => {
+				const got = parseNumberStringToNumber(input);
+				assert.deepStrictEqual(got, expected);
 			});
 		}
 	});


### PR DESCRIPTION
## Describe your changes

update to hearing and inquiry durations from radio button to labels which accept numerical answers for prep, sitting and reporting fields and display under duration under manage case

## Issue ticket number and link
hearing ticket - https://pins-ds.atlassian.net/browse/CROWN-500
inquiry ticket - https://pins-ds.atlassian.net/browse/CROWN-776

<img width="1019" height="629" alt="Screenshot 2025-07-24 122302" src="https://github.com/user-attachments/assets/d8717a63-6413-4577-bb55-fcef7f08629f" />

<img width="1141" height="617" alt="Screenshot 2025-07-24 122315" src="https://github.com/user-attachments/assets/842e2db4-751d-4fbf-a396-5264da24c950" />

![Uploading Screenshot 2025-07-24 122241.png…]()

<img width="1350" height="617" alt="Screenshot 2025-07-24 122222" src="https://github.com/user-attachments/assets/f579c9af-97d0-4df0-829a-37d30f7c6b3b" />


