### PR TITLE
feat(manage): add notification doc banner

### DIFF
--- a/apps/manage/src/app/views/cases/view/manage-reps/view/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/controller.test.js
@@ -42,6 +42,73 @@ describe('controller', () => {
 			assert.strictEqual(viewData.requiresReview, true);
 			assert.strictEqual(viewData.representationRef, 'ref-1');
 			assert.strictEqual(viewData.representationUpdated, false);
+			assert.strictEqual(viewData.documentInfoBanner, undefined);
+		});
+		it('should render the representation with no attachments added banner', async () => {
+			const journeyResponse = new JourneyResponse('id-1', 'id-2', {
+				applicationReference: 'app-ref',
+				requiresReview: true,
+				submittedForId: 'myself',
+				myselfContainsAttachments: 'yes',
+				myselfAttachments: []
+			});
+			const questions = getQuestions();
+			const mockReq = {
+				params: { id: 'case-1', representationRef: 'ref-1' },
+				baseUrl: 'case-1/manage-representations'
+			};
+			const mockRes = {
+				render: mock.fn(),
+				locals: {
+					journeyResponse: journeyResponse,
+					journey: createJourney(questions, journeyResponse, mockReq)
+				}
+			};
+			await assert.doesNotReject(() => viewRepresentation(mockReq, mockRes));
+			assert.strictEqual(mockRes.render.mock.callCount(), 1);
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.deepStrictEqual(viewData.documentInfoBanner, {
+				name: 'noAttachmentsAdded',
+				href: 'case-1/manage-representations/edit/myself/select-attachments'
+			});
+		});
+		it('should render the representation with awaiting review document banner', async () => {
+			const journeyResponse = new JourneyResponse('id-1', 'id-2', {
+				applicationReference: 'app-ref',
+				requiresReview: true,
+				statusId: 'accepted',
+				submittedForId: 'myself',
+				myselfContainsAttachments: 'yes',
+				myselfAttachments: [
+					{
+						fileName: 'test-pdf 1.pdf',
+						statusId: 'accepted'
+					},
+					{
+						fileName: 'test-pdf 2.pdf',
+						statusId: 'awaiting-review'
+					}
+				]
+			});
+			const questions = getQuestions();
+			const mockReq = {
+				params: { id: 'case-1', representationRef: 'ref-1' },
+				baseUrl: 'case-1/manage-representations'
+			};
+			const mockRes = {
+				render: mock.fn(),
+				locals: {
+					journeyResponse: journeyResponse,
+					journey: createJourney(questions, journeyResponse, mockReq)
+				}
+			};
+			await assert.doesNotReject(() => viewRepresentation(mockReq, mockRes));
+			assert.strictEqual(mockRes.render.mock.callCount(), 1);
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.deepStrictEqual(viewData.documentInfoBanner, {
+				name: 'awaitingReview',
+				href: 'case-1/manage-representations/manage/task-list'
+			});
 		});
 		it('should read & clear rep updated session data', async () => {
 			const journeyResponse = new JourneyResponse('id-1', 'id-2', {

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/view.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/view.njk
@@ -22,6 +22,27 @@
         }) }}
     {% endif %}
 
+    {% if documentInfoBanner %}
+        {% if documentInfoBanner.name === "awaitingReview" %}
+            {% set html %}
+                <p class="govuk-notification-banner__heading">
+                    There are attachments awaiting review.
+                    <a class="govuk-notification-banner__link" href="{{ documentInfoBanner.href }}">Manage attachments</a>.
+                </p>
+            {% endset %}
+        {% elseif documentInfoBanner.name === "noAttachmentsAdded" %}
+            {% set html %}
+                <p class="govuk-notification-banner__heading">
+                    There are no attachments added.
+                    <a class="govuk-notification-banner__link" href="{{ documentInfoBanner.href }}">Add attachments</a>.
+                </p>
+            {% endset %}
+        {% endif %}
+        {{ govukNotificationBanner({
+            html: html
+        }) }}
+    {% endif %}
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-l">


### PR DESCRIPTION
## Describe your changes
- Add notification banner to view representation page when there are unreviewed documents
-  Add notification banner to view doc page when there are no documents added but 'Attachments uploaded?' set to yes

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1034
https://pins-ds.atlassian.net/browse/CROWN-1035

<img width="1113" height="943" alt="Screenshot 2025-09-11 at 15 42 33" src="https://github.com/user-attachments/assets/ffe7e3c1-fa57-4371-8970-3e08436e16d2" />

<img width="1089" height="955" alt="Screenshot 2025-09-11 at 15 42 56" src="https://github.com/user-attachments/assets/59f8069c-6e6a-4531-aa9d-3a720d9fc3ac" />