### PR TITLE
fix(package): fix multiple queries not supported by search

### DIFF
--- a/apps/manage/src/app/views/cases/list/controller.test.js
+++ b/apps/manage/src/app/views/cases/list/controller.test.js
@@ -140,7 +140,7 @@ describe('case list', () => {
 			await assert.doesNotReject(() => listCases(mockReq, mockRes));
 			assert.strictEqual(mockDb.crownDevelopment.findMany.mock.callCount(), 1);
 			assert.deepStrictEqual(mockDb.crownDevelopment.findMany.mock.calls[0].arguments[0].where, {
-				reference: { contains: 'case/ref' }
+				AND: [{ OR: [{ reference: { contains: 'case/ref' } }] }]
 			});
 		});
 	});


### PR DESCRIPTION
## Describe your changes
Fixed the way the whereClause builder creates queries when there are multiple queries. The original way doesn't work with MSSQL
