### PR TITLE
feat(lib): allow CrossQuestionValidator to use body values instead of session answers

### DIFF
--- a/packages/lib/validators/cross-question-validator.js
+++ b/packages/lib/validators/cross-question-validator.js
@@ -10,14 +10,28 @@ import { body } from 'express-validator';
  * Validator for validating a question's answer against another question's answer using a custom validation function.
  */
 export default class CrossQuestionValidator extends BaseValidator {
+	/** @type {string} */
+	dependencyFieldName;
+	/** @type {((currentAnswer: any, dependencyAnswer: any) => boolean)} */
+	validationFunction;
+	/** @type {boolean} */
+	useBodyValues;
+
 	/**
 	 * @param {Object} params
 	 * @param {string} params.dependencyFieldName - The field name of the other question to compare against.
 	 * @param {((currentAnswer: any, dependencyAnswer: any) => boolean)| null} params.validationFunction - A function that takes the current question's answer and the other question's answer and returns true if valid, false otherwise.
+	 * @param {boolean} [params.useBodyValues=false] - Whether to use req.body values for validation (default: false). Usually CrossQuestionValidator will be for validating across saved session answers, but if used between multiple fields on one question, it will need to use the body.
 	 * @throws {Error} If validationFunction is not provided or is not a function.
 	 * @throws {Error} If dependencyFieldName is not provided
 	 */
-	constructor({ dependencyFieldName, validationFunction } = { dependencyFieldName: '', validationFunction: null }) {
+	constructor(
+		{ dependencyFieldName, validationFunction, useBodyValues } = {
+			dependencyFieldName: '',
+			validationFunction: null,
+			useBodyValues: false
+		}
+	) {
 		super();
 
 		if (!dependencyFieldName) {
@@ -29,6 +43,7 @@ export default class CrossQuestionValidator extends BaseValidator {
 
 		this.dependencyFieldName = dependencyFieldName;
 		this.validationFunction = validationFunction;
+		this.useBodyValues = useBodyValues ?? false;
 	}
 
 	/**
@@ -42,8 +57,10 @@ export default class CrossQuestionValidator extends BaseValidator {
 		return [
 			body(fieldName).custom((value, { req }) => {
 				const answers = req?.res?.locals?.journeyResponse?.answers || {};
-				const currentAnswer = answers[fieldName];
-				const dependencyAnswer = answers[this.dependencyFieldName];
+				const currentAnswer = this.useBodyValues ? value : answers[fieldName];
+				const dependencyAnswer = this.useBodyValues
+					? req.body[this.dependencyFieldName]
+					: answers[this.dependencyFieldName];
 				return (
 					this.validationFunction(currentAnswer, dependencyAnswer) ||
 					// Fallback if validation fails without throwing an error

--- a/packages/lib/validators/cross-question-validator.test.js
+++ b/packages/lib/validators/cross-question-validator.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from 'node:test';
+import { describe, test, it } from 'node:test';
 import assert from 'node:assert/strict';
 import CrossQuestionValidator from './cross-question-validator.js';
 
@@ -75,6 +75,78 @@ describe('CrossQuestionValidator', () => {
 		const questionObj = { fieldName: 'field' };
 		const chain = validator.validate(questionObj);
 		const req = { res: { locals: {} } };
+		await chain[0].run(req);
+		assert.deepEqual(calledWith, { currentAnswer: undefined, dependencyAnswer: undefined });
+	});
+
+	it('should use session answers instead of request body values when useBodyValues is false', async () => {
+		let calledWith;
+		const validator = new CrossQuestionValidator({
+			dependencyFieldName: 'other',
+			validationFunction: (currentAnswer, dependencyAnswer) => {
+				calledWith = { currentAnswer, dependencyAnswer };
+				return true;
+			}
+		});
+		const questionObj = { fieldName: 'field' };
+		const chain = validator.validate(questionObj);
+		const req = createMockRequest({ field: 'from-session', other: 'from-session-dependency' });
+		req.body = { field: 'from-body', other: 'from-body-dependency' };
+		await chain[0].run(req);
+		assert.deepEqual(calledWith, {
+			currentAnswer: 'from-session',
+			dependencyAnswer: 'from-session-dependency'
+		});
+	});
+
+	it('should use request body values when useBodyValues is true', async () => {
+		let calledWith;
+		const validator = new CrossQuestionValidator({
+			dependencyFieldName: 'other',
+			useBodyValues: true,
+			validationFunction: (currentAnswer, dependencyAnswer) => {
+				calledWith = { currentAnswer, dependencyAnswer };
+				return true;
+			}
+		});
+		const questionObj = { fieldName: 'field' };
+		const chain = validator.validate(questionObj);
+		const req = createMockRequest({ field: 'from-session', other: 'from-session-dependency' });
+		req.body = { field: 'from-body', other: 'from-body-dependency' };
+		await chain[0].run(req);
+		assert.deepEqual(calledWith, {
+			currentAnswer: 'from-body',
+			dependencyAnswer: 'from-body-dependency'
+		});
+	});
+
+	it('should fail validation with thrown error message when validation function throws', async () => {
+		const validator = new CrossQuestionValidator({
+			dependencyFieldName: 'other',
+			validationFunction: () => {
+				throw new Error('boom');
+			}
+		});
+		const questionObj = { fieldName: 'field' };
+		const chain = validator.validate(questionObj);
+		const req = createMockRequest({ field: 'foo', other: 'bar' });
+		const result = await chain[0].run(req);
+		assert.strictEqual(result.isEmpty(), false);
+		assert.strictEqual(result.array()[0].msg, 'boom');
+	});
+
+	it('should call validation function with undefined values when journeyResponse has no answers object', async () => {
+		let calledWith;
+		const validator = new CrossQuestionValidator({
+			dependencyFieldName: 'other',
+			validationFunction: (currentAnswer, dependencyAnswer) => {
+				calledWith = { currentAnswer, dependencyAnswer };
+				return true;
+			}
+		});
+		const questionObj = { fieldName: 'field' };
+		const chain = validator.validate(questionObj);
+		const req = { res: { locals: { journeyResponse: {} } } };
 		await chain[0].run(req);
 		assert.deepEqual(calledWith, { currentAnswer: undefined, dependencyAnswer: undefined });
 	});


### PR DESCRIPTION
## Describe your changes
`CrossQuestionValidator` as built is designed to compare values between different answers in the session. However, if used on a multi-field input question, these values have not yet been saved to the session and are in the express body (like other standard validation behaviour). I've added the `useBodyValues` toggle to this validator to allow it to be used in that situation as well.
Also tests for the above, and explicitly specifying class properties.

Note that usage of `test` has already been corrected to `it` for other tests in https://github.com/Planning-Inspectorate/crown-developments/pull/905, so I've not addressed that here.

## Issue ticket number and link
N/A