### PR TITLE
fix(manage): fix update-case to use originalAnswers for editsToDatabase

### DIFF
--- a/apps/manage/src/app/views/cases/view/controller.js
+++ b/apps/manage/src/app/views/cases/view/controller.js
@@ -169,6 +169,7 @@ export function buildGetJourneyMiddleware(service) {
 		});
 		const questions = getQuestions(groupMembers);
 		// put these on locals for the list controller
+		res.locals.originalAnswers = { ...answers };
 		res.locals.journeyResponse = new JourneyResponse(JOURNEY_ID, 'ref', answers);
 		res.locals.journey = createJourney(questions, res.locals.journeyResponse, req);
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
@@ -34,7 +34,7 @@ export function buildUpdateRepresentation(
 			return;
 		}
 		/** @type {import('@pins/crowndev-lib/forms/representations/types.js').HaveYourSayManageModel} */
-		const fullViewModel = res.locals?.journeyResponse?.answers || {};
+		const fullViewModel = res.locals?.originalAnswers || {};
 
 		if (toSave.containsAttachments && fullViewModel.sharePointFolderCreated !== BOOLEAN_OPTIONS.YES) {
 			await addRepresentationFolderToSharepoint(

--- a/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.test.js
@@ -96,11 +96,9 @@ describe('controller', () => {
 			};
 			const mockRes = {
 				locals: {
-					journeyResponse: {
-						answers: {
-							applicationReference: 'CROWN-2025-0000001',
-							sharePointFolderCreated: 'no'
-						}
+					originalAnswers: {
+						applicationReference: 'CROWN-2025-0000001',
+						sharePointFolderCreated: 'no'
 					}
 				}
 			};
@@ -143,10 +141,8 @@ describe('controller', () => {
 			};
 			const mockRes = {
 				locals: {
-					journeyResponse: {
-						answers: {
-							applicationReference: 'CROWN-2025-0000001'
-						}
+					originalAnswers: {
+						applicationReference: 'CROWN-2025-0000001'
 					}
 				}
 			};
@@ -230,11 +226,9 @@ describe('controller', () => {
 			};
 			const mockRes = {
 				locals: {
-					journeyResponse: {
-						answers: {
-							applicationReference: 'CROWN-2025-0000001',
-							sharePointFolderCreated: 'yes'
-						}
+					originalAnswers: {
+						applicationReference: 'CROWN-2025-0000001',
+						sharePointFolderCreated: 'yes'
 					}
 				}
 			};
@@ -331,11 +325,9 @@ describe('controller', () => {
 			};
 			const mockRes = {
 				locals: {
-					journeyResponse: {
-						answers: {
-							applicationReference: 'CROWN-2025-0000001',
-							sharePointFolderCreated: 'no'
-						}
+					originalAnswers: {
+						applicationReference: 'CROWN-2025-0000001',
+						sharePointFolderCreated: 'no'
 					}
 				}
 			};
@@ -397,11 +389,9 @@ describe('controller', () => {
 			};
 			const mockRes = {
 				locals: {
-					journeyResponse: {
-						answers: {
-							applicationReference: 'CROWN-2025-0000001',
-							sharePointFolderCreated: 'no'
-						}
+					originalAnswers: {
+						applicationReference: 'CROWN-2025-0000001',
+						sharePointFolderCreated: 'no'
 					}
 				}
 			};
@@ -463,11 +453,9 @@ describe('controller', () => {
 			};
 			const mockRes = {
 				locals: {
-					journeyResponse: {
-						answers: {
-							applicationReference: 'CROWN-2025-0000001',
-							sharePointFolderCreated: 'no'
-						}
+					originalAnswers: {
+						applicationReference: 'CROWN-2025-0000001',
+						sharePointFolderCreated: 'no'
 					}
 				}
 			};
@@ -522,11 +510,9 @@ describe('controller', () => {
 			};
 			const mockRes = {
 				locals: {
-					journeyResponse: {
-						answers: {
-							applicationReference: 'CROWN-2025-0000001',
-							sharePointFolderCreated: 'no'
-						}
+					originalAnswers: {
+						applicationReference: 'CROWN-2025-0000001',
+						sharePointFolderCreated: 'no'
 					}
 				}
 			};

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/controller.js
@@ -126,6 +126,7 @@ export function buildGetJourneyMiddleware({ db, logger, isRepsUploadDocsLive }) 
 			}
 		});
 		// put these on locals for the list controller
+		res.locals.originalAnswers = { ...answers };
 		res.locals.journeyResponse = new JourneyResponse(JOURNEY_ID, 'ref', answers);
 		res.locals.journey = createJourney(questions, res.locals.journeyResponse, req, isRepsUploadDocsLive);
 

--- a/apps/manage/src/app/views/cases/view/update-case.js
+++ b/apps/manage/src/app/views/cases/view/update-case.js
@@ -35,10 +35,11 @@ export function buildUpdateCase(service, clearAnswer = false) {
 		}
 		/** @type {import('./types.js').CrownDevelopmentViewModel} */
 		const fullViewModel = res.locals?.journeyResponse?.answers || {};
+		const originalAnswers = res.locals?.originalAnswers || {};
 
 		await customUpdateCaseActions(service, id, toSave, fullViewModel);
 
-		const updateInput = editsToDatabaseUpdates(toSave, fullViewModel);
+		const updateInput = editsToDatabaseUpdates(toSave, originalAnswers);
 		updateInput.updatedDate = new Date();
 
 		logger.info({ fields: Object.keys(toSave) }, 'update case input');

--- a/apps/manage/src/app/views/cases/view/update-case.test.js
+++ b/apps/manage/src/app/views/cases/view/update-case.test.js
@@ -178,11 +178,9 @@ describe('case details', () => {
 			};
 			const mockRes = {
 				locals: {
-					journeyResponse: {
-						answers: {
-							eventId: 'event-1',
-							procedureId: APPLICATION_PROCEDURE_ID.INQUIRY
-						}
+					originalAnswers: {
+						eventId: 'event-1',
+						procedureId: APPLICATION_PROCEDURE_ID.INQUIRY
 					}
 				}
 			};

--- a/apps/manage/src/app/views/cases/view/view-model.js
+++ b/apps/manage/src/app/views/cases/view/view-model.js
@@ -186,7 +186,17 @@ export function editsToDatabaseUpdates(edits, viewModel) {
 	if (agentContactUpdates) {
 		crownDevelopmentUpdateInput.AgentContact = agentContactUpdates;
 	}
-
+	// When the procedure changes the event needs to be deleted
+	if ('procedureId' in edits && edits.procedureId !== viewModel.procedureId) {
+		delete crownDevelopmentUpdateInput.procedureId;
+		crownDevelopmentUpdateInput.procedureNotificationDate = null;
+		crownDevelopmentUpdateInput.Event = {
+			delete: true
+		};
+		crownDevelopmentUpdateInput.Procedure = {
+			connect: { id: edits.procedureId }
+		};
+	}
 	if (hasProcedure(viewModel.procedureId)) {
 		const eventUpdates = viewModelToEventUpdateInput(edits, viewModel.procedureId);
 

--- a/apps/manage/src/app/views/cases/view/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/view-model.test.js
@@ -626,5 +626,125 @@ describe('view-model', () => {
 			assert.strictEqual(upsert.create?.venue, 'some place');
 			assert.strictEqual(upsert.update?.prepDuration, 'prep: 1.5 days');
 		});
+		describe('procedure-change', () => {
+			it('should delete event and nullify procedureNotificationDate if procedure changed from written reps to inquiry', () => {
+				const toSave = {
+					procedureId: APPLICATION_PROCEDURE_ID.INQUIRY
+				};
+				const viewModel = {
+					procedureId: APPLICATION_PROCEDURE_ID.WRITTEN_REPS,
+					eventId: 'event-id'
+				};
+				const updates = editsToDatabaseUpdates(toSave, viewModel);
+				assert.ok(updates);
+				assert.deepStrictEqual(updates.Procedure, {
+					connect: { id: APPLICATION_PROCEDURE_ID.INQUIRY }
+				});
+				assert.ok(updates.Event?.delete);
+				assert.strictEqual(updates.procedureNotificationDate, null);
+			});
+			it('should delete event and nullify procedureNotificationDate if procedure changed from written reps to hearing', () => {
+				const toSave = {
+					procedureId: APPLICATION_PROCEDURE_ID.HEARING
+				};
+				const viewModel = {
+					procedureId: APPLICATION_PROCEDURE_ID.WRITTEN_REPS,
+					eventId: 'event-id'
+				};
+				const updates = editsToDatabaseUpdates(toSave, viewModel);
+				assert.ok(updates);
+				assert.deepStrictEqual(updates.Procedure, {
+					connect: { id: APPLICATION_PROCEDURE_ID.HEARING }
+				});
+				assert.ok(updates.Event?.delete);
+				assert.strictEqual(updates.procedureNotificationDate, null);
+			});
+			it('should delete event and nullify procedureNotificationDate if procedure changed from inquiry to written representations', () => {
+				const toSave = {
+					procedureId: APPLICATION_PROCEDURE_ID.WRITTEN_REPS
+				};
+				const viewModel = {
+					procedureId: APPLICATION_PROCEDURE_ID.INQUIRY,
+					eventId: 'event-id'
+				};
+				const updates = editsToDatabaseUpdates(toSave, viewModel);
+				assert.ok(updates);
+				assert.deepStrictEqual(updates.Procedure, {
+					connect: { id: APPLICATION_PROCEDURE_ID.WRITTEN_REPS }
+				});
+				assert.ok(updates.Event?.delete);
+				assert.strictEqual(updates.procedureNotificationDate, null);
+			});
+			it('should delete event and nullify procedureNotificationDate if procedure changed from inquiry to hearing', () => {
+				const toSave = {
+					procedureId: APPLICATION_PROCEDURE_ID.HEARING
+				};
+				const viewModel = {
+					procedureId: APPLICATION_PROCEDURE_ID.INQUIRY,
+					eventId: 'event-id'
+				};
+				const updates = editsToDatabaseUpdates(toSave, viewModel);
+				assert.ok(updates);
+				assert.deepStrictEqual(updates.Procedure, {
+					connect: { id: APPLICATION_PROCEDURE_ID.HEARING }
+				});
+				assert.ok(updates.Event?.delete);
+				assert.strictEqual(updates.procedureNotificationDate, null);
+			});
+			it('should delete event and nullify procedureNotificationDate if procedure changed from hearing to written representations', () => {
+				const toSave = {
+					procedureId: APPLICATION_PROCEDURE_ID.WRITTEN_REPS
+				};
+				const viewModel = {
+					procedureId: APPLICATION_PROCEDURE_ID.HEARING,
+					eventId: 'event-id'
+				};
+				const updates = editsToDatabaseUpdates(toSave, viewModel);
+				assert.ok(updates);
+				assert.deepStrictEqual(updates.Procedure, {
+					connect: { id: APPLICATION_PROCEDURE_ID.WRITTEN_REPS }
+				});
+				assert.ok(updates.Event?.delete);
+				assert.strictEqual(updates.procedureNotificationDate, null);
+			});
+			it('should delete event and nullify procedureNotificationDate if procedure changed from hearing to inquiry', () => {
+				const toSave = {
+					procedureId: APPLICATION_PROCEDURE_ID.INQUIRY
+				};
+				const viewModel = {
+					procedureId: APPLICATION_PROCEDURE_ID.HEARING,
+					eventId: 'event-id'
+				};
+				const updates = editsToDatabaseUpdates(toSave, viewModel);
+				assert.ok(updates);
+				assert.deepStrictEqual(updates.Procedure, {
+					connect: { id: APPLICATION_PROCEDURE_ID.INQUIRY }
+				});
+				assert.ok(updates.Event?.delete);
+				assert.strictEqual(updates.procedureNotificationDate, null);
+			});
+			it('should not delete event or nullify procedureNotificationDate if procedure not changed', () => {
+				const toSave = {
+					procedureId: APPLICATION_PROCEDURE_ID.WRITTEN_REPS
+				};
+				const viewModel = {
+					procedureId: APPLICATION_PROCEDURE_ID.WRITTEN_REPS,
+					eventId: 'event-id'
+				};
+				const updates = editsToDatabaseUpdates(toSave, viewModel);
+				assert.deepStrictEqual(
+					{
+						Procedure: updates.Procedure,
+						EventDelete: updates.Event?.delete,
+						ProcedureNotificationDate: updates.procedureNotificationDate
+					},
+					{
+						Procedure: undefined,
+						EventDelete: undefined,
+						ProcedureNotificationDate: undefined
+					}
+				);
+			});
+		});
 	});
 });

--- a/apps/portal/src/app/views/applications/view/application-updates/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/application-updates/controller.test.js
@@ -4,7 +4,8 @@ import { buildApplicationUpdatesPage } from './controller.js';
 
 describe('application-updates controller', () => {
 	describe('buildApplicationUpdatesPage', () => {
-		it('should render application updates page with updates', async () => {
+		it('should render application updates page with updates', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-02T03:24:00.000Z') });
 			const mockReq = {
 				params: {
 					applicationId: '9c8846dc-1949-47c4-804c-9f3865cff25e'
@@ -18,9 +19,9 @@ describe('application-updates controller', () => {
 				crownDevelopment: {
 					findUnique: mock.fn(() => ({
 						reference: 'CROWN/2025/0000002/',
-						representationsPublishDate: new Date('2025-10-17T03:24:00.000Z'),
-						representationsPeriodStartDate: new Date('2025-08-17T03:24:00.000Z'),
-						representationsPeriodEndDate: new Date('2025-09-30T03:24:00.000Z')
+						representationsPublishDate: new Date('2025-01-17T03:24:00.000Z'),
+						representationsPeriodStartDate: new Date('2025-01-01T03:24:00.000Z'),
+						representationsPeriodEndDate: new Date('2025-01-30T03:24:00.000Z')
 					}))
 				},
 				applicationUpdate: {


### PR DESCRIPTION
## Describe your changes
EditsToDatabase was using mutated answers due to bug in dynamic forms. This fixes the issue by passing the original values to originalAnswers to locals.
## Issue ticket number and link
