### PR TITLE
feat(manage): add brackets as acceptable format in applicant and agent names

### DIFF
--- a/apps/manage/src/app/views/cases/create-a-case/question-utils.js
+++ b/apps/manage/src/app/views/cases/create-a-case/question-utils.js
@@ -34,8 +34,8 @@ export function contactQuestions({ prefix, title, addressRequired }) {
 					maxLengthMessage: `${title} organisation name must be less than 250 characters`
 				},
 				regex: {
-					regex: "^[A-Za-z0-9 ',’().,&-]+$",
-					regexMessage: `${title} organisation must only include letters, spaces, hyphens, apostrophes, commas, brackets, periods, ampersands or numbers`
+					regex: "^[A-Za-z0-9 ',’(),&-]+$,",
+					regexMessage: `${title} organisation must only include letters, spaces, hyphens, apostrophes, commas, brackets, ampersands or numbers`
 				}
 			})
 		]

--- a/apps/manage/src/app/views/cases/view/question-utils.js
+++ b/apps/manage/src/app/views/cases/view/question-utils.js
@@ -50,8 +50,8 @@ export function contactQuestions({ prefix, title, addressRequired }) {
 							maxLengthMessage: `${title} organisation must be less than 250 characters`
 						},
 						regex: {
-							regex: "^[A-Za-z0-9 ',’().,&-]+$",
-							regexMessage: `${title} organisation must only include letters, spaces, hyphens, apostrophes, commas, brackets, periods, ampersands or numbers`
+							regex: "^[A-Za-z0-9 ',’(),&-]+$,",
+							regexMessage: `${title} organisation must only include letters, spaces, hyphens, apostrophes, commas, brackets, ampersands or numbers`
 						}
 					},
 					{

--- a/apps/manage/src/app/views/cases/view/question-utils.test.js
+++ b/apps/manage/src/app/views/cases/view/question-utils.test.js
@@ -127,10 +127,10 @@ describe('question-utils', () => {
 		});
 	});
 	describe('organisation name regex validation when creating a new case and editing', () => {
-		const regex = /^[A-Za-z0-9 ',’().,&-]+$/;
+		const regex = /^[A-Za-z0-9 ',’(),&-]+$/;
 		it('should allow valid organisation names', () => {
 			assert.ok(regex.test('My Organisation'));
-			assert.ok(regex.test("O'Reilly, Inc."));
+			assert.ok(regex.test("O'Reilly, Inc"));
 			assert.ok(regex.test('ACME (UK) Ltd'));
 			assert.ok(regex.test('Smith & Sons, 123'));
 		});
@@ -139,6 +139,7 @@ describe('question-utils', () => {
 			assert.ok(!regex.test('ACME@UK'));
 			assert.ok(!regex.test('Smith#Sons'));
 			assert.ok(!regex.test('ACME*Ltd'));
+			assert.ok(!regex.test('ACME.Ltd'));
 		});
 	});
 });


### PR DESCRIPTION
## Describe your changes

Brackets can now be added to the applicant and agent names when creating and editing a case. For example Other Gov Department (OGD 

## Issue ticket number and link
834 https://pins-ds.atlassian.net/browse/CROWN-834

<img width="1065" height="255" alt="image" src="https://github.com/user-attachments/assets/7762deb1-867e-4716-a8a7-88c5e54c6932" />
<img width="1026" height="227" alt="image" src="https://github.com/user-attachments/assets/e6d1d0e7-dbde-4d47-901c-84af9d5e398f" />
<img width="800" height="582" alt="image" src="https://github.com/user-attachments/assets/2977536d-59af-44e4-a9bf-6c08b9e7fc48" />