### PR TITLE
fix(manage): searches in back office should search both comment and redacted comment

### DIFF
--- a/apps/manage/src/app/views/cases/view/manage-reps/list/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/list/controller.js
@@ -49,7 +49,7 @@ export function buildListReps({ db }) {
 			{ parent: 'SubmittedByContact', fields: ['firstName', 'lastName'] },
 			{ parent: 'RepresentedContact', fields: ['firstName', 'lastName', 'orgName'] },
 			{ fields: ['commentRedacted'] },
-			{ fields: ['comment'], constraints: [{ commentRedacted: { equals: null } }] }
+			{ fields: ['comment'] }
 		]);
 
 		const [filteredRepresentations, totalFilteredRepresentations] = await Promise.all([


### PR DESCRIPTION
## Describe your changes
Severity- High - The search term inside a redacted comment do not appear in the search results (Manage)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1137