### PR TITLE
fix(manage): update dynamic-forms for redaction fixes and normalise new lines

### DIFF
--- a/apps/manage/src/app/views/cases/view/manage-reps/review/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/controller.js
@@ -264,7 +264,8 @@ export function buildReviewControllers(service, journeyId) {
 				select: { comment: true, commentRedacted: true }
 			});
 
-			const comment = representation.comment;
+			// normalise new lines before processing to ensure suggestion offsets align on the front-end
+			const comment = representation.comment?.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
 			const result = await fetchRedactionSuggestions(
 				comment,
@@ -291,7 +292,8 @@ export function buildReviewControllers(service, journeyId) {
 
 			const response = new JourneyResponse(JOURNEY_ID, 'ref-1', {
 				comment: highlightRedactionSuggestions(comment, redactionSuggestions),
-				commentRedacted
+				commentRedacted,
+				commentOriginal: comment
 			});
 
 			const journey = new createRedactJourney(response, req);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@azure/msal-node": "^3.5.3",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@ministryofjustice/frontend": "^5.1.5",
-        "@planning-inspectorate/dynamic-forms": "^1.12.0",
+        "@planning-inspectorate/dynamic-forms": "^1.12.2",
         "@prisma/client": "^6.14.0",
         "accessible-autocomplete": "^3.0.1",
         "body-parser": "^2.2.0",
@@ -1483,9 +1483,9 @@
       "link": true
     },
     "node_modules/@planning-inspectorate/dynamic-forms": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@planning-inspectorate/dynamic-forms/-/dynamic-forms-1.12.0.tgz",
-      "integrity": "sha512-nFUsduDLKlDR1dnnvA9hebfdb4nlRB5vBfGcZ0guPjJmKJ2E6TQbv4htyahQC3nsaraErfIZRt74n2WSD1Efww==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@planning-inspectorate/dynamic-forms/-/dynamic-forms-1.12.2.tgz",
+      "integrity": "sha512-LT8PzLbQKFmb4K+t9jbDLVX24ujb40ZXJZHc4xnjwLP54thuM02ySvdT1ezNSkQW8zmHg8CmVWyM4wsyiw05vg==",
       "dependencies": {
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@azure/msal-node": "^3.5.3",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@ministryofjustice/frontend": "^5.1.5",
-    "@planning-inspectorate/dynamic-forms": "^1.12.0",
+    "@planning-inspectorate/dynamic-forms": "^1.12.2",
     "@prisma/client": "^6.14.0",
     "accessible-autocomplete": "^3.0.1",
     "body-parser": "^2.2.0",


### PR DESCRIPTION
## Describe your changes

this ensures newline handling is consistent across the front and back end, so that string index offsets match between the comment, redacted comment, and redaction suggestions

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/CROWN-1102

may also fix https://pins-ds.atlassian.net/browse/CROWN-1100
