### PR TITLE
feat(manage): removes data assigned to procedure when user changes procedure type

### DIFF
--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -171,6 +171,7 @@ export function getQuestions(groupMembers = { caseOfficers: [], inspectors: [] }
 			type: COMPONENT_TYPES.RADIO,
 			title: 'Procedure',
 			question: 'What is the application procedure?',
+			hint: "If you change the procedure after it's been set, any details you've added will be lost.",
 			fieldName: 'procedureId',
 			url: 'procedure',
 			validators: [new RequiredValidator()],

--- a/apps/manage/src/app/views/cases/view/view-model.js
+++ b/apps/manage/src/app/views/cases/view/view-model.js
@@ -59,6 +59,20 @@ const UNMAPPED_VIEW_MODEL_FIELDS = Object.freeze([
 	'applicantContactId',
 	'agentContactId',
 	'eventId',
+	'procedureId',
+	'eventDate',
+	'venue',
+	'startTime',
+	'endTime',
+	'notificationDate',
+	'statementsDate',
+	'caseManagementConferenceDate',
+	'prepDuration',
+	'sittingDuration',
+	'reportingDuration',
+	'issuesReportPublishedDate',
+	'proofsOfEvidenceDate',
+	'procedureNotificationDate',
 	'lpaQuestionnaireReceivedEmailSent',
 	'hasApplicationFee',
 	'applicationFee',
@@ -112,6 +126,36 @@ export function crownDevelopmentToViewModel(crownDevelopment) {
 	addLpaDetailsToViewModel(viewModel, crownDevelopment.Lpa);
 	addContactToViewModel(viewModel, crownDevelopment.ApplicantContact, 'applicant');
 	addContactToViewModel(viewModel, crownDevelopment.AgentContact, 'agent');
+	const procedureId = crownDevelopment.procedureId;
+	if (procedureId !== 'writtenReps') {
+		viewModel.writtenRepsProcedureNotificationDate = null;
+	}
+	if (procedureId !== 'hearing') {
+		viewModel.hearingProcedureNotificationDate = null;
+		viewModel.hearingDate = null;
+		viewModel.hearingDuration = null;
+		viewModel.hearingVenue = null;
+		viewModel.hearingNotificationDate = null;
+		viewModel.hearingIssuesReportPublishedDate = null;
+		viewModel.hearingStatementsDate = null;
+		viewModel.hearingCaseManagementConferenceDate = null;
+		viewModel.hearingDurationPrep = null;
+		viewModel.hearingDurationSitting = null;
+		viewModel.hearingDurationReporting = null;
+	}
+	if (procedureId !== 'inquiry') {
+		viewModel.inquiryProcedureNotificationDate = null;
+		viewModel.inquiryStatementsDate = null;
+		viewModel.inquiryDate = null;
+		viewModel.inquiryDuration = null;
+		viewModel.inquiryVenue = null;
+		viewModel.inquiryNotificationDate = null;
+		viewModel.inquiryCaseManagementConferenceDate = null;
+		viewModel.inquiryProofsOfEvidenceDate = null;
+		viewModel.inquiryDurationPrep = null;
+		viewModel.inquiryDurationSitting = null;
+		viewModel.inquiryDurationReporting = null;
+	}
 
 	if (hasProcedure(crownDevelopment.procedureId)) {
 		const event = crownDevelopment.Event || {};
@@ -161,6 +205,16 @@ export function editsToDatabaseUpdates(edits, viewModel) {
 		crownDevelopmentUpdateInput.Category = {
 			connect: { id: edits.subCategoryId }
 		};
+	}
+
+	if (edits.procedureId) {
+		crownDevelopmentUpdateInput.Procedure = {
+			connect: { id: edits.procedureId }
+		};
+		delete crownDevelopmentUpdateInput.procedureId;
+	}
+	if ('eventTypeId' in edits) {
+		crownDevelopmentUpdateInput.eventTypeId = edits.eventTypeId;
 	}
 
 	if ('siteAddress' in edits) {
@@ -367,7 +421,7 @@ function isHearing(procedureId) {
  * @param {string|null} procedureId
  * @returns {string}
  */
-function eventPrefix(procedureId) {
+export function eventPrefix(procedureId) {
 	switch (procedureId) {
 		case APPLICATION_PROCEDURE_ID.INQUIRY:
 			return 'inquiry';

--- a/apps/manage/src/app/views/cases/view/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/view-model.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { crownDevelopmentToViewModel, editsToDatabaseUpdates, eventPrefix } from './view-model.js';
+import { crownDevelopmentToViewModel, editsToDatabaseUpdates } from './view-model.js';
 import { APPLICATION_PROCEDURE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
 
 /**
@@ -626,7 +626,7 @@ describe('view-model', () => {
 			assert.strictEqual(upsert.create?.venue, 'some place');
 			assert.strictEqual(upsert.update?.prepDuration, 'prep: 1.5 days');
 		});
-		it('should update procedure relation and event type correctly', () => {
+		it('should update procedure and event type correctly', () => {
 			/** @type {CrownDevelopmentViewModel} */
 			const toSave = {
 				procedureId: 'proc-1',
@@ -638,35 +638,17 @@ describe('view-model', () => {
 			assert.strictEqual(updates.procedureId, undefined);
 			assert.strictEqual(updates.eventTypeId, 'event-type-1');
 		});
-		it('should map procedureId to Procedure.connect and remove procedureId', () => {
+		it('should map eventTypeId when procedureId is undefined', () => {
 			/** @type {import('./types.js').CrownDevelopmentViewModel} */
 			const edits = {
-				procedureId: 'proc-2',
+				procedureId: undefined,
 				eventTypeId: 'event-type-2'
 			};
 			const updates = editsToDatabaseUpdates(edits, {});
-			assert.deepStrictEqual(updates.Procedure, { connect: { id: 'proc-2' } });
+			assert.strictEqual(updates.Procedure, undefined);
 			assert.strictEqual(updates.procedureId, undefined);
 			assert.strictEqual(updates.eventTypeId, 'event-type-2');
 		});
-		it('should throw error for invalid procedureId', () => {
-			const invalidId = 'WRONG_ID';
-			assert.throws(
-				() => eventPrefix(invalidId),
-				(err) => {
-					assert.strictEqual(
-						err.message,
-						`invalid procedureId, expected ${APPLICATION_PROCEDURE_ID.HEARING} or ${APPLICATION_PROCEDURE_ID.INQUIRY}, got ${invalidId}`
-					);
-					return true;
-				}
-			);
-		});
-		it('should return writtenReps prefix for written reps procedureId', () => {
-			const prefix = eventPrefix(APPLICATION_PROCEDURE_ID.WRITTEN_REPS);
-			assert.strictEqual(prefix, 'writtenReps');
-		});
-
 		it('should map writtenReps event fields', () => {
 			const input = {
 				id: 'id-1',


### PR DESCRIPTION
## Describe your changes
When a user has selected either Written Representation, Hearing or Inquiry first and added answers to that part of the form, if they then go to change the procedure type for example from Hearing to Inquiry the data assigned to Hearing will be removed and Inquiry answers will be blank for the user to complete.

Hint also added into procedure to warn user of this.

## Issue ticket number and link
152 https://pins-ds.atlassian.net/browse/CROWN-152


<img width="1113" height="630" alt="image" src="https://github.com/user-attachments/assets/56e838b2-3dfe-4f78-83d1-1028fdf2e3b8" />
<img width="1168" height="616" alt="image" src="https://github.com/user-attachments/assets/745ffa73-5aa5-48d3-8a18-b5e6b0c31f02" />
<img width="1035" height="585" alt="image" src="https://github.com/user-attachments/assets/0ff80b07-3094-4be3-8b05-7ba5659b9d25" />

