### PR TITLE
Feat/upgrade govuk frontend

### DIFF
--- a/apps/manage/src/app/app.js
+++ b/apps/manage/src/app/app.js
@@ -69,7 +69,6 @@ export function getApp(service) {
 	const nunjucksEnvironment = configureNunjucks();
 	// Set the express view engine to nunjucks
 	// calls to res.render will use nunjucks
-	nunjucksEnvironment.addGlobal('govukRebrand', true);
 	nunjucksEnvironment.express(app);
 	app.set('view engine', 'njk');
 

--- a/apps/manage/src/app/sass/header.scss
+++ b/apps/manage/src/app/sass/header.scss
@@ -39,6 +39,67 @@ nav.govuk-header__navigation.pins-header-navigation {
 	}
 }
 
+// Temporary fix to get old header working with govuk-frontend > 6
+// TODO remove in CROWN-1510
+.pins-header-navigation {
+	.govuk-header__navigation-list {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		.govuk-header__navigation-item {
+			padding: govuk.govuk-spacing(2) 0;
+
+			@media #{govuk.govuk-from-breakpoint(desktop)} {
+				display: inline-block;
+				margin-right: govuk.govuk-spacing(3);
+				padding: govuk.govuk-spacing(1) 0;
+				border: 0;
+			}
+
+			a {
+				@include govuk.govuk-font-size($size: 16);
+				@include govuk.govuk-typography-weight-regular;
+				white-space: nowrap;
+			}
+		}
+
+		.govuk-header__navigation-item--active {
+			a {
+				@include govuk.govuk-typography-weight-bold;
+
+				&:link,
+				&:hover,
+				&:visited {
+					color: inherit;
+				}
+
+				&:focus {
+					color: govuk.$govuk-focus-text-colour;
+				}
+			}
+		}
+	}
+	.govuk-header__link {
+		@include govuk.govuk-link-style-inverse;
+
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+			text-decoration-thickness: 3px;
+
+			@if govuk.$govuk-link-underline-offset {
+				text-underline-offset: govuk.$govuk-link-underline-offset;
+			}
+		}
+
+		&:focus {
+			@include govuk.govuk-focused-text;
+		}
+	}
+}
+// End section to remove in CROWN-1510
+
 #pins-header {
 	background: govuk.govuk-colour('white');
 	color: govuk.govuk-colour('black');

--- a/apps/manage/src/app/sass/header.scss
+++ b/apps/manage/src/app/sass/header.scss
@@ -2,7 +2,7 @@
 @use 'sass:map';
 
 /// pins colours
-$pins-colours-grey-100: govuk.govuk-colour('light-grey');
+$pins-colours-grey-100: govuk.govuk-colour('black', $variant: 'tint-95');
 $pins-colours-blue-500: govuk.govuk-colour('blue');
 $pins-colours-green-200: #13a19b;
 $pins-colours-teal-100: #10847e;

