### PR TITLE
fix(app): add line breaks to representations for improved readability

### DIFF
--- a/apps/manage/src/app/sass/style.scss
+++ b/apps/manage/src/app/sass/style.scss
@@ -22,6 +22,9 @@ $font-family: arial, helvetica, sans-serif;
 .pins-white-space-pre-wrap {
 	white-space: pre-wrap;
 }
+.pins-white-space-pre-line {
+	white-space: pre-line;
+}
 
 .status-tag-width {
 	max-width: 250px !important;

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/redact-confirmation.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/redact-confirmation.njk
@@ -21,16 +21,17 @@
     </div>
 
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full pins-pre-wrap">
+        <div class="govuk-grid-column-full">
             {{ govukSummaryList({
                 rows: [
                     {
                         key: {text: 'Original representation'},
-                        value: {text: originalComment}
+                        value: {html:"<span class='pins-white-space-pre-line'>" + originalComment + "</span>"}
+
                     },
                     {
                         key: {text: 'Redacted representation'},
-                        value: {text: commentRedacted},
+                        value: {html:"<span class='pins-white-space-pre-line'>" + commentRedacted + "</span>"},
                         actions: {
                         items: [
                             {

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/redact-confirmation.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/redact-confirmation.njk
@@ -21,7 +21,7 @@
     </div>
 
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-full pins-pre-wrap">
             {{ govukSummaryList({
                 rows: [
                     {

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/review-comment.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/review-comment.njk
@@ -38,8 +38,8 @@
                             text: "Tell us about application"
                         },
                             value: {
-                            text: comment,
-                            classes: "pins-pre-wrap"
+                            html: "<span class='pins-white-space-pre-line'>" + comment + "</span>"
+
                         }
                         }
                     ]

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/review-comment.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/review-comment.njk
@@ -38,7 +38,8 @@
                             text: "Tell us about application"
                         },
                             value: {
-                            text: comment
+                            text: comment,
+                            classes: "pins-pre-wrap"
                         }
                         }
                     ]

--- a/apps/portal/src/app/sass/style.scss
+++ b/apps/portal/src/app/sass/style.scss
@@ -22,3 +22,9 @@
 .pins-pre-wrap {
 	white-space: pre-wrap;
 }
+.pins-pre-line {
+	white-space: pre-line;
+}
+.pins-overflow-break-word {
+	overflow-wrap: break-word;
+}

--- a/apps/portal/src/app/views/applications/view/application-info/view.njk
+++ b/apps/portal/src/app/views/applications/view/application-info/view.njk
@@ -20,7 +20,7 @@
                 <div class="govuk-grid-row">
                     {% set html %}
                         <h3 class="govuk-notification-banner__heading">Latest update - {{ latestApplicationUpdate.firstPublished }}</h3>
-                        <p class="govuk-body pins-pre-wrap">{{ latestApplicationUpdate.details }}</p>
+                        <p class="govuk-body pins-pre-line">{{ latestApplicationUpdate.details }}</p>
                         <p><a class="govuk-notification-banner__link" href="{{ baseUrl }}/application-updates">View all updates</a></p>
                     {% endset %}
                     {{ govukNotificationBanner({

--- a/apps/portal/src/app/views/applications/view/written-representations/read-more/view.njk
+++ b/apps/portal/src/app/views/applications/view/written-representations/read-more/view.njk
@@ -48,7 +48,7 @@
                 }
             ]
         }) }}
-        <p class="govuk-body">{{ representationViewModel.representationComment }}</p>
+        <p class="govuk-body pins-pre-line pins-overflow-break-word">{{ representationViewModel.representationComment }}</p>
 
         {% if representationViewModel.hasAttachments %}
             <h2 class="govuk-heading-m">Attachment(s)</h2>

--- a/apps/portal/src/app/views/applications/view/written-representations/representation.njk
+++ b/apps/portal/src/app/views/applications/view/written-representations/representation.njk
@@ -6,7 +6,7 @@
     </p>
     <p class="govuk-body">
         {% if representation.representationCommentIsRedacted %}
-            <span class="redacted" aria-hidden="true">{{ representation.representationComment }}{{ representation.truncatedReadMoreLink | safe }}</span>
+            <span class="redacted pins-pre-line pins-overflow-break-word" aria-hidden="true">{{ representation.representationComment }}{{ representation.truncatedReadMoreLink | safe }}</span>
             <span class="govuk-visually-hidden">Redacted representation comment</span>
         {% else %}
             {{ representation.representationComment }}{{ representation.truncatedReadMoreLink | safe }}


### PR DESCRIPTION
## Describe your changes
Added the pins-pre-wrap class to redact-confirmation and review-comment.njk to add line breaks when present in the comment for readability on both Portal and Manage app.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1097

<img width="1445" height="739" alt="Screenshot 2025-09-25 091525" src="https://github.com/user-attachments/assets/7e262820-4b02-4da9-8316-bb4b24d38cdc" />
<img width="1272" height="820" alt="Screenshot 2025-09-25 091542" src="https://github.com/user-attachments/assets/2e9de5af-ebf5-40a8-a1c4-e00bd2749de3" />
<img width="1243" height="813" alt="Screenshot 2025-09-25 091558" src="https://github.com/user-attachments/assets/1d90676a-bdf5-4019-a544-4229c677a45b" />
<img width="747" height="681" alt="Screenshot 2025-09-25 092832" src="https://github.com/user-attachments/assets/cf86b383-7b9f-4399-8cb5-16a5746124da" />
<img width="1250" height="856" alt="Screenshot 2025-09-25 092623" src="https://github.com/user-attachments/assets/6be9959a-b140-4a70-afac-ecc62e96d4ac" />
<img width="1496" height="933" alt="Screenshot 2025-09-25 092644" src="https://github.com/user-attachments/assets/e56104dd-76e6-424c-9e83-8454b83e7861" />
<img width="1312" height="1259" alt="Screenshot 2025-09-25 092704" src="https://github.com/user-attachments/assets/53b9bfa9-a889-4d19-96df-de444ec884c9" />

