### PR TITLE
fix(portal): Severity: Minor - declaration page uses inconsistent font size and weight

### DIFF
--- a/apps/portal/src/app/views/applications/view/have-your-say/declaration.njk
+++ b/apps/portal/src/app/views/applications/view/have-your-say/declaration.njk
@@ -5,6 +5,15 @@
 {% set title = "Declaration – " + config.haveYourSayServiceName %}
 {% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
 
+{% block pageHeading %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-l">
+                {{ pageTitle }}
+            </h1>
+        </div>
+    </div>
+{% endblock %}
 {% block pageContent %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -25,6 +34,7 @@
             <form method="post" novalidate="novalidate">
                 {{ govukButton({
                     text: "Accept and submit",
+                    type: "submit",
                     preventDoubleClick: true
                 }) }}
             </form>


### PR DESCRIPTION
## Describe your changes
Severity: Minor - declaration page uses inconsistent font size and weight
override pageHeading so that we can use govuk-heading-l instead of xl

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-959

<img width="1294" height="821" alt="Screenshot 2025-07-29 at 14 33 45" src="https://github.com/user-attachments/assets/6ffd3a00-d9f5-4579-9a62-5a0a4e8be944" />