### PR TITLE
fix(portal): prevent read more link from always being presented

### DIFF
--- a/apps/portal/src/app/views/applications/view/view-model.js
+++ b/apps/portal/src/app/views/applications/view/view-model.js
@@ -11,7 +11,11 @@ import {
 } from '@pins/crowndev-database/src/seed/data-static.js';
 import { addressToViewModel } from '@planning-inspectorate/dynamic-forms/src/lib/address-utils.js';
 import { nameToViewModel } from '@pins/crowndev-lib/util/name.js';
-import { truncateComment, truncatedReadMoreCommentLink } from '@pins/crowndev-lib/util/questions.js';
+import {
+	shouldTruncateComment,
+	truncateComment,
+	truncatedReadMoreCommentLink
+} from '@pins/crowndev-lib/util/questions.js';
 
 /**
  *
@@ -152,9 +156,10 @@ export function representationToViewModel(representation, truncateCommentForView
 		hasAttachments:
 			representation.Attachments?.some((doc) => doc.statusId === REPRESENTATION_STATUS_ID.ACCEPTED) &&
 			representation.containsAttachments,
-		...(truncateCommentForView && {
-			truncatedReadMoreLink: truncatedReadMoreCommentLink(`written-representations/${representation.reference}`)
-		})
+		...(truncateCommentForView &&
+			shouldTruncateComment(representationComment) && {
+				truncatedReadMoreLink: truncatedReadMoreCommentLink(`written-representations/${representation.reference}`)
+			})
 	};
 }
 

--- a/packages/lib/util/questions.js
+++ b/packages/lib/util/questions.js
@@ -1,5 +1,7 @@
 import { REPRESENTATION_SUBMITTED_FOR_ID } from '@pins/crowndev-database/src/seed/data-static.js';
 
+const MAX_LENGTH = 500;
+
 /**
  * @param {{displayName?: string, id: string}[]} reference
  * @param {boolean} [addNullOption]
@@ -32,9 +34,12 @@ export function getSubmittedForId(answers) {
 		: REPRESENTATION_SUBMITTED_FOR_ID.ON_BEHALF_OF;
 }
 
+export function shouldTruncateComment(comment) {
+	return comment?.length > MAX_LENGTH;
+}
+
 export function truncateComment(comment) {
-	const MAX_LENGTH = 500;
-	if (comment.length > MAX_LENGTH) {
+	if (shouldTruncateComment(comment)) {
 		const truncated = comment.substring(0, MAX_LENGTH);
 		return `${truncated}... `;
 	}

--- a/packages/lib/util/questions.test.js
+++ b/packages/lib/util/questions.test.js
@@ -1,9 +1,31 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { getSubmittedForId, truncateComment, truncatedReadMoreCommentLink } from './questions.js';
+import {
+	getSubmittedForId,
+	shouldTruncateComment,
+	truncateComment,
+	truncatedReadMoreCommentLink
+} from './questions.js';
 import { REPRESENTATION_SUBMITTED_FOR_ID } from '@pins/crowndev-database/src/seed/data-static.js';
 
 describe('questions', () => {
+	describe('shouldTruncateComment', () => {
+		it('should return true if comment is greater 500 chars', () => {
+			const comment =
+				'It began with an ordinary morning. The air smelled faintly of dew, the street empty but for leaves drifting lazily. Johnathan Le-Smithard adjusted his collar, noting his watch was three minutes late—a stubborn old thing, loyal only to its own time. Across the street, a bakery opened, the scent of bread spilling into the cool air. A woman in a green scarf carried loaves in quiet balance. The square stirred slowly; Johnathan Le-Smithard wrote in his notebook, letting the day delay his errands, wholly unhurried and serene.';
+
+			assert.deepEqual(shouldTruncateComment(comment), true);
+		});
+		it('should return false if comment does not exceed 500 characters', () => {
+			assert.deepEqual(shouldTruncateComment('a short comment'), false);
+		});
+		it('should return false if comment passed is null', () => {
+			assert.deepEqual(shouldTruncateComment(null), false);
+		});
+		it('should return false if comment passed is undefined', () => {
+			assert.deepEqual(shouldTruncateComment(undefined), false);
+		});
+	});
 	describe('truncateComment', () => {
 		it('should truncate comment if it exceeds 500 characters', () => {
 			const comment =


### PR DESCRIPTION
## Describe your changes
[PORTAL] Prevent read more link from being presented when comment is not longer than 500 chars

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-239

<img width="1363" height="791" alt="Screenshot 2025-08-14 at 11 04 56" src="https://github.com/user-attachments/assets/0c175604-adf2-4703-b020-3fa316d04df4" />