--- a/apps/manage/src/app/sass/style.scss
+++ b/apps/manage/src/app/sass/style.scss
@@ -36,7 +36,7 @@ $font-family: arial, helvetica, sans-serif;
 }
 
 .filter-container {
-	background-color: govuk.govuk-colour('light-grey');
+	background-color: govuk.govuk-colour('black', $variant: 'tint-95');
 }
 
 .filter-box {
@@ -55,9 +55,9 @@ $font-family: arial, helvetica, sans-serif;
 	padding: govuk.govuk-spacing(5) govuk.govuk-spacing(5) 1px;
 	margin-bottom: govuk.govuk-spacing(7);
 	box-shadow:
-		0 2px 0 govuk.govuk-colour('mid-grey'),
-		inset 2px 0 0 govuk.govuk-colour('mid-grey'),
-		inset -2px 0 0 govuk.govuk-colour('mid-grey'),
+		0 2px 0 govuk.govuk-colour('black', $variant: 'tint-80'),
+		inset 2px 0 0 govuk.govuk-colour('black', $variant: 'tint-80'),
+		inset -2px 0 0 govuk.govuk-colour('black', $variant: 'tint-80'),
 		inset 0 4px 0 govuk.govuk-colour('blue');
 
 	&--title {

--- a/apps/manage/src/app/views/layouts/main.njk
+++ b/apps/manage/src/app/views/layouts/main.njk
@@ -22,7 +22,7 @@
 	{{ header('Manage a Crown Development Application') }}
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 	<script {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>
 		document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 	</script>

--- a/apps/portal/src/app/app.js
+++ b/apps/portal/src/app/app.js
@@ -45,7 +45,6 @@ export function getApp(service) {
 	const nunjucksEnvironment = configureNunjucks();
 	// Set the express view engine to nunjucks
 	// calls to res.render will use nunjucks
-	nunjucksEnvironment.addGlobal('govukRebrand', true);
 	nunjucksEnvironment.express(app);
 	app.set('view engine', 'njk');
 

--- a/apps/portal/src/app/sass/components/application-links.scss
+++ b/apps/portal/src/app/sass/components/application-links.scss
@@ -8,8 +8,8 @@
 		margin-left: calc(-0.7em);
 	}
 	li.application-links__active {
-		background-color: govuk.govuk-colour('light-grey');
+		background-color: govuk.govuk-colour('black', $variant: 'tint-95');
 		margin-left: calc(-0.7em - 6px);
-		border-left: 6px solid govuk.govuk-colour('turquoise');
+		border-left: 6px solid govuk.govuk-colour('teal');
 	}
 }

--- a/apps/portal/src/app/sass/components/document-list.scss
+++ b/apps/portal/src/app/sass/components/document-list.scss
@@ -6,12 +6,12 @@
 	li {
 		@extend .govuk-\!-margin-0, .govuk-\!-padding-top-2, .govuk-\!-padding-bottom-5;
 
-		border-top: 1px solid govuk.$govuk-border-colour;
+		border-top: 1px solid govuk.govuk-functional-colour('border');
 	}
 
 	&__meta-data {
 		@extend .govuk-\!-margin-top-1;
-		color: govuk.$govuk-secondary-text-colour;
+		color: govuk.govuk-functional-colour('secondary-text');
 		display: grid;
 		grid-template-columns: 1fr 1fr 1fr;
 	}

--- a/apps/portal/src/app/sass/components/pins-chevron-cards.scss
+++ b/apps/portal/src/app/sass/components/pins-chevron-cards.scss
@@ -2,7 +2,7 @@
 
 .pins-chevron-card {
 	&__wrapper {
-		border-top: 1px solid govuk.govuk-colour('mid-grey');
+		border-top: 1px solid govuk.govuk-colour('black', $variant: 'tint-80');
 		padding: 15px 0;
 		margin-bottom: 20px;
 	}

--- a/apps/portal/src/app/sass/components/pins-filter-accordion.scss
+++ b/apps/portal/src/app/sass/components/pins-filter-accordion.scss
@@ -28,7 +28,7 @@
 	}
 
 	&__section {
-		border-bottom: 1px solid govuk.govuk-colour('mid-grey');
+		border-bottom: 1px solid govuk.govuk-colour('black', $variant: 'tint-80');
 		padding: 1rem 0 0 0.9375rem;
 	}
 
@@ -80,8 +80,8 @@
 
 .filter-selected-tag {
 	margin: 0;
-	background: govuk.govuk-colour('light-grey');
-	border: solid 1px govuk.govuk-colour('mid-grey');
+	background: govuk.govuk-colour('black', $variant: 'tint-95');
+	border: solid 1px govuk.govuk-colour('black', $variant: 'tint-80');
 	padding: 4px 12px;
 
 	&__remove-button {

--- a/apps/portal/src/app/sass/components/pins-navigation.scss
+++ b/apps/portal/src/app/sass/components/pins-navigation.scss
@@ -1,7 +1,7 @@
 @use 'node_modules/govuk-frontend/dist/govuk/index' as govuk;
 
 .pins-navigation {
-	box-shadow: 0 0 0 100vmax govuk.govuk-colour('light-grey');
+	box-shadow: 0 0 0 100vmax govuk.govuk-colour('black', $variant: 'tint-95');
 	clip-path: inset(0 -100vmax);
 	border-bottom: none;
 }

--- a/apps/portal/src/app/sass/style.scss
+++ b/apps/portal/src/app/sass/style.scss
@@ -49,7 +49,7 @@
 .pins-application-stage-summary-row {
 	display: block;
 	width: 100%;
-	border-bottom: 1px solid govuk.govuk-colour('mid-grey');
+	border-bottom: 1px solid govuk.govuk-colour('black', $variant: 'tint-80');
 }
 .pins-application-stage-summary-row:last-child {
 	border-bottom: none;

--- a/apps/portal/src/app/views/applications/list/view.njk
+++ b/apps/portal/src/app/views/applications/list/view.njk
@@ -6,7 +6,7 @@
 
 {% block pageHeading %}{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
     <div class="govuk-width-container">
         {% include "views/layouts/components/core/intro-to-service.njk" %}
     </div>

--- a/apps/portal/src/app/views/applications/view/written-representations/read-more/view.njk
+++ b/apps/portal/src/app/views/applications/view/written-representations/read-more/view.njk
@@ -6,7 +6,7 @@
 
 {% block pageHeading %}{% endblock %}
 
-{% block beforeContent %}{% endblock %}
+{% block containerStart %}{% endblock %}
 
 {% block pageContent %}
 <div class="govuk-grid-row">

--- a/apps/portal/src/app/views/layouts/components/core/footer.njk
+++ b/apps/portal/src/app/views/layouts/components/core/footer.njk
@@ -1,7 +1,7 @@
 <footer class="govuk-footer govuk-!-padding-bottom-8" role="contentinfo">
 	<div class="govuk-width-container">
 		<div class="govuk-footer__meta">
-			<div class="govuk-footer__meta-item govuk-footer__meta-item--grow govuk-!-margin-bottom-0">
+			<div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
 				<h2 class="govuk-visually-hidden">Support links</h2>
 
 				<ul class="govuk-footer__inline-list">

--- a/apps/portal/src/app/views/layouts/main.njk
+++ b/apps/portal/src/app/views/layouts/main.njk
@@ -58,7 +58,7 @@
 	{% include "views/layouts/components/core/header.njk" %}
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 	<script {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>
 		document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 	</script>

--- a/apps/portal/src/app/views/static/detailed-information/view.njk
+++ b/apps/portal/src/app/views/static/detailed-information/view.njk
@@ -2,7 +2,7 @@
 
 {% from "chevron-card/chevron-card.njk" import chevronCard %}
 
-{% block beforeContent %}
+{% block containerStart %}
     <div class="govuk-width-container">
 <div class="govuk-grid-row pins-info-container">
   <div class="govuk-grid-column-two-thirds">

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "express-session": "^1.19.0",
         "express-validator": "^7.3.1",
         "file-type": "^21.3.4",
-        "govuk-frontend": "^5.14.0",
+        "govuk-frontend": "^6.1.0",
         "helmet": "^8.1.0",
         "multer": "^2.1.1",
         "notifications-node-client": "^8.3.0",
@@ -4403,9 +4403,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
+      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@azure/identity": "^4.13.1",
         "@azure/msal-node": "^5.1.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@ministryofjustice/frontend": "^8.0.0",
+        "@ministryofjustice/frontend": "^9.0.0",
         "@planning-inspectorate/dynamic-forms": "^3.7.1",
         "@prisma/adapter-mssql": "^7.5.0",
         "@prisma/client": "^7.5.0",
@@ -1204,15 +1204,15 @@
       "license": "MIT"
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-8.0.0.tgz",
-      "integrity": "sha512-hVWJAFfVdIc+azwFJ3eZQRIuG3BW83wtTwjZDPvxCCUrY6wvGQLSoBOxExFb+1C+cvzM02WkTj0kS46zku7YhA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-9.0.0.tgz",
+      "integrity": "sha512-R63EvHq//lONAhpUfZCMfxlUHoysDx5Hc6mi9EEV+sfVGm2spGV52PJAkYCYAc3bhTaTiJDtEM+PXgJm0iTWvQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.11.2",
+        "govuk-frontend": "^6.0.0",
         "moment": "2.30.1"
       }
     },
@@ -4217,6 +4217,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@azure/identity": "^4.13.1",
     "@azure/msal-node": "^5.1.1",
     "@microsoft/microsoft-graph-client": "^3.0.7",
-    "@ministryofjustice/frontend": "^8.0.0",
+    "@ministryofjustice/frontend": "^9.0.0",
     "@planning-inspectorate/dynamic-forms": "^3.7.1",
     "@prisma/adapter-mssql": "^7.5.0",
     "@prisma/client": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "express-session": "^1.19.0",
     "express-validator": "^7.3.1",
     "file-type": "^21.3.4",
-    "govuk-frontend": "^5.14.0",
+    "govuk-frontend": "^6.1.0",
     "helmet": "^8.1.0",
     "multer": "^2.1.1",
     "notifications-node-client": "^8.3.0",

--- a/packages/lib/util/build.js
+++ b/packages/lib/util/build.js
@@ -69,20 +69,17 @@ async function copyAssets({ staticDir, govUkRoot, mojRoot }) {
 	const fonts = path.join(govUkRoot, 'node_modules/govuk-frontend/dist/govuk/assets/fonts');
 	const js = path.join(govUkRoot, 'node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js');
 	const manifest = path.join(govUkRoot, 'node_modules/govuk-frontend/dist/govuk/assets/manifest.json');
-	const rebrand = path.join(govUkRoot, 'node_modules/govuk-frontend/dist/govuk/assets/rebrand');
 
 	const staticImages = path.join(staticDir, 'assets', 'images');
 	const staticFonts = path.join(staticDir, 'assets', 'fonts');
 	const staticJs = path.join(staticDir, 'assets', 'js', 'govuk-frontend.min.js');
 	const staticManifest = path.join(staticDir, 'assets', 'manifest.json');
-	const staticRebrand = path.join(staticDir, 'assets', 'rebrand');
 
 	// copy all images and fonts for govuk-frontend
 	await copyFolder(images, staticImages);
 	await copyFolder(fonts, staticFonts);
 	await copyFile(js, staticJs);
 	await copyFile(manifest, staticManifest);
-	await copyFolder(rebrand, staticRebrand);
 
 	const mojImages = path.join(mojRoot, 'node_modules/@ministryofjustice/frontend/moj/assets/images');
 	const mojJs = path.join(mojRoot, 'node_modules/@ministryofjustice/frontend/moj/moj-frontend.min.js');


### PR DESCRIPTION
## Describe your changes
Changed required for compatibility with `govuk-frontend@>=6.0.0`:

1. Update MOJ frontend package to latest version for compatibility
2. Remove deprecated rebrand assets and feature flag from nunjucks environment
3. Change deprecated `beforeContent` block name to `containerStart`
4. Replace deprecated `mid-grey` and `light-grey` with suggested replacements
5. Shim the styles of the old back office header for now (since not ready to roll out new replacement)
6. Minor tweak to front office footer so it doesn't look terrible - footer will be fully updated in CROWN-1506

There is a compilation warning, however this is due to MOJ frontend not yet addressing a deprecation in `govuk-frontend@6.1.0`.

## Issue ticket number and link
N/A