### PR TITLE
feat(portal): add distressing content handling for written representations

### DIFF
--- a/apps/portal/src/app/views/applications/view/written-representations/controller.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/controller.js
@@ -169,6 +169,7 @@ export function buildWrittenRepresentationsListPage({ db, logger }) {
 						submittedForId: true,
 						representedTypeId: true,
 						containsAttachments: true,
+						distressingContentInRepresentation: true,
 						SubmittedFor: { select: { displayName: true } },
 						SubmittedByContact: { select: { firstName: true, lastName: true } },
 						RepresentedContact: { select: { orgName: true, firstName: true, lastName: true } },
@@ -260,7 +261,8 @@ export function buildWrittenRepresentationsListPage({ db, logger }) {
 			hasQueries: hasQueries(req.query),
 			filterQueries: filterQueryItems,
 			errorSummary,
-			dateErrors
+			dateErrors,
+			containsDistressingContent: crownDevelopment.containsDistressingContent || false
 		});
 	};
 }

--- a/apps/portal/src/app/views/applications/view/written-representations/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/controller.test.js
@@ -9,7 +9,9 @@ describe('written representations', () => {
 	const logger = mockLogger();
 
 	describe('buildWrittenRepresentationsPage', () => {
-		it('should render the view with representations', async () => {
+		it('should render the view with representations', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
+
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: {
@@ -88,7 +90,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.resultsStartNumber, 1);
 			assert.strictEqual(viewData.resultsEndNumber, 1);
 		});
-		it('should show representation-level distressing tag when a representation has distressingContentInRepresentation true', async () => {
+		it('should show representation-level distressing tag when a representation has distressingContentInRepresentation true', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: {
@@ -142,7 +145,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.representations[0].distressingContent, true);
 		});
 
-		it('should not show representation-level distressing tag when a representation has distressingContentInRepresentation false', async () => {
+		it('should not show representation-level distressing tag when a representation has distressingContentInRepresentation false', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: {
@@ -196,7 +200,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.representations[0].distressingContent, false);
 		});
 
-		it('should show application-level distressing tag when application containsDistressingContent is true', async () => {
+		it('should show application-level distressing tag when application containsDistressingContent is true', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: {
@@ -249,7 +254,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.representations.length, 1);
 		});
 
-		it('should not show application-level distressing tag when application containsDistressingContent is false', async () => {
+		it('should not show application-level distressing tag when application containsDistressingContent is false', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: {
@@ -301,7 +307,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.containsDistressingContent, false);
 			assert.strictEqual(viewData.representations.length, 1);
 		});
-		it('should render the view with representation and read more link if the comment exceeds 500 chars', async () => {
+		it('should render the view with representation and read more link if the comment exceeds 500 chars', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: {
@@ -385,7 +392,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.resultsStartNumber, 1);
 			assert.strictEqual(viewData.resultsEndNumber, 1);
 		});
-		it('should render the view with values provided in url query parameters', async () => {
+		it('should render the view with values provided in url query parameters', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const mockReq = {
 				params: {
 					applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8'
@@ -431,7 +439,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.pageNumber, 4);
 		});
 
-		it('should render the view with values for pagination based on url params', async () => {
+		it('should render the view with values for pagination based on url params', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const mockReq = {
 				params: {
 					applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8'
@@ -478,7 +487,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.resultsEndNumber, 200);
 		});
 
-		it('should render the view with values for pagination when total representations less than 25', async () => {
+		it('should render the view with values for pagination when total representations less than 25', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const mockReq = {
 				params: {
 					applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8'
@@ -521,7 +531,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.resultsEndNumber, 17);
 		});
 
-		it('should wrap prisma errors if error on findMany query', async () => {
+		it('should wrap prisma errors if error on findMany query', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockDb = {
 				crownDevelopment: {
@@ -562,7 +573,8 @@ describe('written representations', () => {
 			assert.strictEqual(mockRes.redirect.mock.callCount(), 0);
 		});
 
-		it('should wrap prisma errors if error on count query', async () => {
+		it('should wrap prisma errors if error on count query', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockDb = {
 				crownDevelopment: {
@@ -603,7 +615,8 @@ describe('written representations', () => {
 			assert.strictEqual(mockRes.redirect.mock.callCount(), 0);
 		});
 
-		it('should throw error if totalRepresentations is null', async () => {
+		it('should throw error if totalRepresentations is null', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const mockReq = {
 				params: {
 					applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8'
@@ -632,7 +645,8 @@ describe('written representations', () => {
 			await assertRenders404Page(handler, mockReq, false);
 		});
 
-		it('should throw error if totalRepresentations is undefined', async () => {
+		it('should throw error if totalRepresentations is undefined', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const mockReq = {
 				params: {
 					applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8'
@@ -661,7 +675,8 @@ describe('written representations', () => {
 			await assertRenders404Page(handler, mockReq, false);
 		});
 
-		it('should throw error if totalRepresentations is NaN', async () => {
+		it('should throw error if totalRepresentations is NaN', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const mockReq = {
 				params: {
 					applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8'
@@ -752,7 +767,8 @@ describe('written representations', () => {
 			const writtenRepresentationsPage = buildWrittenRepresentationsListPage({ db: mockDb, config: {} });
 			await assertRenders404Page(writtenRepresentationsPage, mockReq, false);
 		});
-		it('should 404 if the application written representations are not published', async () => {
+		it('should 404 if the application written representations are not published', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const mockReq = { params: { applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8' } };
 			const mockDb = {
 				crownDevelopment: {
@@ -770,7 +786,8 @@ describe('written representations', () => {
 		});
 	});
 	describe('date filters in controller', () => {
-		it('should apply submittedDate when complete valid From/To date provided', async () => {
+		it('should apply submittedDate when complete valid From/To date provided', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: { applicationId },
@@ -816,7 +833,8 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.errorSummary, null, 'errorSummary should be null for complete dates');
 			assert.ok(Array.isArray(viewData.dateErrors), 'dateErrors should be an array');
 		});
-		it('should build error summary entries when incomplete From date provided', async () => {
+		it('should build error summary entries when incomplete From date provided', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: { applicationId },
@@ -849,7 +867,8 @@ describe('written representations', () => {
 			assert.match(viewData.dateErrors[0].href, /submittedDateFrom-day/, 'error href should point to From day input');
 		});
 
-		it('should not apply submittedDate filter when all From parts are empty', async () => {
+		it('should not apply submittedDate filter when all From parts are empty', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: { applicationId },
@@ -879,7 +898,8 @@ describe('written representations', () => {
 			assert.strictEqual(!!args.where.submittedDate, false, 'submittedDate should not be present when all parts empty');
 		});
 
-		it('should apply date range filter and return only in-range representations', async () => {
+		it('should apply date range filter and return only in-range representations', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
 				params: { applicationId },

--- a/apps/portal/src/app/views/applications/view/written-representations/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/controller.test.js
@@ -41,6 +41,7 @@ describe('written representations', () => {
 							submittedForId: 'on-behalf-of',
 							representedTypeId: 'organisation',
 							containsAttachments: true,
+							distressingContentInRepresentation: false,
 							SubmittedFor: { displayName: 'John Doe' },
 							SubmittedByContact: { firstName: 'Jane', lastName: 'Smith' },
 							RepresentedContact: { firstName: 'Alice', lastName: 'Brown' },
@@ -87,6 +88,219 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.resultsStartNumber, 1);
 			assert.strictEqual(viewData.resultsEndNumber, 1);
 		});
+		it('should show representation-level distressing tag when a representation has distressingContentInRepresentation true', async () => {
+			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
+			const mockReq = {
+				params: {
+					applicationId
+				},
+				originalUrl: `/applications/${applicationId}/written-representations`
+			};
+
+			const mockRes = { render: mock.fn(), status: mock.fn() };
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: applicationId,
+						reference: 'CROWN/2025/0000001',
+						representationsPeriodStartDate: new Date('2025-01-01'),
+						representationsPeriodEndDate: new Date('2025-02-01'),
+						representationsPublishDate: new Date('2025-03-01'),
+						applicationStatus: 'active',
+						containsDistressingContent: false
+					}))
+				},
+				representation: {
+					findMany: mock.fn(() => [
+						{
+							reference: '4SNR8-ZS27T',
+							submittedDate: new Date('2025-01-15'),
+							comment: 'This is a test representation.',
+							commentRedacted: null,
+							submittedByAgentOrgName: 'Test Organization',
+							submittedForId: 'on-behalf-of',
+							representedTypeId: 'organisation',
+							containsAttachments: false,
+							distressingContentInRepresentation: true,
+							SubmittedFor: { displayName: 'John Doe' },
+							SubmittedByContact: { firstName: 'Jane', lastName: 'Smith' },
+							RepresentedContact: { firstName: 'Alice', lastName: 'Brown' },
+							Category: { displayName: 'General Representation' },
+							Attachments: []
+						}
+					]),
+					count: mock.fn(() => 1)
+				},
+				applicationUpdate: { findFirst: mock.fn(() => undefined), count: mock.fn(() => 0) }
+			};
+
+			const handler = buildWrittenRepresentationsListPage({ db: mockDb });
+			await handler(mockReq, mockRes);
+
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.strictEqual(viewData.representations.length, 1);
+			assert.strictEqual(viewData.representations[0].distressingContent, true);
+		});
+
+		it('should not show representation-level distressing tag when a representation has distressingContentInRepresentation false', async () => {
+			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
+			const mockReq = {
+				params: {
+					applicationId
+				},
+				originalUrl: `/applications/${applicationId}/written-representations`
+			};
+
+			const mockRes = { render: mock.fn(), status: mock.fn() };
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: applicationId,
+						reference: 'CROWN/2025/0000001',
+						representationsPeriodStartDate: new Date('2025-01-01'),
+						representationsPeriodEndDate: new Date('2025-02-01'),
+						representationsPublishDate: new Date('2025-03-01'),
+						applicationStatus: 'active',
+						containsDistressingContent: false
+					}))
+				},
+				representation: {
+					findMany: mock.fn(() => [
+						{
+							reference: '4SNR8-ZS27T',
+							submittedDate: new Date('2025-01-15'),
+							comment: 'This is a test representation.',
+							commentRedacted: null,
+							submittedByAgentOrgName: 'Test Organization',
+							submittedForId: 'on-behalf-of',
+							representedTypeId: 'organisation',
+							containsAttachments: false,
+							distressingContentInRepresentation: false,
+							SubmittedFor: { displayName: 'John Doe' },
+							SubmittedByContact: { firstName: 'Jane', lastName: 'Smith' },
+							RepresentedContact: { firstName: 'Alice', lastName: 'Brown' },
+							Category: { displayName: 'General Representation' },
+							Attachments: []
+						}
+					]),
+					count: mock.fn(() => 1)
+				},
+				applicationUpdate: { findFirst: mock.fn(() => undefined), count: mock.fn(() => 0) }
+			};
+
+			const handler = buildWrittenRepresentationsListPage({ db: mockDb });
+			await handler(mockReq, mockRes);
+
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.strictEqual(viewData.representations.length, 1);
+			assert.strictEqual(viewData.representations[0].distressingContent, false);
+		});
+
+		it('should show application-level distressing tag when application containsDistressingContent is true', async () => {
+			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
+			const mockReq = {
+				params: {
+					applicationId
+				},
+				originalUrl: `/applications/${applicationId}/written-representations`
+			};
+			const mockRes = { render: mock.fn(), status: mock.fn() };
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: applicationId,
+						reference: 'CROWN/2025/0000001',
+						representationsPeriodStartDate: new Date('2025-01-01'),
+						representationsPeriodEndDate: new Date('2025-02-01'),
+						representationsPublishDate: new Date('2025-03-01'),
+						applicationStatus: 'active',
+						containsDistressingContent: true
+					}))
+				},
+				representation: {
+					findMany: mock.fn(() => [
+						{
+							reference: '4SNR8-ZS27T',
+							submittedDate: new Date('2025-01-15'),
+							comment: 'This is a test representation.',
+							commentRedacted: null,
+							submittedByAgentOrgName: 'Test Organization',
+							submittedForId: 'on-behalf-of',
+							representedTypeId: 'organisation',
+							containsAttachments: false,
+							distressingContentInRepresentation: false,
+							SubmittedFor: { displayName: 'John Doe' },
+							SubmittedByContact: { firstName: 'Jane', lastName: 'Smith' },
+							RepresentedContact: { firstName: 'Alice', lastName: 'Brown' },
+							Category: { displayName: 'General Representation' },
+							Attachments: []
+						}
+					]),
+					count: mock.fn(() => 1)
+				},
+				applicationUpdate: { findFirst: mock.fn(() => undefined), count: mock.fn(() => 0) }
+			};
+
+			const handler = buildWrittenRepresentationsListPage({ db: mockDb });
+			await handler(mockReq, mockRes);
+
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.strictEqual(viewData.containsDistressingContent, true);
+			assert.strictEqual(viewData.representations.length, 1);
+		});
+
+		it('should not show application-level distressing tag when application containsDistressingContent is false', async () => {
+			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
+			const mockReq = {
+				params: {
+					applicationId
+				},
+				originalUrl: `/applications/${applicationId}/written-representations`
+			};
+			const mockRes = { render: mock.fn(), status: mock.fn() };
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: applicationId,
+						reference: 'CROWN/2025/0000001',
+						representationsPeriodStartDate: new Date('2025-01-01'),
+						representationsPeriodEndDate: new Date('2025-02-01'),
+						representationsPublishDate: new Date('2025-03-01'),
+						applicationStatus: 'active',
+						containsDistressingContent: false
+					}))
+				},
+				representation: {
+					findMany: mock.fn(() => [
+						{
+							reference: '4SNR8-ZS27T',
+							submittedDate: new Date('2025-01-15'),
+							comment: 'This is a test representation.',
+							commentRedacted: null,
+							submittedByAgentOrgName: 'Test Organization',
+							submittedForId: 'on-behalf-of',
+							representedTypeId: 'organisation',
+							containsAttachments: false,
+							distressingContentInRepresentation: false,
+							SubmittedFor: { displayName: 'John Doe' },
+							SubmittedByContact: { firstName: 'Jane', lastName: 'Smith' },
+							RepresentedContact: { firstName: 'Alice', lastName: 'Brown' },
+							Category: { displayName: 'General Representation' },
+							Attachments: []
+						}
+					]),
+					count: mock.fn(() => 1)
+				},
+				applicationUpdate: { findFirst: mock.fn(() => undefined), count: mock.fn(() => 0) }
+			};
+
+			const handler = buildWrittenRepresentationsListPage({ db: mockDb });
+			await handler(mockReq, mockRes);
+
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.strictEqual(viewData.containsDistressingContent, false);
+			assert.strictEqual(viewData.representations.length, 1);
+		});
 		it('should render the view with representation and read more link if the comment exceeds 500 chars', async () => {
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
 			const mockReq = {
@@ -121,6 +335,7 @@ describe('written representations', () => {
 							submittedForId: 'on-behalf-of',
 							representedTypeId: 'organisation',
 							containsAttachments: true,
+							distressingContentInRepresentation: false,
 							SubmittedFor: { displayName: 'John Doe' },
 							SubmittedByContact: { firstName: 'Jane', lastName: 'Smith' },
 							RepresentedContact: { firstName: 'Alice', lastName: 'Brown' },
@@ -713,6 +928,7 @@ describe('written representations', () => {
 								submittedForId: '',
 								representedTypeId: '',
 								containsAttachments: false,
+								distressingContentInRepresentation: true,
 								SubmittedFor: { displayName: '' },
 								SubmittedByContact: { firstName: '', lastName: '' },
 								RepresentedContact: { orgName: '', firstName: '', lastName: '' },

--- a/apps/portal/src/app/views/applications/view/written-representations/representation.njk
+++ b/apps/portal/src/app/views/applications/view/written-representations/representation.njk
@@ -1,5 +1,13 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
 {% macro renderRepresentation(representation) %}
     <p class="govuk-body govuk-!-font-weight-bold">
+        {% if representation.distressingContent %}
+            {{ govukTag({
+                text: "Content warning",
+                classes: "govuk-tag--red"
+            }) }}
+        {% endif %}
         <a href="written-representations/{{ representation.representationReference }}" class="govuk-link">
             {{ representation.representationTitle }}
         </a>

--- a/apps/portal/src/app/views/applications/view/written-representations/view.njk
+++ b/apps/portal/src/app/views/applications/view/written-representations/view.njk
@@ -37,7 +37,7 @@
 		</div>
 
 		<div class="govuk-grid-column-two-thirds">
-			{{ distressingContentBanner(crownDevelopmentFields.containsDistressingContent) }}
+			{{ distressingContentBanner(containsDistressingContent) }}
 			<div class="govuk-grid-row">
 				<div class="govuk-grid-column-full">
 					<h1 class="govuk-heading-l">


### PR DESCRIPTION
## Describe your changes

This pull request adds support for displaying content warning tags when a written representation or an application contains distressing content. It updates both the backend logic and the frontend templates to handle and visually indicate distressing content at the representation and application levels. Comprehensive tests have been added to ensure the new behavior works as intended.

**Backend logic and data handling:**
- Added the `distressingContentInRepresentation` field to the representation query in `buildWrittenRepresentationsListPage`, enabling the backend to detect and pass distressing content information for each representation.
- Updated the view data to include `containsDistressingContent` at the application level, ensuring the frontend knows whether to display an application-level warning.

**Frontend display updates:**
- Updated `representation.njk` to show a red "Content warning" tag next to any representation flagged as distressing.
- Modified `view.njk` to use the new `containsDistressingContent` variable for displaying the application-level distressing content banner.

**Testing:**
- Added and extended tests in `controller.test.js` to verify that distressing content tags appear correctly for both representations and applications, and to ensure the logic is robust for all scenarios. [[1]](diffhunk://#diff-f2d56a81d06bfc9881eb26ff43984564c028b150b3859b3c3866bbba3dd5292aR44) [[2]](diffhunk://#diff-f2d56a81d06bfc9881eb26ff43984564c028b150b3859b3c3866bbba3dd5292aR91-R303) [[3]](diffhunk://#diff-f2d56a81d06bfc9881eb26ff43984564c028b150b3859b3c3866bbba3dd5292aR338) [[4]](diffhunk://#diff-f2d56a81d06bfc9881eb26ff43984564c028b150b3859b3c3866bbba3dd5292aR931)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1441
<img width="1495" height="1237" alt="Screenshot 2026-04-07 092658" src="https://github.com/user-attachments/assets/e8092218-2949-44a7-a852-6e15e76040b4" />
