### PR TITLE
fix(manage): add error message for lpa when answer is the same

### DIFF
--- a/apps/manage/src/app/views/cases/view/view-model.js
+++ b/apps/manage/src/app/views/cases/view/view-model.js
@@ -135,6 +135,11 @@ export function editsToDatabaseUpdates(edits, viewModel) {
 	// map all the regular fields to the update input
 	for (const field of UNMAPPED_VIEW_MODEL_FIELDS) {
 		if (Object.hasOwn(edits, field)) {
+			if (field === 'lpaId' && edits.lpaId === viewModel.lpaId) {
+				const error = new Error('Select a new Local Planning Authority or select ‘Back’ to discard your changes');
+				error.fieldName = 'lpaId';
+				throw error;
+			}
 			crownDevelopmentUpdateInput[field] = edits[field];
 		}
 	}

--- a/apps/manage/src/app/views/cases/view/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/view-model.test.js
@@ -717,5 +717,21 @@ describe('view-model', () => {
 				}
 			);
 		});
+		it('should error if lpa answer is the same as previous', () => {
+			const toSave = {
+				lpaId: 'Another System Test Borough Council'
+			};
+			const viewModel = {
+				lpaId: 'Another System Test Borough Council'
+			};
+			assert.throws(
+				() => editsToDatabaseUpdates(toSave, viewModel),
+				(err) => {
+					assert.strictEqual(err.fieldName, 'lpaId');
+					assert.match(err.message, /Select a new Local Planning Authority or select ‘Back’ to discard your changes/);
+					return true;
+				}
+			);
+		});
 	});
 });


### PR DESCRIPTION
## Describe your changes
Add an error message to the local planning authority edits question when saving the answer which is already saved

## Issue ticket number and link
369 https://pins-ds.atlassian.net/browse/CROWN-369
<img width="802" height="609" alt="Screenshot 2025-10-17 163309" src="https://github.com/user-attachments/assets/38baf445-a291-4823-bd59-265c11e75b81" />
