### PR TITLE
Fix/crown 1014 enhancement severity low invalid file error displays some of the stack trace may be confusing

### DIFF
--- a/packages/lib/forms/custom-components/representation-attachments/document-validation-util.js
+++ b/packages/lib/forms/custom-components/representation-attachments/document-validation-util.js
@@ -23,7 +23,7 @@ export async function validateUploadedFile(file, logger, allowedFileExtensions, 
 	}
 
 	const fileTypeResult = await fileTypeFromBuffer(buffer);
-	logger.info(fileTypeResult);
+
 	if (!fileTypeResult) {
 		validationErrors.push({
 			text: `${originalname}: Could not determine file type from signature`,
@@ -71,12 +71,13 @@ export async function validateUploadedFile(file, logger, allowedFileExtensions, 
 	}
 
 	if (ext === 'zip' || mime === 'application/zip') {
-		validationErrors = [
-			{
-				text: `${originalname}: The attachment must not be a zip file`,
-				href: '#upload-form'
-			}
-		];
+		// reset validation errors if zip file is detected
+		// zip files are not allowed, so we add a specific error message
+		validationErrors = [];
+		validationErrors.push({
+			text: `${originalname}: The attachment must not be a zip file`,
+			href: '#upload-form'
+		});
 	}
 
 	return validationErrors;

--- a/packages/lib/forms/custom-components/representation-attachments/zip-file-util.js
+++ b/packages/lib/forms/custom-components/representation-attachments/zip-file-util.js
@@ -1,0 +1,59 @@
+// Returns a Buffer containing a minimal valid ZIP file
+export function createMinimalZipBuffer() {
+	// Minimal ZIP file: local file header + end of central directory record
+	return Buffer.from([
+		0x50,
+		0x4b,
+		0x03,
+		0x04, // Local file header signature
+		0x14,
+		0x00, // Version needed to extract
+		0x00,
+		0x00, // General purpose bit flag
+		0x00,
+		0x00, // Compression method
+		0x00,
+		0x00, // File last mod time
+		0x00,
+		0x00, // File last mod date
+		0x00,
+		0x00,
+		0x00,
+		0x00, // CRC-32
+		0x00,
+		0x00,
+		0x00,
+		0x00, // Compressed size
+		0x00,
+		0x00,
+		0x00,
+		0x00, // Uncompressed size
+		0x00,
+		0x00, // File name length
+		0x00,
+		0x00, // Extra field length
+		// No file name, no extra field, no file data
+		0x50,
+		0x4b,
+		0x05,
+		0x06, // End of central directory signature
+		0x00,
+		0x00, // Number of this disk
+		0x00,
+		0x00, // Disk where central directory starts
+		0x00,
+		0x00, // Number of central directory records on this disk
+		0x00,
+		0x00, // Total number of central directory records
+		0x00,
+		0x00,
+		0x00,
+		0x00, // Size of central directory (bytes)
+		0x00,
+		0x00,
+		0x00,
+		0x00, // Offset of start of central directory
+		0x00,
+		0x00 // Comment length
+	]);
+}


### PR DESCRIPTION
## Describe your changes
Stop doubling errors for disallowed fileTypes (bmp would trigger both files allowed and file spoofing error
Make zip files only show no zips allowed error
Add more tests around validation and fix zip validation
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1014
https://pins-ds.atlassian.net/browse/CROWN-1089