### PR TITLE
Feat/crown 1430 add distressing content tags

### DIFF
--- a/apps/portal/src/app/views/applications/view/documents/controller.js
+++ b/apps/portal/src/app/views/applications/view/documents/controller.js
@@ -30,7 +30,8 @@ export function buildApplicationDocumentsPage(service) {
 			folderPath,
 			logger,
 			id,
-			sortFn: sortByField('lastModifiedDateTime', true)
+			sortFn: sortByField('lastModifiedDateTime', true),
+			metaDataFields: ['Distressing']
 		});
 
 		const queries = splitStringQueries(req.query?.searchCriteria);

--- a/apps/portal/src/app/views/applications/view/documents/view.njk
+++ b/apps/portal/src/app/views/applications/view/documents/view.njk
@@ -3,6 +3,7 @@
 {% from "views/applications/view/links.njk" import applicationLinks %}
 {% import "pagination/pagination.njk" as pagination %}
 {% import "pagination/pagination-options.njk" as paginationOptions %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "search-bar/search-bar.njk" import searchBar %}
 
 {% block pageHeading %}{% endblock %}
@@ -54,9 +55,17 @@
                             <ul class="govuk-list document-list">
                                 {% for document in documents %}
                                     <li>
-                                        <a class="govuk-link" href="{{ baseUrl }}/{{ document.id }}" target="_blank" rel="noreferrer">
-                                            {{ document.name }}
-                                        </a>
+                                        <div>
+                                                {% if document.distressing %}
+                                                    {{ govukTag({
+                                                        text: "Content warning",
+                                                        classes: "govuk-tag--red"
+                                                    }) }}
+                                                {% endif %}
+                                            <a class="govuk-link" href="{{ baseUrl }}/{{ document.id }}" target="_blank" rel="noreferrer">
+                                                {{ document.name }}
+                                            </a>
+                                        </div>
                                         <div class="document-list__meta-data">
                                             <div>{{ document.lastModified }}</div>
                                             <div>{{ document.type }}</div>

--- a/packages/lib/documents/get.js
+++ b/packages/lib/documents/get.js
@@ -10,14 +10,21 @@ import { FILE_PROPERTIES, mapDriveItemToViewModel } from './view-model.js';
  * @param {import('pino').BaseLogger} opts.logger
  * @param {string} opts.id
  * @param {function(a, b): number} [opts.sortFn]
+ * @param {string[]} [opts.metaDataFields]
  * @returns {Promise<import('./types.js').DocumentViewModel[]>}
  */
-export async function getDocuments({ sharePointDrive, folderPath, logger, id, sortFn }) {
+export async function getDocuments({ sharePointDrive, folderPath, logger, id, sortFn, metaDataFields }) {
 	try {
-		const items = await sharePointDrive.getItemsByPath(folderPath, [
-			['$top', '999'],
-			['$select', FILE_PROPERTIES.join(',')]
-		]);
+		let items;
+		if (metaDataFields && metaDataFields.length > 0) {
+			items = await sharePointDrive.getItemsByPathWithCustomMetadata(
+				folderPath,
+				[['$select', FILE_PROPERTIES.join(',')]],
+				metaDataFields
+			);
+		} else {
+			items = await sharePointDrive.getItemsByPath(folderPath, [['$select', FILE_PROPERTIES.join(',')]]);
+		}
 		if (sortFn) {
 			items.sort(sortFn);
 		}

--- a/packages/lib/documents/get.test.js
+++ b/packages/lib/documents/get.test.js
@@ -23,7 +23,8 @@ describe('get', () => {
 				name: 'File 1',
 				type: 'Image',
 				lastModified: '',
-				size: undefined
+				size: undefined,
+				distressing: false
 			});
 		});
 

--- a/packages/lib/documents/types.d.ts
+++ b/packages/lib/documents/types.d.ts
@@ -4,4 +4,5 @@ export interface DocumentViewModel {
 	size?: string;
 	lastModified?: string;
 	type?: string;
+	distressing?: boolean;
 }


### PR DESCRIPTION
## Describe your changes
This pull request introduces support for fetching and displaying custom metadata fields (specifically a "Distressing" flag) for SharePoint documents in the application documents view. It also adds robust pagination handling for SharePoint API responses and updates the UI to show a content warning tag for distressing documents. Unit tests have been added to ensure correct behavior for metadata fetching and pagination.

**SharePoint API enhancements:**

* Added a new `getItemsByPathWithCustomMetadata` method to the `SharePointDrive` class to fetch items with custom metadata fields, and refactored `getItemsByPath` to use a shared internal pagination helper, `#fetchAllPages`, that follows `@odata.nextLink` for multi-page results. [[1]](diffhunk://#diff-d935823726ae545dbcd8f9b7ea378693180f2cd2515256e54b145162a1080896L110-R133) [[2]](diffhunk://#diff-d935823726ae545dbcd8f9b7ea378693180f2cd2515256e54b145162a1080896R526-R548)
* Updated unit tests in `drives.test.js` to cover pagination for both `getItemsByPath` and `getItemsByPathWithCustomMetadata`.

**Document retrieval and metadata support:**

* Modified the `getDocuments` function to accept a `metaDataFields` parameter and use the new SharePoint API method when custom metadata is requested.
* Updated the application documents controller to request the "Distressing" metadata field when fetching documents.

**User interface improvements:**

* Updated the documents view template to display a red "Content warning" tag for documents marked as distressing, using the GOV.UK tag component. [[1]](diffhunk://#diff-08e83f2f833939ef05d87a0b55c1482d7677f92ff31da20c6adfeccbd7fe93eaR6) [[2]](diffhunk://#diff-08e83f2f833939ef05d87a0b55c1482d7677f92ff31da20c6adfeccbd7fe93eaR58-R68)

**Testing and type updates:**

* Adjusted document test data to include the `distressing` property for consistency with new metadata.

<img width="679" height="236" alt="image" src="https://github.com/user-attachments/assets/3637e0d7-95ae-4e29-9131-b6d61170eadc" />


## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1430