### PR TITLE
fix(portal): content change on success message have your say journey

### DIFF
--- a/apps/portal/src/app/views/applications/view/have-your-say/save.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/save.js
@@ -166,7 +166,7 @@ export async function viewHaveYourSaySuccessPage(req, res) {
 	clearSessionData(req, id, ['representationReference', 'representationSubmitted'], 'representations');
 
 	res.render('views/applications/view/have-your-say/success.njk', {
-		title: 'Representation Submitted',
+		title: 'Written representation submitted',
 		bodyText: `Your reference number <br><strong>${representationReference}</strong>`,
 		successBackLinkUrl: `/applications/${id}/application-information`,
 		successBackLinkText: 'Back to the application information page'

--- a/apps/portal/src/app/views/applications/view/have-your-say/save.test.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/save.test.js
@@ -578,7 +578,7 @@ describe('have your say', () => {
 				'views/applications/view/have-your-say/success.njk'
 			);
 			assert.deepStrictEqual(mockRes.render.mock.calls[0].arguments[1], {
-				title: 'Representation Submitted',
+				title: 'Written representation submitted',
 				bodyText: 'Your reference number <br><strong>AAAAA-BBBBB</strong>',
 				successBackLinkUrl: `/applications/${mockReq.params.applicationId}/application-information`,
 				successBackLinkText: 'Back to the application information page'

--- a/apps/portal/src/app/views/applications/view/have-your-say/success.njk
+++ b/apps/portal/src/app/views/applications/view/have-your-say/success.njk
@@ -13,11 +13,21 @@
                 html: bodyText
             }) }}
 
-            <p class="govuk-body">We have received your comments. Make a note of your representation reference number.</p>
-            <p class="govuk-body">We will contact you if we need more information about the comments you have provided.</p>
+            <p class="govuk-body">We’ve received your written representation.</p>
+            <p class="govuk-body">We’ve sent your reference number by email and will contact you if we need more information about your comment or supporting documents.</p>
 
             <h2 class="govuk-heading-m">What happens next</h2>
-            <p class="govuk-body">Following the end of the representation period we will notify you of the procedure that the application will follow. Where a hearing of local inquiry is to be held, you will be able to request in writing to participate in the hearing or inquiry.</p>
+            <p class="govuk-body">At the end of this representations period, we’ll update the website with the procedure that the application will follow.</p>
+            <p class="govuk-body">The Planning Inspectors will decide on one of the following procedures:</p>
+
+            <h3 class="govuk-heading-s">Written representations</h3>
+            <p class="govuk-body">If this procedure is chosen, Planning Inspectors will make their decision based on written submissions only.</p>
+
+            <h3 class="govuk-heading-s">Hearing</h3>
+            <p class="govuk-body">If you’ve requested in your comment to attend the hearing, we’ll contact you with details of the hearing date and location.</p>
+
+            <h3 class="govuk-heading-s">Inquiry</h3>
+            <p class="govuk-body">If this procedure is chosen, we’ll contact you with details of the inquiry date and location.</p>
             {% if not config.isRepsUploadDocsLive %}
                 <h2 class="govuk-heading-m">Providing more information</h2>
                 <p class="govuk-body">If you wish to include documents or photographs as part of your comments, you must send them to <a href="mailto:{{ config.contactEmail }}" class="govuk-link">{{ config.contactEmail }}</a> and include your name, representation reference number and application reference number in the subject line.</p>


### PR DESCRIPTION
## Describe your changes
Content change on the success message after completing the have my say journey. These changes are for "myself" and "On behalf of another person or an organisation"
## Issue ticket number and link
1018 https://pins-ds.atlassian.net/browse/CROWN-1018

<img width="1107" height="1082" alt="Screenshot 2025-10-01 141701" src="https://github.com/user-attachments/assets/d07c9b23-15b3-42db-9a79-fd8d785fd725" />
