### PR TITLE
Feat/crown 1374 handle orphaned applicant contacts

### DIFF
--- a/apps/manage/src/app/views/cases/create-a-case/index.js
+++ b/apps/manage/src/app/views/cases/create-a-case/index.js
@@ -13,6 +13,7 @@ import { JOURNEY_ID, createJourney, createJourneyV2 } from './journey.js';
 import { getQuestions } from './questions.js';
 import { buildSaveController, buildSuccessController } from './save.js';
 import { getSummaryWarningMessage } from '@pins/crowndev-lib/util/linked-case.js';
+import { removeApplicantContactsWhenOrganisationRemoved } from './session.js';
 
 /**
  * @param {import('#service').ManageService} service
@@ -21,8 +22,14 @@ import { getSummaryWarningMessage } from '@pins/crowndev-lib/util/linked-case.js
 export function createRoutes(service) {
 	const router = createRouter({ mergeParams: true });
 
+	/**
+	 * @param {boolean} isQuestionView
+	 */
 	function makeGetJourneyCallback(isQuestionView) {
-		return (req, journeyResponse) => {
+		return (
+			/** @type {import('express').Request} */ req,
+			/** @type {import('@planning-inspectorate/dynamic-forms/src/journey/journey.js').JourneyResponse} */ journeyResponse
+		) => {
 			const questions = getQuestions(journeyResponse, isQuestionView);
 			return service.isMultipleApplicantsLive
 				? createJourneyV2(questions, journeyResponse, req)
@@ -52,6 +59,7 @@ export function createRoutes(service) {
 		getQuestionJourney,
 		validate,
 		validationErrorHandler,
+		removeApplicantContactsWhenOrganisationRemoved(),
 		buildSave(saveDataToSession)
 	);
 

--- a/apps/manage/src/app/views/cases/create-a-case/session.js
+++ b/apps/manage/src/app/views/cases/create-a-case/session.js
@@ -1,0 +1,39 @@
+import { JOURNEY_ID } from './journey.js';
+
+/**
+ * When removing an applicant organisation, also remove any applicant contacts linked to it.
+ *
+ * @returns {import('express').Handler}
+ */
+export function removeApplicantContactsWhenOrganisationRemoved() {
+	return (req, res, next) => {
+		try {
+			const { question, manageListAction, manageListItemId, manageListQuestion } = req.params;
+			// Only act on the manage-list remove confirm step for applicant organisations
+			if (
+				question !== 'check-applicant-details' ||
+				manageListAction !== 'remove' ||
+				manageListQuestion !== 'confirm' ||
+				typeof manageListItemId !== 'string' ||
+				!manageListItemId
+			) {
+				return next();
+			}
+
+			const answers = req.session?.forms?.[JOURNEY_ID];
+			if (!answers || typeof answers !== 'object') return next();
+
+			const key = 'manageApplicantContactDetails';
+			const existing = answers[key];
+
+			// Filter out any contacts linked to the removed organisation.
+			if (Array.isArray(existing)) {
+				answers[key] = existing.filter((contact) => contact?.applicantContactOrganisation !== manageListItemId);
+			}
+
+			return next();
+		} catch (e) {
+			return next(e);
+		}
+	};
+}

--- a/apps/manage/src/app/views/cases/create-a-case/session.test.js
+++ b/apps/manage/src/app/views/cases/create-a-case/session.test.js
@@ -1,0 +1,134 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import { removeApplicantContactsWhenOrganisationRemoved } from './session.js';
+import { JOURNEY_ID } from './journey.js';
+
+describe('create-a-case - remove applicant contacts when organisation removed', () => {
+	function makeReq({ params, answers } = {}) {
+		return {
+			params: {
+				question: 'check-applicant-details',
+				manageListAction: 'remove',
+				manageListItemId: 'org-1',
+				manageListQuestion: 'confirm',
+				...params
+			},
+			session:
+				answers === undefined
+					? undefined
+					: {
+							forms: {
+								[JOURNEY_ID]: answers
+							}
+						}
+		};
+	}
+
+	it('should remove contacts linked to the removed organisation id', () => {
+		const req = makeReq({
+			answers: {
+				manageApplicantContactDetails: [
+					{ applicantContactOrganisation: 'org-1', applicantFirstName: 'A' },
+					{ applicantContactOrganisation: 'org-2', applicantFirstName: 'B' },
+					{ applicantContactOrganisation: 'org-1', applicantFirstName: 'C' }
+				]
+			}
+		});
+		const next = mock.fn();
+
+		removeApplicantContactsWhenOrganisationRemoved()(req, {}, next);
+
+		assert.deepStrictEqual(req.session.forms[JOURNEY_ID].manageApplicantContactDetails, [
+			{ applicantContactOrganisation: 'org-2', applicantFirstName: 'B' }
+		]);
+		assert.strictEqual(next.mock.callCount(), 1);
+		assert.deepStrictEqual(next.mock.calls[0].arguments, []);
+	});
+
+	it('should keep contacts that are missing an organisation selector', () => {
+		const req = makeReq({
+			answers: {
+				manageApplicantContactDetails: [
+					{ applicantContactOrganisation: 'org-1', applicantFirstName: 'A' },
+					null,
+					{ applicantFirstName: 'No selector' }
+				]
+			}
+		});
+		const next = mock.fn();
+
+		removeApplicantContactsWhenOrganisationRemoved()(req, {}, next);
+
+		assert.deepStrictEqual(req.session.forms[JOURNEY_ID].manageApplicantContactDetails, [
+			null,
+			{ applicantFirstName: 'No selector' }
+		]);
+		assert.strictEqual(next.mock.callCount(), 1);
+	});
+
+	it('should do nothing when manageApplicantContactDetails is not an array', () => {
+		const req = makeReq({ answers: { manageApplicantContactDetails: { some: 'object' } } });
+		const next = mock.fn();
+
+		removeApplicantContactsWhenOrganisationRemoved()(req, {}, next);
+
+		assert.deepStrictEqual(req.session.forms[JOURNEY_ID].manageApplicantContactDetails, { some: 'object' });
+		assert.strictEqual(next.mock.callCount(), 1);
+	});
+
+	it('should do nothing when session does not contain answers for the journey', () => {
+		const req = makeReq();
+		const next = mock.fn();
+
+		removeApplicantContactsWhenOrganisationRemoved()(req, {}, next);
+
+		assert.strictEqual(req.session, undefined);
+		assert.strictEqual(next.mock.callCount(), 1);
+	});
+
+	it('should do nothing when request is not the remove confirm step for applicant organisations', () => {
+		const req = makeReq({
+			params: { manageListAction: 'add' },
+			answers: {
+				manageApplicantContactDetails: [{ applicantContactOrganisation: 'org-1' }]
+			}
+		});
+		const next = mock.fn();
+
+		removeApplicantContactsWhenOrganisationRemoved()(req, {}, next);
+
+		assert.deepStrictEqual(req.session.forms[JOURNEY_ID].manageApplicantContactDetails, [
+			{ applicantContactOrganisation: 'org-1' }
+		]);
+		assert.strictEqual(next.mock.callCount(), 1);
+	});
+
+	it('should do nothing when manageListItemId is missing', () => {
+		const req = makeReq({
+			params: { manageListItemId: '' },
+			answers: {
+				manageApplicantContactDetails: [{ applicantContactOrganisation: 'org-1' }]
+			}
+		});
+		const next = mock.fn();
+
+		removeApplicantContactsWhenOrganisationRemoved()(req, {}, next);
+
+		assert.deepStrictEqual(req.session.forms[JOURNEY_ID].manageApplicantContactDetails, [
+			{ applicantContactOrganisation: 'org-1' }
+		]);
+		assert.strictEqual(next.mock.callCount(), 1);
+	});
+
+	it('should forward errors to next when an exception is thrown', () => {
+		const req = makeReq({ answers: { manageApplicantContactDetails: [] } });
+		delete req.params;
+		const next = mock.fn();
+
+		removeApplicantContactsWhenOrganisationRemoved()(req, {}, next);
+
+		assert.strictEqual(next.mock.callCount(), 1);
+		const [err] = next.mock.calls[0].arguments;
+		assert.ok(err instanceof Error);
+	});
+});

--- a/apps/manage/src/app/views/cases/view/delete.js
+++ b/apps/manage/src/app/views/cases/view/delete.js
@@ -69,17 +69,57 @@ export function buildDeleteManageListItemOnConfirmRemove(service) {
 	const deleteHandlersByFieldName = {
 		// Applicants: session item id is Organisation.id; remove relationship record for this case
 		manageApplicantDetails: async ({ req, id, manageListItemId }) => {
-			await db.crownDevelopmentToOrganisation.deleteMany({
-				where: { crownDevelopmentId: id, organisationId: manageListItemId }
+			// Fetch linked contacts up-front (we may attempt to clean them up later)
+			const contacts = await db.organisationToContact.findMany({
+				where: {
+					organisationId: manageListItemId,
+					Organisation: {
+						CrownDevelopmentToOrganisation: {
+							some: { crownDevelopmentId: id, role: ORGANISATION_ROLES_ID.APPLICANT }
+						}
+					}
+				},
+				select: { contactId: true }
 			});
+
 			try {
-				await db.organisation.delete({ where: { id: manageListItemId } });
+				await db.$transaction([
+					// 1) remove contact join rows for this organisation first (prevents foreign key failures)
+					db.organisationToContact.deleteMany({
+						where: {
+							organisationId: manageListItemId,
+							Organisation: {
+								CrownDevelopmentToOrganisation: {
+									some: { crownDevelopmentId: id, role: ORGANISATION_ROLES_ID.APPLICANT }
+								}
+							}
+						}
+					}),
+					// 2) remove relationship to this case
+					db.crownDevelopmentToOrganisation.deleteMany({
+						where: { crownDevelopmentId: id, organisationId: manageListItemId, role: ORGANISATION_ROLES_ID.APPLICANT }
+					}),
+					// 3) remove the organisation row (may still fail if referenced elsewhere)
+					db.organisation.delete({ where: { id: manageListItemId } })
+				]);
 				setBannerMessage(req, id, 'check-applicant-details');
 			} catch (error) {
 				logger.warn(
 					{ id, manageListItemId, err: error },
 					'Unable to delete Organisation record (may still be referenced)'
 				);
+			}
+
+			// Best-effort cleanup of contacts (only safe if contacts are not shared elsewhere)
+			const contactIds = contacts.map((c) => c.contactId);
+			if (contactIds.length) {
+				try {
+					await db.contact.deleteMany({
+						where: { id: { in: contactIds }, OrganisationToContact: { none: {} } }
+					});
+				} catch (error) {
+					logger.warn({ id, manageListItemId, err: error }, 'Unable to delete contact record linked to organisation.');
+				}
 			}
 		},
 		// Applicant contacts: session item id is Contact.id; remove join rows across the organisations for this case

--- a/apps/manage/src/app/views/cases/view/delete.test.js
+++ b/apps/manage/src/app/views/cases/view/delete.test.js
@@ -39,10 +39,15 @@ describe('buildDeleteManageListItemOnConfirmRemove', () => {
 				deleteMany: mock.fn(async () => ({ count: 1 })),
 				findFirst: mock.fn()
 			},
-			organisationToContact: { deleteMany: mock.fn() },
+			organisationToContact: { deleteMany: mock.fn(), findMany: mock.fn(async () => []) },
 			organisation: { delete: mock.fn(async () => ({ id: 'org-1' })) },
 			contact: { delete: mock.fn() }
 		};
+		db.$transaction = mock.fn(async (ops) => {
+			// prisma allows passing an array of operations; we just execute them in order for this test
+			for (const op of ops) await op;
+			return [];
+		});
 		const middleware = buildDeleteManageListItemOnConfirmRemove({ db, logger: mockLogger() });
 		const req = {
 			params: {
@@ -59,6 +64,9 @@ describe('buildDeleteManageListItemOnConfirmRemove', () => {
 
 		await middleware(req, res, next);
 
+		assert.strictEqual(db.$transaction.mock.callCount(), 1);
+		assert.strictEqual(db.organisationToContact.findMany.mock.callCount(), 1);
+		assert.strictEqual(db.organisationToContact.deleteMany.mock.callCount(), 1);
 		assert.strictEqual(db.crownDevelopmentToOrganisation.deleteMany.mock.callCount(), 1);
 		assert.strictEqual(db.organisation.delete.mock.callCount(), 1);
 		assert.strictEqual(req.session.bannerMessage['case-1']['check-applicant-details:item-removed-success'], true);
@@ -151,9 +159,14 @@ describe('buildDeleteManageListItemOnConfirmRemove', () => {
 				deleteMany: mock.fn(async () => ({ count: 1 })),
 				findFirst: mock.fn()
 			},
-			organisationToContact: { deleteMany: mock.fn() },
+			organisationToContact: { deleteMany: mock.fn(), findMany: mock.fn(async () => []) },
+			organisation: { delete: mock.fn(async () => ({ id: 'org-1' })) },
 			contact: { delete: mock.fn() }
 		};
+		db.$transaction = mock.fn(async (ops) => {
+			for (const op of ops) await op;
+			return [];
+		});
 		const middleware = buildDeleteManageListItemOnConfirmRemove({ db, logger: mockLogger() });
 		const req = {
 			params: {
@@ -169,9 +182,10 @@ describe('buildDeleteManageListItemOnConfirmRemove', () => {
 
 		await middleware(req, res, next);
 
+		assert.strictEqual(db.$transaction.mock.callCount(), 1);
 		assert.strictEqual(db.crownDevelopmentToOrganisation.deleteMany.mock.callCount(), 1);
 		assert.deepStrictEqual(db.crownDevelopmentToOrganisation.deleteMany.mock.calls[0].arguments[0], {
-			where: { crownDevelopmentId: 'case-1', organisationId: 'org-1' }
+			where: { crownDevelopmentId: 'case-1', organisationId: 'org-1', role: 'applicant' }
 		});
 		assert.strictEqual(next.mock.callCount(), 1);
 		assert.strictEqual(next.mock.calls[0].arguments.length, 0);
@@ -410,6 +424,177 @@ describe('buildDeleteManageListItemOnConfirmRemove', () => {
 		assert.strictEqual(next.mock.callCount(), 1);
 		assert.strictEqual(next.mock.calls[0].arguments.length, 1);
 		assert.ok(next.mock.calls[0].arguments[0] instanceof Error);
+	});
+
+	it('should delete linked contacts after deleting an applicant organisation', async () => {
+		const db = {
+			crownDevelopmentToOrganisation: {
+				deleteMany: mock.fn(async () => ({ count: 1 })),
+				findFirst: mock.fn()
+			},
+			organisationToContact: {
+				deleteMany: mock.fn(async () => ({ count: 2 })),
+				findMany: mock.fn(async () => [{ contactId: 'contact-1' }, { contactId: 'contact-2' }])
+			},
+			organisation: { delete: mock.fn(async () => ({ id: 'org-1' })) },
+			contact: { delete: mock.fn(), deleteMany: mock.fn(async () => ({ count: 2 })) }
+		};
+		db.$transaction = mock.fn(async (ops) => {
+			for (const op of ops) await op;
+			return [];
+		});
+		const middleware = buildDeleteManageListItemOnConfirmRemove({ db, logger: mockLogger() });
+		const req = {
+			params: {
+				id: 'case-1',
+				manageListAction: 'remove',
+				manageListItemId: 'org-1',
+				manageListQuestion: 'confirm',
+				question: 'check-applicant-details'
+			},
+			session: {}
+		};
+		const res = {};
+		const next = mock.fn();
+
+		await middleware(req, res, next);
+
+		assert.strictEqual(db.contact.deleteMany.mock.callCount(), 1);
+		assert.deepStrictEqual(db.contact.deleteMany.mock.calls[0].arguments[0], {
+			where: { id: { in: ['contact-1', 'contact-2'] }, OrganisationToContact: { none: {} } }
+		});
+		assert.strictEqual(req.session.bannerMessage['case-1']['check-applicant-details:item-removed-success'], true);
+		assert.strictEqual(next.mock.callCount(), 1);
+		assert.strictEqual(next.mock.calls[0].arguments.length, 0);
+	});
+
+	it('should not attempt to delete contacts when an applicant organisation has no linked contacts', async () => {
+		const db = {
+			crownDevelopmentToOrganisation: {
+				deleteMany: mock.fn(async () => ({ count: 1 })),
+				findFirst: mock.fn()
+			},
+			organisationToContact: { deleteMany: mock.fn(async () => ({ count: 0 })), findMany: mock.fn(async () => []) },
+			organisation: { delete: mock.fn(async () => ({ id: 'org-1' })) },
+			contact: { delete: mock.fn(), deleteMany: mock.fn() }
+		};
+		db.$transaction = mock.fn(async (ops) => {
+			for (const op of ops) await op;
+			return [];
+		});
+		const middleware = buildDeleteManageListItemOnConfirmRemove({ db, logger: mockLogger() });
+		const req = {
+			params: {
+				id: 'case-1',
+				manageListAction: 'remove',
+				manageListItemId: 'org-1',
+				manageListQuestion: 'confirm',
+				question: 'check-applicant-details'
+			},
+			session: {}
+		};
+		const res = {};
+		const next = mock.fn();
+
+		await middleware(req, res, next);
+
+		assert.strictEqual(db.contact.deleteMany.mock.callCount(), 0);
+		assert.strictEqual(req.session.bannerMessage['case-1']['check-applicant-details:item-removed-success'], true);
+		assert.strictEqual(next.mock.callCount(), 1);
+		assert.strictEqual(next.mock.calls[0].arguments.length, 0);
+	});
+
+	it('should continue when linked contact cleanup fails after deleting an applicant organisation', async () => {
+		const logger = mockLogger();
+		const db = {
+			crownDevelopmentToOrganisation: {
+				deleteMany: mock.fn(async () => ({ count: 1 })),
+				findFirst: mock.fn()
+			},
+			organisationToContact: {
+				deleteMany: mock.fn(async () => ({ count: 2 })),
+				findMany: mock.fn(async () => [{ contactId: 'contact-1' }])
+			},
+			organisation: { delete: mock.fn(async () => ({ id: 'org-1' })) },
+			contact: {
+				delete: mock.fn(),
+				deleteMany: mock.fn(async () => {
+					throw new Error('still referenced');
+				})
+			}
+		};
+		db.$transaction = mock.fn(async (ops) => {
+			for (const op of ops) await op;
+			return [];
+		});
+		const middleware = buildDeleteManageListItemOnConfirmRemove({ db, logger });
+		const req = {
+			params: {
+				id: 'case-1',
+				manageListAction: 'remove',
+				manageListItemId: 'org-1',
+				manageListQuestion: 'confirm',
+				question: 'check-applicant-details'
+			},
+			session: {}
+		};
+		const res = {};
+		const next = mock.fn();
+
+		await middleware(req, res, next);
+
+		assert.strictEqual(logger.warn.mock.callCount(), 1);
+		assert.strictEqual(
+			logger.warn.mock.calls[0].arguments[1],
+			'Unable to delete contact record linked to organisation.'
+		);
+		assert.strictEqual(req.session.bannerMessage['case-1']['check-applicant-details:item-removed-success'], true);
+		assert.strictEqual(next.mock.callCount(), 1);
+		assert.strictEqual(next.mock.calls[0].arguments.length, 0);
+	});
+
+	it('should attempt to delete linked contacts even when applicant organisation deletion fails', async () => {
+		const logger = mockLogger();
+		const db = {
+			crownDevelopmentToOrganisation: {
+				deleteMany: mock.fn(async () => ({ count: 1 })),
+				findFirst: mock.fn()
+			},
+			organisationToContact: {
+				deleteMany: mock.fn(async () => ({ count: 2 })),
+				findMany: mock.fn(async () => [{ contactId: 'contact-1' }, { contactId: 'contact-2' }])
+			},
+			organisation: { delete: mock.fn(async () => ({ id: 'org-1' })) },
+			contact: { delete: mock.fn(), deleteMany: mock.fn(async () => ({ count: 2 })) }
+		};
+		db.$transaction = mock.fn(async () => {
+			throw new Error('org still referenced');
+		});
+		const middleware = buildDeleteManageListItemOnConfirmRemove({ db, logger });
+		const req = {
+			params: {
+				id: 'case-1',
+				manageListAction: 'remove',
+				manageListItemId: 'org-1',
+				manageListQuestion: 'confirm',
+				question: 'check-applicant-details'
+			},
+			session: {}
+		};
+		const res = {};
+		const next = mock.fn();
+
+		await middleware(req, res, next);
+
+		assert.strictEqual(logger.warn.mock.callCount(), 1);
+		assert.strictEqual(
+			logger.warn.mock.calls[0].arguments[1],
+			'Unable to delete Organisation record (may still be referenced)'
+		);
+		assert.strictEqual(db.contact.deleteMany.mock.callCount(), 1);
+		assert.strictEqual(req.session.bannerMessage?.['check-applicant-details:item-removed-success'], undefined);
+		assert.strictEqual(next.mock.callCount(), 1);
+		assert.strictEqual(next.mock.calls[0].arguments.length, 0);
 	});
 });
 describe('addSuccessBannerFromMessage', () => {

--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -476,6 +476,8 @@ export function getQuestions(
 			fieldName: 'manageApplicantDetails',
 			titleSingular: 'Applicant',
 			emptyListText: 'No applicants found',
+			removalPrompt:
+				'Removing this organisation will also remove any linked contacts. You will not be able to undo this.',
 			showAnswersInSummary: true,
 			maximumAnswers: 5,
 			validators: [

--- a/apps/manage/src/types/express-session.d.ts
+++ b/apps/manage/src/types/express-session.d.ts
@@ -12,6 +12,10 @@ type BannerMessageKey = `${BannerMessageQuestionUrl}:item-removed-success`;
 // properties to req.session / SessionData.
 
 declare module 'express-session' {
+	interface FormSessionData {
+		[key: string]: unknown;
+	}
+
 	interface SessionData {
 		// Auth
 		account?: import('@azure/msal-node').AccountInfo & {
@@ -35,7 +39,7 @@ declare module 'express-session' {
 		reviewDecisions?: Record<string, unknown>;
 		itemsToBeDeleted?: Record<string, string[]>;
 		files?: Record<string, unknown>;
-		forms?: Record<string, unknown>;
+		forms?: Record<string, FormSessionData>;
 		bannerMessage?: Record<CaseId, Record<BannerMessageKey, boolean>>;
 
 		// Common error/session transient state

--- a/packages/lib/forms/custom-components/manage-list/confirm.njk
+++ b/packages/lib/forms/custom-components/manage-list/confirm.njk
@@ -1,28 +1,34 @@
 {% extends layoutTemplate %}
-
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block dynQuestionContent %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="" method="post" novalidate>
-                {% if _csrf %}<input type="hidden" name="_csrf" value="{{ _csrf }}">{% endif %}
-                <h1 class="govuk-heading-l">Remove {{ titleSingular | lower }}</h1>
-                <p class="govuk-body" id="remove-description">Are you sure you want to remove this {{ titleSingular | lower }}?</p>
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+		<form action="" method="post" novalidate>
+			{% if _csrf %}<input type="hidden" name="_csrf" value="{{ _csrf }}">{% endif %}
+			<h1 class="govuk-heading-l">Remove {{ titleSingular | lower }}</h1>
+			<p class="govuk-body" id="remove-description">{{ removalPrompt }}</p>
 
-                <div class="govuk-inset-text">
-                    {% for item in questionSummary %}
-                        <p class="govuk-body">{{ item.answer | safe }}</p>
-                    {% endfor %}
-                </div>
-                {{ govukButton({
-                    text: confirmRemoveButtonText,
-                    type: "submit",
-                    classes: "govuk-button--warning",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
-                <a href="{{ backLink }}" class="govuk-button govuk-button--secondary" data-cy="button-back" aria-describedby="remove-description">Cancel</a>
-            </form>
-        </div>
-    </div>
+			<div class="govuk-inset-text">
+				{% for item in questionSummary %}
+					<p class="govuk-body">{{ item.answer | safe }}</p>
+				{% endfor %}
+			</div>
+			{{
+				govukButton({
+				text: confirmRemoveButtonText,
+				type: "submit",
+				classes: "govuk-button--warning",
+				attributes: { "data-cy":"button-save-and-continue"}
+				})
+			}}
+			<a
+				href="{{ backLink }}"
+				class="govuk-button govuk-button--secondary"
+				data-cy="button-back"
+				aria-describedby="remove-description"
+			>Cancel</a>
+		</form>
+	</div>
+</div>
 {% endblock %}

--- a/packages/lib/forms/custom-components/manage-list/question.js
+++ b/packages/lib/forms/custom-components/manage-list/question.js
@@ -13,12 +13,23 @@ import nunjucks from 'nunjucks';
  *  emptyListText?: string;
  * 	isAllowedEmpty?: boolean;
  * 	confirmRemoveButtonText?: string;
+ * 	removalPrompt?: string;
  * }} CustomManageListQuestionParameters
  */
 
 export default class CustomManageListQuestion extends ManageListQuestion {
 	/** @type {boolean} */
 	#showAnswersInSummary;
+	/** @type {number|null} */
+	maximumAnswers;
+	/** @type {string} */
+	emptyListText;
+	/** @type {boolean} */
+	isAllowedEmpty;
+	/** @type {string} */
+	confirmRemoveButtonText;
+	/** @type {string} */
+	removalPrompt;
 
 	/**
 	 * @param {CustomManageListQuestionParameters} params
@@ -27,10 +38,12 @@ export default class CustomManageListQuestion extends ManageListQuestion {
 		super(params);
 		this.viewFolder = 'custom-components/manage-list';
 		this.#showAnswersInSummary = true;
-		this.maximumAnswers = params.maximumAnswers;
+		this.maximumAnswers = params.maximumAnswers ?? null;
 		this.emptyListText = params.emptyListText || 'No items have been added yet.';
-		this.isAllowedEmpty = params.isAllowedEmpty;
+		this.isAllowedEmpty = params.isAllowedEmpty ?? false;
 		this.confirmRemoveButtonText = params.confirmRemoveButtonText || `Remove ${params.titleSingular.toLowerCase()}`;
+		this.removalPrompt =
+			params.removalPrompt || `Are you sure you want to remove this ${params.titleSingular.toLowerCase()}?`;
 	}
 	/**
 	 * @param {QuestionViewModel} viewModel
@@ -44,6 +57,7 @@ export default class CustomManageListQuestion extends ManageListQuestion {
 		viewModel.confirmRemoveButtonText = this.confirmRemoveButtonText;
 		viewModel.emptyListText = this.emptyListText;
 		viewModel.hideAddButton = this.maximumAnswers && viewModel.question.value.length >= this.maximumAnswers;
+		viewModel.removalPrompt = this.removalPrompt;
 	}
 
 	/**

--- a/packages/lib/forms/custom-components/manage-list/question.test.js
+++ b/packages/lib/forms/custom-components/manage-list/question.test.js
@@ -73,6 +73,27 @@ describe('ManageApplicantsQuestion', () => {
 	};
 
 	describe('addCustomDataToViewModel', () => {
+		it('should set default remove button text and removal prompt using lowercased titleSingular', (context) => {
+			const { question, journey } = questionWithManageQuestions(context, { titleSingular: 'APPLICANT' }, 2);
+			const viewModel = question.prepQuestionForRendering({}, journey);
+			assert.strictEqual(viewModel?.confirmRemoveButtonText, 'Remove applicant');
+			assert.strictEqual(viewModel?.removalPrompt, 'Are you sure you want to remove this applicant?');
+		});
+
+		it('should use provided confirmRemoveButtonText and removalPrompt overrides', (context) => {
+			const { question, journey } = questionWithManageQuestions(
+				context,
+				{
+					confirmRemoveButtonText: 'Delete applicant',
+					removalPrompt: 'This will permanently delete the applicant. Continue?'
+				},
+				2
+			);
+			const viewModel = question.prepQuestionForRendering({}, journey);
+			assert.strictEqual(viewModel?.confirmRemoveButtonText, 'Delete applicant');
+			assert.strictEqual(viewModel?.removalPrompt, 'This will permanently delete the applicant. Continue?');
+		});
+
 		it('should hide the remove button if only one is added', (context) => {
 			const { question, journey } = questionWithManageQuestions(context, {}, 1);
 			const viewModel = question.prepQuestionForRendering({}, journey);


### PR DESCRIPTION
## Describe your changes

1. Add ability to customise removal prompt to custom manage list question
2. Add tests for the above
3. Specify class properties

### Create journey

1. Add deletion handler to remove orphaned applicant contacts for the session.
2. Add tests for the above

### Edit journey

1. Extend deletion handler for applicant contacts so that organisations, contacts, and any related join rows are deleted.
2. Add tests for the above

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1374