### PR TITLE
Fix/crown 1584 post creation agent addition

### DIFF
--- a/apps/manage/src/app/views/cases/view/journey.js
+++ b/apps/manage/src/app/views/cases/view/journey.js
@@ -287,6 +287,7 @@ export function createJourneyV2(questions, response, req) {
 				.startMultiQuestionCondition('has-agent', hasAgent)
 				.addQuestion(questions.addAgentOrganisationName)
 				.addQuestion(questions.addAgentAddress)
+				.withCondition(hasAgentOrganisationName)
 				.addQuestion(questions.manageAgentContacts, new ManageListSection().addQuestion(questions.agentContactDetails))
 				.withCondition(hasAgentOrganisationName)
 				.endMultiQuestionCondition('has-agent')

--- a/apps/manage/src/app/views/cases/view/view-model.js
+++ b/apps/manage/src/app/views/cases/view/view-model.js
@@ -391,7 +391,18 @@ function buildAgentOrganisationNameUpdates(edits, viewModel) {
 	}
 
 	if (!viewModel.agentOrganisationRelationId) {
-		throw new Error('Unable to find agent organisation for this case - cannot update agent name');
+		return {
+			create: [
+				{
+					Role: { connect: { id: ORGANISATION_ROLES_ID.AGENT } },
+					Organisation: {
+						create: {
+							name: edits.agentOrganisationName
+						}
+					}
+				}
+			]
+		};
 	}
 
 	return {

--- a/apps/manage/src/app/views/cases/view/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/view-model.test.js
@@ -1916,20 +1916,29 @@ describe('view-model', () => {
 			const updates = editsToDatabaseUpdates(toSave, viewModel);
 			assert.strictEqual(updates.Organisations, undefined);
 		});
-		it('should throw when updating agent organisation name without an agent organisation relation id', () => {
+		it('should create new organisation when updating agent organisation name without an agent organisation relation id', () => {
 			const toSave = {
 				agentOrganisationName: 'New agent name'
 			};
 			const viewModel = {
-				agentOrganisationName: 'Old agent name',
+				agentOrganisationName: null,
 				agentOrganisationAddress: null,
 				agentOrganisationRelationId: null
 			};
 
-			assert.throws(
-				() => editsToDatabaseUpdates(toSave, viewModel),
-				/Unable to find agent organisation for this case - cannot update agent name/
-			);
+			const updates = editsToDatabaseUpdates(toSave, viewModel);
+			assert.deepStrictEqual(updates.Organisations, {
+				create: [
+					{
+						Organisation: {
+							create: {
+								name: 'New agent name'
+							}
+						},
+						Role: { connect: { id: 'agent' } }
+					}
+				]
+			});
 		});
 		it('should update agent address', () => {
 			const toSave = {


### PR DESCRIPTION
## Describe your changes
If there is no linked agent organisation to update, create one, instead of throwing an error.
Additionally, make agent address conditional on agent name, to avoid the situation of trying to add an address to an organisation that does not yet exist.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1584