### PR TITLE
fix(portal): remove caching middleware from non-document pages

### DIFF
--- a/apps/portal/src/app/views/applications/index.js
+++ b/apps/portal/src/app/views/applications/index.js
@@ -2,7 +2,6 @@ import { Router as createRouter } from 'express';
 import { createRoutes as createViewRoutes } from './view/index.js';
 import { buildApplicationListPage } from './list/controller.js';
 import { asyncHandler } from '@pins/crowndev-lib/util/async-handler.js';
-import { buildCachingDynamicContentMiddleware } from '../util/caching-middleware.js';
 
 /**
  * @param {import('#service').PortalService} service
@@ -12,9 +11,8 @@ export function createRoutes(service) {
 	const router = createRouter({ mergeParams: true });
 
 	const applicationListController = buildApplicationListPage(service);
-	const cachingMiddleware = buildCachingDynamicContentMiddleware(service);
 
-	router.get('/applications', cachingMiddleware, asyncHandler(applicationListController));
+	router.get('/applications', asyncHandler(applicationListController));
 	router.use('/applications/:applicationId', createViewRoutes(service));
 
 	return router;

--- a/apps/portal/src/app/views/applications/view/index.js
+++ b/apps/portal/src/app/views/applications/view/index.js
@@ -26,21 +26,11 @@ export function createRoutes(service) {
 	const isPublishedAndNotWithdrawnOrExpired = checkIfWithdrawnOrExpiredMiddleware(service);
 	const cachingMiddleware = buildCachingDynamicContentMiddleware(service);
 
-	router.get('/application-information', cachingMiddleware, asyncHandler(applicationInfoController));
-	router.get(
-		'/application-updates',
-		isPublishedAndNotExpired,
-		cachingMiddleware,
-		asyncHandler(applicationUpdatesController)
-	);
-	router.get('/documents', isPublishedAndNotExpired, cachingMiddleware, asyncHandler(applicationDocumentsPage));
+	router.get('/application-information', asyncHandler(applicationInfoController));
+	router.get('/application-updates', isPublishedAndNotExpired, asyncHandler(applicationUpdatesController));
+	router.get('/documents', isPublishedAndNotExpired, asyncHandler(applicationDocumentsPage));
 	router.get('/documents/:documentId', isPublishedAndNotExpired, cachingMiddleware, asyncHandler(viewDocumentPage));
-	router.get(
-		'/detailed-information',
-		isPublishedAndNotExpired,
-		cachingMiddleware,
-		asyncHandler(buildDetailedInformationPage)
-	);
+	router.get('/detailed-information', isPublishedAndNotExpired, asyncHandler(buildDetailedInformationPage));
 	router.use('/have-your-say', isPublishedAndNotWithdrawnOrExpired, haveYourSayPageRoutes);
 	router.use('/written-representations', isPublishedAndNotExpired, writtenRepresentationsRoutes);
 


### PR DESCRIPTION
## Describe your changes
This pull request removes the use of the `cachingMiddleware` from several application routes in the portal.
These changes are put in place due to issues with caching and cookie choice.
Removed caching middleware from application routes:

* In `apps/portal/src/app/views/applications/index.js`, the `cachingMiddleware` is no longer imported or used for the `/applications` route. [[1]](diffhunk://#diff-9934d35b6a098600327ab0e3144d9f3b5d590f6089c4b331232cf50bf9fb8e4bL5) [[2]](diffhunk://#diff-9934d35b6a098600327ab0e3144d9f3b5d590f6089c4b331232cf50bf9fb8e4bL15-R15)
* In `apps/portal/src/app/views/applications/view/index.js`, the `cachingMiddleware` has been removed from the following routes:
  - `/application-information`
  - `/application-updates`
  - `/documents`
  - `/detailed-information`
  These routes now use only the relevant status-check middleware and async handlers.

Retained caching for document viewing:

* The `cachingMiddleware` is still applied to the `/documents/:documentId` route, so caching remains enabled for individual document views.
## Issue ticket number and link
