### PR TITLE
fix(manage): fix an issue where you can't update procedure if an event doesn't exist

### DIFF
--- a/apps/manage/src/app/views/cases/view/view-model.js
+++ b/apps/manage/src/app/views/cases/view/view-model.js
@@ -194,9 +194,12 @@ export function editsToDatabaseUpdates(edits, viewModel) {
 			connect: { id: edits.procedureId }
 		};
 		crownDevelopmentUpdateInput.procedureNotificationDate = null;
-		crownDevelopmentUpdateInput.Event = {
-			delete: true
-		};
+		if (viewModel.eventId) {
+			// delete existing event if procedure changed and there is an existing event
+			crownDevelopmentUpdateInput.Event = {
+				delete: true
+			};
+		}
 	}
 	if (hasProcedure(viewModel.procedureId)) {
 		const eventUpdates = viewModelToEventUpdateInput(edits, viewModel.procedureId);

--- a/apps/manage/src/app/views/cases/view/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/view-model.test.js
@@ -624,7 +624,7 @@ describe('view-model', () => {
 			assert.strictEqual(upsert.create?.venue, 'some place');
 			assert.strictEqual(upsert.update?.prepDuration, 'prep: 1.5 days');
 		});
-		describe('should delete event and nullify procedureNotificationDate', () => {
+		describe('should delete the event if it exists and nullify procedureNotificationDate', () => {
 			const testCases = [
 				{ from: APPLICATION_PROCEDURE_ID.WRITTEN_REPS, to: APPLICATION_PROCEDURE_ID.INQUIRY },
 				{ from: APPLICATION_PROCEDURE_ID.WRITTEN_REPS, to: APPLICATION_PROCEDURE_ID.HEARING },
@@ -651,6 +651,28 @@ describe('view-model', () => {
 					assert.strictEqual(updates.procedureNotificationDate, null);
 				});
 			});
+		});
+		it('should not delete the event if no event exists', () => {
+			const toSave = {
+				procedureId: APPLICATION_PROCEDURE_ID.INQUIRY
+			};
+			const viewModel = {
+				procedureId: APPLICATION_PROCEDURE_ID.WRITTEN_REPS,
+				eventId: null
+			};
+			const updates = editsToDatabaseUpdates(toSave, viewModel);
+			assert.deepStrictEqual(
+				{
+					Procedure: updates.Procedure,
+					EventDelete: updates.Event?.delete,
+					ProcedureNotificationDate: updates.procedureNotificationDate
+				},
+				{
+					Procedure: { connect: { id: APPLICATION_PROCEDURE_ID.INQUIRY } },
+					EventDelete: undefined,
+					ProcedureNotificationDate: null
+				}
+			);
 		});
 		it('should not delete event or nullify procedureNotificationDate if procedure not changed', () => {
 			const toSave = {


### PR DESCRIPTION
## Describe your changes
Fixes bug introduced in [this branch](https://github.com/Planning-Inspectorate/crown-developments/commit/9a1485366bdef00a05709324e212c11b71cfd852) where changing the procedure when an event doesn't exist causes a Prisma error
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-152