### PR TITLE
Feat/crown 1595 convert seed data to typescript

### DIFF
--- a/apps/manage/src/app/notify/controller.js
+++ b/apps/manage/src/app/notify/controller.js
@@ -1,4 +1,4 @@
-import { NOTIFICATION_SOURCE } from '@pins/crowndev-database/src/seed/data-static.js';
+import { NOTIFICATION_SOURCE } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 /**
  *

--- a/apps/manage/src/app/notify/controller.test.js
+++ b/apps/manage/src/app/notify/controller.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { test, describe, beforeEach, mock } from 'node:test';
 import { buildNotifyCallbackController, findMissingReference, getNotificationSource } from './controller.js';
 import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
-import { NOTIFICATION_SOURCE } from '@pins/crowndev-database/src/seed/data-static.js';
+import { NOTIFICATION_SOURCE } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('findMissingReference', () => {
 	test('should extract representation reference', () => {

--- a/apps/manage/src/app/views/cases/create-a-case/questions.js
+++ b/apps/manage/src/app/views/cases/create-a-case/questions.js
@@ -6,8 +6,8 @@ import { createQuestions } from '@planning-inspectorate/dynamic-forms/src/questi
 import { questionClasses } from '@planning-inspectorate/dynamic-forms/src/questions/questions.js';
 import { COMPONENT_TYPES } from '@planning-inspectorate/dynamic-forms';
 import { APPLICATION_TYPES, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.js';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.js';
+import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.ts';
+import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.ts';
 import { contactQuestions, multiContactQuestions } from './question-utils.js';
 import { ENVIRONMENT_NAME, loadEnvironmentConfig } from '../../../config.js';
 import AddressValidator from '@planning-inspectorate/dynamic-forms/src/validator/address-validator.js';

--- a/apps/manage/src/app/views/cases/create-a-case/questions.js
+++ b/apps/manage/src/app/views/cases/create-a-case/questions.js
@@ -5,7 +5,7 @@ import NumericValidator from '@planning-inspectorate/dynamic-forms/src/validator
 import { createQuestions } from '@planning-inspectorate/dynamic-forms/src/questions/create-questions.js';
 import { questionClasses } from '@planning-inspectorate/dynamic-forms/src/questions/questions.js';
 import { COMPONENT_TYPES } from '@planning-inspectorate/dynamic-forms';
-import { APPLICATION_TYPES, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_TYPES, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.js';
 import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.js';
 import { contactQuestions, multiContactQuestions } from './question-utils.js';

--- a/apps/manage/src/app/views/cases/create-a-case/save.js
+++ b/apps/manage/src/app/views/cases/create-a-case/save.js
@@ -8,7 +8,7 @@ import {
 	APPLICATION_SUB_TYPE_ID,
 	APPLICATION_TYPE_ID,
 	ORGANISATION_ROLES_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { getLinkedCaseId, hasLinkedCase as hasLinkedCaseFunction } from '@pins/crowndev-lib/util/linked-case.js';
 import { extractAgentContactFields, extractApplicantContactFields } from '../util/contact.js';
 import { getRecipientEmails } from '../view/notification.js';

--- a/apps/manage/src/app/views/cases/view/application-updates/controller.js
+++ b/apps/manage/src/app/views/cases/view/application-updates/controller.js
@@ -8,7 +8,7 @@ import {
 	readAppUpdateStatus,
 	validateParams
 } from './utils.js';
-import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 
 export function buildApplicationUpdates({ db }) {

--- a/apps/manage/src/app/views/cases/view/application-updates/create/controller.js
+++ b/apps/manage/src/app/views/cases/view/application-updates/create/controller.js
@@ -1,7 +1,7 @@
 import { getAnswers } from '@pins/crowndev-lib/util/answers.js';
 import { clearDataFromSession } from '@planning-inspectorate/dynamic-forms/src/lib/session-answer-store.js';
 import { JOURNEY_ID } from '../journey.js';
-import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { addAppUpdateStatus } from '../utils.js';
 
 export function buildCreateController() {

--- a/apps/manage/src/app/views/cases/view/application-updates/review/controller.js
+++ b/apps/manage/src/app/views/cases/view/application-updates/review/controller.js
@@ -1,6 +1,6 @@
 import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
 import { formatDateForDisplay } from '@planning-inspectorate/dynamic-forms/src/lib/date-utils.js';
-import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import {
 	addAppUpdateStatus,
 	clearAppUpdatesFromSession,

--- a/apps/manage/src/app/views/cases/view/application-updates/unpublish/controller.js
+++ b/apps/manage/src/app/views/cases/view/application-updates/unpublish/controller.js
@@ -1,5 +1,5 @@
 import { addAppUpdateStatus, validateParams } from '../utils.js';
-import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 export function buildUnpublishUpdateController({ db, logger }) {
 	return async (req, res) => {

--- a/apps/manage/src/app/views/cases/view/controller.js
+++ b/apps/manage/src/app/views/cases/view/controller.js
@@ -10,7 +10,7 @@ import { dateIsBeforeToday, dateIsToday } from '@planning-inspectorate/dynamic-f
 import { clearSessionData, readSessionData } from '@pins/crowndev-lib/util/session.js';
 import { caseReferenceToFolderName } from '@pins/crowndev-lib/util/sharepoint-path.js';
 import { getLinkedCaseId, getLinkedCaseLinkText, hasLinkedCase } from '@pins/crowndev-lib/util/linked-case.js';
-import { APPLICATION_SUB_TYPE_ID, APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_SUB_TYPE_ID, APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { filteredStagesToRadioOptions } from './question-utils.js';
 import { clearDataFromSession } from '@planning-inspectorate/dynamic-forms/src/lib/session-answer-store.js';
 import { yesNoToBoolean } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';

--- a/apps/manage/src/app/views/cases/view/delete.js
+++ b/apps/manage/src/app/views/cases/view/delete.js
@@ -1,4 +1,4 @@
-import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { addSessionData, clearSessionData, readSessionData } from '@pins/crowndev-lib/util/session.js';
 
 export const questionConfig = {

--- a/apps/manage/src/app/views/cases/view/journey.js
+++ b/apps/manage/src/app/views/cases/view/journey.js
@@ -9,7 +9,7 @@ import {
 	APPLICATION_PROCEDURE_ID,
 	APPLICATION_SUB_TYPE_ID,
 	APPLICATION_TYPE_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { yesNoToBoolean } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 import { ManageListSection } from '@planning-inspectorate/dynamic-forms/src/components/manage-list/manage-list-section.js';
 export const JOURNEY_ID = 'case-details';

--- a/apps/manage/src/app/views/cases/view/journey.test.js
+++ b/apps/manage/src/app/views/cases/view/journey.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { createJourney, createJourneyV2, JOURNEY_ID } from './journey.js';
 import { getQuestions } from './questions.js';
 import { JourneyResponse } from '@planning-inspectorate/dynamic-forms/src/journey/journey-response.js';
-import { APPLICATION_PROCEDURE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_PROCEDURE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('case details journey', () => {
 	it('should error if used with the wrong router structure', () => {

--- a/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
@@ -11,7 +11,7 @@ import {
 	deleteRepresentationAttachmentsFolder,
 	moveAttachmentsToCaseFolder
 } from '@pins/crowndev-lib/util/handle-attachments.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { getRepresentationWithdrawalRequestsFolder } from '../withdraw/controller.js';
 
 /**

--- a/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.test.js
@@ -5,7 +5,7 @@ import { buildUpdateRepresentation } from './controller.js';
 import {
 	REPRESENTATION_STATUS_ID,
 	REPRESENTATION_SUBMITTED_FOR_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 import { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/list/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/list/controller.js
@@ -1,6 +1,6 @@
 import { representationsToViewModel } from './view-model.js';
 import { clearRepReviewedSession, readRepReviewedSession } from '../review/controller.js';
-import { REPRESENTATION_STATUS } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { createWhereClause, splitStringQueries } from '@pins/crowndev-lib/util/search-queries.js';
 import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
 import { getPageData, getPaginationParams } from '@pins/crowndev-lib/views/pagination/pagination-utils.js';

--- a/apps/manage/src/app/views/cases/view/manage-reps/list/view-model.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/list/view-model.js
@@ -1,5 +1,5 @@
 import { formatDateForDisplay } from '@planning-inspectorate/dynamic-forms/src/lib/date-utils.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { nameToViewModel } from '@pins/crowndev-lib/util/name.js';
 
 /**

--- a/apps/manage/src/app/views/cases/view/manage-reps/list/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/list/view-model.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { representationsToViewModel, representationToViewModel } from './view-model.js';
 import assert from 'node:assert';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('view-model', () => {
 	describe('representationsToViewModel', () => {

--- a/apps/manage/src/app/views/cases/view/manage-reps/manage-reps-utils.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/manage-reps-utils.js
@@ -1,4 +1,4 @@
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 export function generateJourneyTitle(statusId) {
 	return statusId === REPRESENTATION_STATUS_ID.AWAITING_REVIEW ? 'Review Representation' : 'View Representation';

--- a/apps/manage/src/app/views/cases/view/manage-reps/reinstate/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/reinstate/controller.js
@@ -1,6 +1,6 @@
 import { validateParams } from '../view/controller.js';
 import { wrapPrismaError } from '@pins/crowndev-lib/util/database.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 export function reinstateRepConfirmation(req, res) {
 	const { id, representationRef } = validateParams(req.params);

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/controller.js
@@ -1,4 +1,4 @@
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { ACCEPT_AND_REDACT } from '@pins/crowndev-lib/forms/representations/questions.js';
 import { renderRepresentation, validateParams } from '../view/controller.js';
 import { addSessionData, clearSessionData, readSessionData } from '@pins/crowndev-lib/util/session.js';

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/controller.test.js
@@ -12,7 +12,7 @@ import {
 import { JourneyResponse } from '@planning-inspectorate/dynamic-forms/src/journey/journey-response.js';
 import { ACCEPT_AND_REDACT, getQuestions } from '@pins/crowndev-lib/forms/representations/questions.js';
 import { createJourney } from '../view/journey.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
 import { assertRenders404Page } from '@pins/crowndev-lib/testing/custom-asserts.js';
 import { ReadableStream } from 'node:stream/web';

--- a/apps/manage/src/app/views/cases/view/manage-reps/validation-middleware.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/validation-middleware.js
@@ -1,4 +1,4 @@
-import { REPRESENTATION_SUBMITTED_FOR_ID, REPRESENTED_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_SUBMITTED_FOR_ID, REPRESENTED_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
 import { addSessionData } from '@pins/crowndev-lib/util/session.js';
 import { fileAlreadyExistsInFolder } from '@pins/crowndev-lib/forms/custom-components/representation-attachments/document-validation-util.js';

--- a/apps/manage/src/app/views/cases/view/manage-reps/validation-middleware.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/validation-middleware.test.js
@@ -5,7 +5,7 @@ import {
 	REPRESENTATION_CATEGORY_ID,
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	REPRESENTED_TYPE_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
 import { assertRenders404Page } from '@pins/crowndev-lib/testing/custom-asserts.js';
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/controller.js
@@ -10,7 +10,7 @@ import {
 	REPRESENTATION_STATUS_ID,
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	RECEIVED_METHOD_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { getSubmittedForId } from '@pins/crowndev-lib/util/questions.js';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/controller.test.js
@@ -6,7 +6,7 @@ import { buildGetJourneyMiddleware, validateParams, viewRepresentation } from '.
 import { JourneyResponse } from '@planning-inspectorate/dynamic-forms/src/journey/journey-response.js';
 import { createJourney } from './journey.js';
 import { getQuestions } from '@pins/crowndev-lib/forms/representations/questions.js';
-import { RECEIVED_METHOD_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { RECEIVED_METHOD_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import nunjucks from 'nunjucks';
 
 describe('controller', () => {

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/journey.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/journey.js
@@ -1,7 +1,7 @@
 import { Journey } from '@planning-inspectorate/dynamic-forms/src/journey/journey.js';
 import { haveYourSayManageSections } from '@pins/crowndev-lib/forms/representations/sections.js';
 import { generateJourneyTitle } from '../manage-reps-utils.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 export const JOURNEY_ID = 'manage-representations';
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/withdraw/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/withdraw/controller.js
@@ -2,7 +2,7 @@ import { clearDataFromSession } from '@planning-inspectorate/dynamic-forms/src/l
 import { JOURNEY_ID } from './journey.js';
 import { validateParams } from '../view/controller.js';
 import { wrapPrismaError } from '@pins/crowndev-lib/util/database.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import {
 	deleteRepresentationAttachmentsFolder,
 	moveAttachmentsToCaseFolder

--- a/apps/manage/src/app/views/cases/view/organisation-contact-updates.test.ts
+++ b/apps/manage/src/app/views/cases/view/organisation-contact-updates.test.ts
@@ -11,7 +11,7 @@ import {
 	buildApplicantOrganisationUpdates,
 	buildApplicantContactOrganisationUpdates
 } from './organisation-contact-updates.ts';
-import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('organisation/contact updates', () => {
 	describe('hasOrganisationWriteEdits', () => {

--- a/apps/manage/src/app/views/cases/view/organisation-contact-updates.ts
+++ b/apps/manage/src/app/views/cases/view/organisation-contact-updates.ts
@@ -1,4 +1,4 @@
-import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { optionalWhere } from '@pins/crowndev-lib/util/database.js';
 import { viewModelToAddressUpdateInput, isAddress, isSameAddress } from '@pins/crowndev-lib/util/address.ts';
 import { extractApplicantContactFields, extractAgentContactFields } from '../util/contact.js';

--- a/apps/manage/src/app/views/cases/view/question-utils.js
+++ b/apps/manage/src/app/views/cases/view/question-utils.js
@@ -9,7 +9,7 @@ import {
 	APPLICATION_PROCEDURE_ID,
 	APPLICATION_STAGE,
 	APPLICATION_STAGE_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { CUSTOM_COMPONENTS } from '@pins/crowndev-lib/forms/custom-components/index.js';
 import CILAmountValidator from '@pins/crowndev-lib/forms/custom-components/cil-amount/cil-amount-validator.js';
 import { camelCaseToUrlCase, camelCaseToSentenceCase, sentenceCase } from '@pins/crowndev-lib/util/string.js';

--- a/apps/manage/src/app/views/cases/view/question-utils.test.js
+++ b/apps/manage/src/app/views/cases/view/question-utils.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { contactQuestions, dateQuestion, eventQuestions, filteredStagesToRadioOptions } from './question-utils.js';
-import { APPLICATION_PROCEDURE_ID, APPLICATION_STAGE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_PROCEDURE_ID, APPLICATION_STAGE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('question-utils', () => {
 	describe('contactQuestions', () => {

--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -13,7 +13,7 @@ import {
 	APPLICATION_TYPES,
 	CATEGORIES,
 	ORGANISATION_ROLES_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.js';
 import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.js';
 import {

--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -14,8 +14,8 @@ import {
 	CATEGORIES,
 	ORGANISATION_ROLES_ID
 } from '@pins/crowndev-database/src/seed/data-static.ts';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.js';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.js';
+import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.ts';
+import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.ts';
 import {
 	contactQuestions,
 	dateQuestion,

--- a/apps/manage/src/app/views/cases/view/update-case.js
+++ b/apps/manage/src/app/views/cases/view/update-case.js
@@ -12,7 +12,7 @@ import {
 	executeCaseUpdateWritePlan
 } from './organisation-contact-updates.ts';
 import { wrapPrismaError } from '@pins/crowndev-lib/util/database.js';
-import { APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 /**
  * @param {import('#service').ManageService} service

--- a/apps/manage/src/app/views/cases/view/update-case.test.js
+++ b/apps/manage/src/app/views/cases/view/update-case.test.js
@@ -2,7 +2,7 @@ import { describe, it, mock } from 'node:test';
 import { buildUpdateCase } from './update-case.js';
 import assert from 'node:assert';
 import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
-import { APPLICATION_PROCEDURE_ID, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_PROCEDURE_ID, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 

--- a/apps/manage/src/app/views/cases/view/view-model.js
+++ b/apps/manage/src/app/views/cases/view/view-model.js
@@ -2,7 +2,7 @@ import {
 	APPLICATION_PROCEDURE_ID,
 	APPLICATION_STAGE_ID,
 	ORGANISATION_ROLES_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { toFloat, toInt } from '@pins/crowndev-lib/util/numbers.js';
 import { booleanToYesNoValue } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 import { optionalWhere } from '@pins/crowndev-lib/util/database.js';

--- a/apps/manage/src/app/views/cases/view/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/view-model.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { crownDevelopmentToViewModel, editsToDatabaseUpdates } from './view-model.js';
-import { APPLICATION_PROCEDURE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_PROCEDURE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 /**
  * @typedef {import('@pins/crowndev-database').Prisma.CrownDevelopmentGetPayload<{

--- a/apps/portal/src/app/views/applications/view/application-info/application-stage/controller.js
+++ b/apps/portal/src/app/views/applications/view/application-info/application-stage/controller.js
@@ -2,7 +2,7 @@ import {
 	APPLICATION_PROCEDURE,
 	APPLICATION_STAGE,
 	APPLICATION_STAGE_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 
 export function buildApplicationStages(crownDevelopment) {
 	const applicableStageIds = [

--- a/apps/portal/src/app/views/applications/view/application-info/controller.js
+++ b/apps/portal/src/app/views/applications/view/application-info/controller.js
@@ -10,7 +10,7 @@ import {
 	getProcedureDetailsSectionItems
 } from './section-items.js';
 import { shouldDisplayApplicationUpdatesLink } from '../../../util/application-util.js';
-import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { buildApplicationStages, getCurrentStage } from './application-stage/controller.js';
 import {
 	getLinkedCaseId,

--- a/apps/portal/src/app/views/applications/view/application-info/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/application-info/controller.test.js
@@ -2,7 +2,7 @@ import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { buildApplicationInformationPage } from './controller.js';
 import { assertRenders404Page } from '@pins/crowndev-lib/testing/custom-asserts.js';
-import { APPLICATION_PROCEDURE_ID, APPLICATION_STAGE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_PROCEDURE_ID, APPLICATION_STAGE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('application info controller', () => {
 	describe('buildApplicationInformationPage', () => {

--- a/apps/portal/src/app/views/applications/view/application-updates/controller.js
+++ b/apps/portal/src/app/views/applications/view/application-updates/controller.js
@@ -2,7 +2,7 @@ import { applicationLinks, applicationUpdateToTimelineItem } from '../view-model
 import { isValidUuidFormat } from '@pins/crowndev-lib/util/uuid.js';
 import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
 import { shouldDisplayApplicationUpdatesLink } from '../../../util/application-util.js';
-import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { fetchPublishedApplication } from '#util/applications.js';
 
 /**

--- a/apps/portal/src/app/views/applications/view/have-your-say/journey.test.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/journey.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { createJourney, JOURNEY_ID } from './journey.js';
 import { JourneyResponse } from '@planning-inspectorate/dynamic-forms/src/journey/journey-response.js';
 import { getQuestions } from '@pins/crowndev-lib/forms/representations/questions.js';
-import { REPRESENTATION_SUBMITTED_FOR_ID, REPRESENTED_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_SUBMITTED_FOR_ID, REPRESENTED_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 
 describe('have-your-say journey', () => {

--- a/apps/portal/src/app/views/applications/view/have-your-say/save.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/save.js
@@ -6,7 +6,7 @@ import { formatDateForDisplay } from '@planning-inspectorate/dynamic-forms/src/l
 import { addSessionData, clearSessionData, readSessionData } from '@pins/crowndev-lib/util/session.js';
 import { uniqueReference } from '@pins/crowndev-lib/util/random-reference.js';
 import { JOURNEY_ID } from './journey.js';
-import { REPRESENTATION_SUBMITTED_FOR_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_SUBMITTED_FOR_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { saveRepresentation } from '@pins/crowndev-lib/forms/representations/save.js';
 import { nameToViewModel } from '@pins/crowndev-lib/util/name.js';
 import {

--- a/apps/portal/src/app/views/applications/view/view-model.js
+++ b/apps/portal/src/app/views/applications/view/view-model.js
@@ -8,7 +8,7 @@ import {
 	REPRESENTATION_STATUS_ID,
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	REPRESENTED_TYPE_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { addressToViewModel } from '@planning-inspectorate/dynamic-forms/src/lib/address-utils.js';
 import { nameToViewModel } from '@pins/crowndev-lib/util/name.js';
 import {

--- a/apps/portal/src/app/views/applications/view/view-model.test.js
+++ b/apps/portal/src/app/views/applications/view/view-model.test.js
@@ -7,7 +7,7 @@ import {
 	representationTitle,
 	representationToViewModel
 } from './view-model.js';
-import { REPRESENTATION_SUBMITTED_FOR_ID, REPRESENTED_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_SUBMITTED_FOR_ID, REPRESENTED_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('view-model', () => {
 	describe('crownDevelopmentToViewModel', () => {

--- a/apps/portal/src/app/views/applications/view/written-representations/controller.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/controller.js
@@ -2,7 +2,7 @@ import { isValidUuidFormat } from '@pins/crowndev-lib/util/uuid.js';
 import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
 import { fetchPublishedApplication } from '#util/applications.js';
 import { applicationLinks, representationToViewModel } from '../view-model.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { wrapPrismaError } from '@pins/crowndev-lib/util/database.js';
 import { createWhereClause, splitStringQueries } from '@pins/crowndev-lib/util/search-queries.js';
 import { dateIsBeforeToday, dateIsToday } from '@planning-inspectorate/dynamic-forms/src/lib/date-utils.js';

--- a/apps/portal/src/app/views/applications/view/written-representations/filters/filters.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/filters/filters.js
@@ -1,4 +1,4 @@
-import { REPRESENTATION_CATEGORY_ID, REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_CATEGORY_ID, REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { wrapPrismaError } from '@pins/crowndev-lib/util/database.js';
 import { dateFilter } from './date-filter.js';
 import { parseDateFromParts } from '@pins/crowndev-lib/validators/date-filter-validator.js';

--- a/apps/portal/src/app/views/applications/view/written-representations/filters/filters.test.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/filters/filters.test.js
@@ -7,7 +7,7 @@ import {
 	mapWithAndWithoutToBoolean,
 	sanitiseQueryToStringArray
 } from './filters.js';
-import { REPRESENTATION_CATEGORY_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_CATEGORY_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
 import { dateFilter } from './date-filter.js';

--- a/apps/portal/src/app/views/applications/view/written-representations/read-more/controller.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/read-more/controller.js
@@ -1,7 +1,7 @@
 import { isValidUuidFormat } from '@pins/crowndev-lib/util/uuid.js';
 import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
 import { fetchPublishedApplication } from '#util/applications.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { applicationLinks, representationToViewModel } from '../../view-model.js';
 import {
 	publishedRepresentationsAttachmentsFolderPath,

--- a/apps/portal/src/app/views/util/application-util.js
+++ b/apps/portal/src/app/views/util/application-util.js
@@ -1,7 +1,7 @@
 import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
 import { fetchPublishedApplication } from '#util/applications.js';
 import { isValidUuidFormat } from '@pins/crowndev-lib/util/uuid.js';
-import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 /**
  * @typedef {{start: Date, end: Date}} HaveYourSayPeriod

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -10,8 +10,8 @@
     "migrate-prod": "npx prisma migrate deploy",
     "generate": "npx prisma generate",
     "seed": "npx prisma db seed",
-    "seed-prod": "npm run generate && node src/seed/seed-prod.js",
-    "read-lpa-data": "node src/seed/data-lpa-prod-read.js"
+    "seed-prod": "npm run generate && node src/seed/seed-prod.ts",
+    "read-lpa-data": "node src/seed/data-lpa-prod-read.ts"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/database/prisma.config.js
+++ b/packages/database/prisma.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
 	schema: path.join('src', 'schema.prisma'),
 	migrations: {
 		path: path.join('src', 'migrations'),
-		seed: 'node src/seed/seed-dev.js'
+		seed: 'node src/seed/seed-dev.ts'
 	},
 	datasource: {
 		url: process.env.SQL_CONNECTION_STRING_ADMIN || ''

--- a/packages/database/src/configuration/config.ts
+++ b/packages/database/src/configuration/config.ts
@@ -1,9 +1,7 @@
 /**
  * Load configuration for seeding the database
- *
- * @returns {{db: string}}
  */
-export function loadConfig() {
+export function loadConfig(): { db: string } {
 	const db = process.env.SQL_CONNECTION_STRING;
 	if (!db) {
 		throw new Error('SQL_CONNECTION_STRING is required');

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -1,4 +1,4 @@
-import { APPLICATION_TYPE_ID } from './data-static.js';
+import { APPLICATION_TYPE_ID } from './data-static.ts';
 import {
 	applicationUpdates,
 	generateWrittenRepresentation,

--- a/packages/database/src/seed/data-dev.ts
+++ b/packages/database/src/seed/data-dev.ts
@@ -10,12 +10,10 @@ import {
 	repsBehalfOfPersonContacts,
 	repsContacts,
 	repsOnBehalfOfOrgContacts
-} from './representations-data-dev.js';
+} from './representations-data-dev.ts';
+import type { PrismaClient } from '../client/client.ts';
 
-/**
- * @param {import('@pins/crowndev-database').PrismaClient} dbClient
- */
-export async function seedDev(dbClient) {
+export async function seedDev(dbClient: PrismaClient) {
 	// ensure there is a case to link representations to
 	const crownDev = await dbClient.crownDevelopment.upsert({
 		where: { reference: 'CROWN/2025/0000001' },
@@ -24,9 +22,12 @@ export async function seedDev(dbClient) {
 	});
 
 	const allAddresses = representationContactAddresses;
-	const addressIds = new Map();
+	const addressIds = new Map<string, boolean>();
 	// check IDs are unique
 	for (const address of allAddresses) {
+		if (!address.id) {
+			throw new Error('Address is missing ID');
+		}
 		if (addressIds.has(address.id)) {
 			throw new Error(`Duplicate address ID: ${address.id}`);
 		}
@@ -42,9 +43,12 @@ export async function seedDev(dbClient) {
 	}
 
 	const allContacts = [...repsContacts, ...repsOnBehalfOfOrgContacts, ...repsBehalfOfPersonContacts];
-	const contactIds = new Map();
+	const contactIds = new Map<string, boolean>();
 	// check IDs are unique
 	for (const contact of allContacts) {
+		if (!contact.id) {
+			throw new Error('Contact is missing ID');
+		}
 		if (contactIds.has(contact.id)) {
 			throw new Error(`Duplicate contact ID: ${contact.id}`);
 		}
@@ -59,7 +63,7 @@ export async function seedDev(dbClient) {
 		});
 	}
 
-	const repRefs = new Map();
+	const repRefs = new Map<string, boolean>();
 	// check references are unique
 	for (const representation of representations) {
 		if (repRefs.has(representation.reference)) {
@@ -75,14 +79,16 @@ export async function seedDev(dbClient) {
 		repRefs.set(representationReference, true);
 	}
 
-	for (const representation of representations) {
-		representation.Application = { connect: { id: crownDev.id } };
-		await persistWrittenRepresentation(dbClient, representation);
+	for (const partialRepresentation of representations) {
+		const fullRepresentation = {
+			...partialRepresentation,
+			Application: { connect: { id: crownDev.id } }
+		};
+		await persistWrittenRepresentation(dbClient, fullRepresentation);
 	}
 
 	for (const representationReference of repReferences) {
-		const representation = generateWrittenRepresentation(representationReference);
-		representation.Application = { connect: { id: crownDev.id } };
+		const representation = generateWrittenRepresentation(representationReference, crownDev.id);
 		await persistWrittenRepresentation(dbClient, representation);
 	}
 
@@ -104,8 +110,11 @@ export async function seedDev(dbClient) {
 		});
 	}
 	//Create or update application updates and update the crown development application to contain application updates
-	for (const applicationUpdate of applicationUpdates) {
-		applicationUpdate.Application = { connect: { id: crownDev.id } };
+	for (const partialApplicationUpdate of applicationUpdates) {
+		const applicationUpdate = {
+			...partialApplicationUpdate,
+			Application: { connect: { id: crownDev.id } }
+		};
 		await dbClient.applicationUpdate.upsert({
 			where: { id: applicationUpdate.id },
 			create: applicationUpdate,

--- a/packages/database/src/seed/data-dev.ts
+++ b/packages/database/src/seed/data-dev.ts
@@ -1,4 +1,4 @@
-import { APPLICATION_TYPE_ID } from './data-static.ts';
+import { APPLICATION_TYPE_ID, APPLICATION_STATUS } from './data-static.ts';
 import {
 	applicationUpdates,
 	generateWrittenRepresentation,
@@ -11,14 +11,22 @@ import {
 	repsContacts,
 	repsOnBehalfOfOrgContacts
 } from './representations-data-dev.ts';
+import { LOCAL_PLANNING_AUTHORITIES } from './data-lpa-dev.ts';
 import type { PrismaClient } from '../client/client.ts';
 
 export async function seedDev(dbClient: PrismaClient) {
 	// ensure there is a case to link representations to
+	const reference = `CROWN/${new Date().getFullYear()}/0000001`;
+	const upsertOperation = {
+		reference: reference,
+		Type: { connect: { id: APPLICATION_TYPE_ID.PLANNING_PERMISSION } },
+		Lpa: { connect: { id: LOCAL_PLANNING_AUTHORITIES[0].id } },
+		Status: { connect: { id: APPLICATION_STATUS[0].id } }
+	};
 	const crownDev = await dbClient.crownDevelopment.upsert({
-		where: { reference: 'CROWN/2025/0000001' },
-		create: { reference: 'CROWN/2025/0000001', Type: { connect: { id: APPLICATION_TYPE_ID.PLANNING_PERMISSION } } },
-		update: { reference: 'CROWN/2025/0000001', Type: { connect: { id: APPLICATION_TYPE_ID.PLANNING_PERMISSION } } }
+		where: { reference: reference },
+		create: upsertOperation,
+		update: upsertOperation
 	});
 
 	const allAddresses = representationContactAddresses;

--- a/packages/database/src/seed/data-dev.ts
+++ b/packages/database/src/seed/data-dev.ts
@@ -1,4 +1,4 @@
-import { APPLICATION_TYPE_ID, APPLICATION_STATUS } from './data-static.ts';
+import { APPLICATION_TYPE_ID, APPLICATION_STATUS_ID } from './data-static.ts';
 import {
 	applicationUpdates,
 	generateWrittenRepresentation,
@@ -16,12 +16,12 @@ import type { PrismaClient } from '../client/client.ts';
 
 export async function seedDev(dbClient: PrismaClient) {
 	// ensure there is a case to link representations to
-	const reference = `CROWN/${new Date().getFullYear()}/0000001`;
+	const reference = `CROWN/2025/0000001`;
 	const upsertOperation = {
 		reference: reference,
 		Type: { connect: { id: APPLICATION_TYPE_ID.PLANNING_PERMISSION } },
 		Lpa: { connect: { id: LOCAL_PLANNING_AUTHORITIES[0].id } },
-		Status: { connect: { id: APPLICATION_STATUS[0].id } }
+		Status: { connect: { id: APPLICATION_STATUS_ID.NEW } }
 	};
 	const crownDev = await dbClient.crownDevelopment.upsert({
 		where: { reference: reference },

--- a/packages/database/src/seed/data-lpa-dev.ts
+++ b/packages/database/src/seed/data-lpa-dev.ts
@@ -1,7 +1,9 @@
+import type { Prisma, PrismaClient } from '@pins/crowndev-database/src/client/client.ts';
+
 const address1 = { connect: { id: 'c17101b1-b4bc-4824-928a-74a970f0e50a' } };
 const address2 = { connect: { id: '8e71bff1-e8c5-4980-8431-dd5c1cc766a4' } };
 
-export const ADDRESSES = [
+export const ADDRESSES: Prisma.AddressCreateInput[] = [
 	{
 		id: 'c17101b1-b4bc-4824-928a-74a970f0e50a',
 		line1: 'PO Box 270',
@@ -20,9 +22,8 @@ export const ADDRESSES = [
 /**
  * IDs here are just generated GUIDs
  * (e.g. run `node -e "console.log(require('crypto').randomUUID())"'`)
- * @type {import('@pins/crowndev-database').Prisma.LpaCreateInput[]}
  */
-export const LOCAL_PLANNING_AUTHORITIES = [
+export const LOCAL_PLANNING_AUTHORITIES: Prisma.LpaCreateInput[] = [
 	{
 		id: '4515ebac-65e2-4bcd-bc0b-a6fee69ae25a',
 		name: 'System Test Borough Council',
@@ -40,10 +41,7 @@ export const LOCAL_PLANNING_AUTHORITIES = [
 	}
 ];
 
-/**
- * @param {import('@pins/crowndev-database').PrismaClient} dbClient
- */
-export async function seedDevLpas(dbClient) {
+export async function seedDevLpas(dbClient: PrismaClient) {
 	await Promise.all(
 		ADDRESSES.map((address) =>
 			dbClient.address.upsert({

--- a/packages/database/src/seed/data-lpa-prod-read.ts
+++ b/packages/database/src/seed/data-lpa-prod-read.ts
@@ -8,6 +8,7 @@
 import { readFile, writeFile } from 'fs/promises';
 import { fileURLToPath } from 'url';
 import path from 'path';
+import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -29,6 +30,9 @@ const HEADERS = Object.freeze({
 });
 
 async function run() {
+	if (!process.env.LPA_DATA_FILE_PATH) {
+		throw new Error('LPA_DATA_FILE_PATH environment variable not set');
+	}
 	const contents = await readFile(process.env.LPA_DATA_FILE_PATH, 'utf8');
 	const lines = contents
 		.toString()
@@ -52,7 +56,7 @@ async function run() {
 		.map(toCreateInput);
 
 	// quick data integrity check - ONS codes may not be unique, but should always have the same name
-	const onsCodeToName = new Map();
+	const onsCodeToName: Map<string, string> = new Map();
 	for (const lpa of createInputs) {
 		if (lpa.onsCode) {
 			if (onsCodeToName.has(lpa.onsCode)) {
@@ -69,11 +73,7 @@ async function run() {
 	console.log(`data-lpa-prod-list.json written with ${createInputs.length} LPAs`);
 }
 
-/**
- * @param {Object<string, string>} lpa
- * @returns {import('@pins/crowndev-database').Prisma.LpaCreateInput}
- */
-function toCreateInput(lpa) {
+function toCreateInput(lpa: Record<string, string>): Prisma.LpaCreateInput {
 	const address = {
 		line1: lpa[HEADERS.ADDRESS_1] || null,
 		line2: lpa[HEADERS.ADDRESS_2] || null,
@@ -81,11 +81,9 @@ function toCreateInput(lpa) {
 		county: lpa[HEADERS.COUNTY] || null,
 		postcode: lpa[HEADERS.POSTCODE] || null
 	};
-	/**
-	 * @type {import('@pins/crowndev-database').Prisma.LpaCreateInput}
-	 */
-	const createInput = {
-		id: ONS_CODE_TO_ID[lpa[HEADERS.ONS_LPA_CODE]],
+
+	const createInput: Prisma.LpaCreateInput = {
+		id: ONS_CODE_TO_ID[lpa[HEADERS.ONS_LPA_CODE] as keyof typeof ONS_CODE_TO_ID],
 		name: lpa[HEADERS.ONS_LPA_NAME],
 		pinsCode: lpa[HEADERS.PINS_LPA_CODE] || null,
 		onsCode: lpa[HEADERS.ONS_LPA_CODE] || null,
@@ -101,13 +99,8 @@ function toCreateInput(lpa) {
 	return createInput;
 }
 
-/**
- * @param {string[]} headers
- * @param {string[]} line
- * @returns {Object<string, string>}
- */
-function mapToObject(headers, line) {
-	const obj = {};
+function mapToObject(headers: string[], line: string[]): Record<string, string> {
+	const obj: Record<string, string> = {};
 	headers.forEach((header, i) => {
 		obj[header] = line[i];
 	});
@@ -116,11 +109,9 @@ function mapToObject(headers, line) {
 
 /**
  * Parse one line of a CSV file, handling quoted fields and escaped quotes
- * @param {string} line
- * @returns {string[]}
  */
-function parseCSVLine(line) {
-	const result = [];
+function parseCSVLine(line: string): string[] {
+	const result: string[] = [];
 	let field = '';
 	let inQuotes = false;
 
@@ -475,4 +466,4 @@ const ONS_CODE_TO_ID = Object.freeze({
 	E60000335: '8b03d137-de51-4bdd-92d2-b276522846f8',
 	E60000336: '5f69c564-97f5-40fd-939f-a8d4cbad8c5d',
 	E60000337: '61e47f7d-eaa1-4887-8c2d-13298b3a44e6'
-});
+} as const);

--- a/packages/database/src/seed/data-lpa-prod.ts
+++ b/packages/database/src/seed/data-lpa-prod.ts
@@ -1,14 +1,9 @@
 import PROD_LPAS from './data-lpa-prod-list.json' with { type: 'json' };
+import type { Prisma, PrismaClient } from '@pins/crowndev-database/src/client/client.ts';
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.LpaCreateInput[]}
- */
-export const LOCAL_PLANNING_AUTHORITIES = PROD_LPAS;
+export const LOCAL_PLANNING_AUTHORITIES: Prisma.LpaCreateInput[] = PROD_LPAS;
 
-/**
- * @param {import('@pins/crowndev-database').PrismaClient} dbClient
- */
-export async function seedProdLpas(dbClient) {
+export async function seedProdLpas(dbClient: PrismaClient) {
 	const counts = {
 		created: 0,
 		updated: 0
@@ -25,13 +20,8 @@ export async function seedProdLpas(dbClient) {
 	console.log('prod LPAs seed complete', counts);
 }
 
-/**
- * @param {import('@pins/crowndev-database').PrismaClient} dbClient
- * @param {import('@pins/crowndev-database').Prisma.LpaCreateInput} lpaCreateInput
- * @returns {Promise<boolean>} - true if created
- */
-async function seedLpa(dbClient, lpaCreateInput) {
-	await dbClient.$transaction(async ($tx) => {
+async function seedLpa(dbClient: PrismaClient, lpaCreateInput: Prisma.LpaCreateInput): Promise<boolean> {
+	return await dbClient.$transaction(async ($tx) => {
 		const lpa = await $tx.lpa.findFirst({
 			where: {
 				onsCode: lpaCreateInput.onsCode
@@ -56,7 +46,7 @@ async function seedLpa(dbClient, lpaCreateInput) {
 			// update the address
 			await dbClient.address.update({
 				where: {
-					id: lpa.addressId
+					id: lpa.addressId ?? undefined
 				},
 				data: address
 			});

--- a/packages/database/src/seed/data-static.ts
+++ b/packages/database/src/seed/data-static.ts
@@ -82,62 +82,79 @@ export const ORGANISATION_ROLES: Prisma.CrownDevelopmentToOrganisationRoleCreate
 	}
 ];
 
+export const APPLICATION_STATUS_ID = Object.freeze({
+	NEW: 'new',
+	ACCEPTANCE: 'acceptance',
+	INVALID: 'invalid',
+	CONSULTATION_PERIOD_OPEN: 'consultation-period-open',
+	EVENT_DATE_SET: 'event-date-set',
+	ON_HOLD: 'on-hold',
+	REPORT_AWAITED: 'report-awaited',
+	REPORT_SENT: 'report-sent',
+	DECISION_AWAITED: 'decision-awaited',
+	DECIDED: 'decided',
+	WITHDRAWN: 'withdrawn',
+	DECLINED_TO_DETERMINE: 'declined-to-determine',
+	CLOSED_INVALID: 'closed-invalid',
+	CLOSED_OPEN_IN_ERROR: 'closed-open-in-error'
+} as const);
+
 export const APPLICATION_STATUS: Prisma.ApplicationStatusCreateInput[] = [
 	{
-		id: 'new',
+		id: APPLICATION_STATUS_ID.NEW,
 		displayName: 'New'
 	},
 	{
-		id: 'acceptance',
+		id: APPLICATION_STATUS_ID.ACCEPTANCE,
 		// called complete to match the terminology in the draft order
 		displayName: 'Accepted'
 	},
 	{
-		id: 'invalid',
+		id: APPLICATION_STATUS_ID.INVALID,
 		displayName: 'Invalid'
 	},
 	{
-		id: 'consultation-period-open',
+		id: APPLICATION_STATUS_ID.CONSULTATION_PERIOD_OPEN,
 		displayName: 'Consultation period open'
 	},
 	{
-		id: 'event-date-set',
+		id: APPLICATION_STATUS_ID.EVENT_DATE_SET,
 		displayName: 'Hearing/Inquiry date set'
 	},
 	{
-		id: 'on-hold',
+		id: APPLICATION_STATUS_ID.ON_HOLD,
 		displayName: 'Application on hold awaiting further information'
 	},
 	{
-		id: 'report-awaited',
+		id: APPLICATION_STATUS_ID.REPORT_AWAITED,
 		displayName: 'Report awaited'
 	},
 	{
-		id: 'report-sent',
+		id: APPLICATION_STATUS_ID.REPORT_SENT,
 		displayName: 'Report sent to Decision Branch'
 	},
 	{
-		id: 'decision-awaited',
+		id: APPLICATION_STATUS_ID.DECISION_AWAITED,
 		displayName: 'Decision awaited'
 	},
 	{
-		id: 'decided',
+		id: APPLICATION_STATUS_ID.DECIDED,
 		displayName: 'Decided'
 	},
 	{
-		id: 'withdrawn',
+		id: APPLICATION_STATUS_ID.WITHDRAWN,
 		displayName: 'Withdrawn'
 	},
 	{
-		id: 'declined-to-determine',
+		id: APPLICATION_STATUS_ID.DECLINED_TO_DETERMINE,
 		displayName: 'Declined to determine'
 	},
 	{
-		id: 'closed-invalid',
+		id: APPLICATION_STATUS_ID.CLOSED_INVALID,
 		displayName: 'Closed - invalid'
 	},
 	{
-		id: 'closed-open-in-error',
+		id: APPLICATION_STATUS_ID.CLOSED_OPEN_IN_ERROR,
 		displayName: 'Closed - opened in error'
 	}
 ];

--- a/packages/database/src/seed/data-static.ts
+++ b/packages/database/src/seed/data-static.ts
@@ -1,7 +1,6 @@
-/**
- * @type {import('@pins/crowndev-database').Prisma.ApplicationDecisionOutcomeCreateInput[]}
- */
-export const APPLICATION_DECISION_OUTCOME = [
+import type { Prisma, PrismaClient } from '@pins/crowndev-database/src/client/client.ts';
+
+export const APPLICATION_DECISION_OUTCOME: Prisma.ApplicationDecisionOutcomeCreateInput[] = [
 	{
 		id: 'approved',
 		displayName: 'Approved'
@@ -20,21 +19,15 @@ export const APPLICATION_DECISION_OUTCOME = [
 	}
 ];
 
-/**
- * @type {Readonly<{PLANNING_PERMISSION: string, OUTLINE_PLANNING_SOME_RESERVED: string, OUTLINE_PLANNING_ALL_RESERVED: string, APPROVAL_OF_RESERVED_MATTERS: string, PLANNING_AND_LISTED_BUILDING_CONSENT: string}>}
- */
 export const APPLICATION_TYPE_ID = Object.freeze({
 	PLANNING_PERMISSION: 'planning-permission',
 	OUTLINE_PLANNING_SOME_RESERVED: 'outline-planning-permission-some-reserved',
 	OUTLINE_PLANNING_ALL_RESERVED: 'outline-planning-permission-all-reserved',
 	APPROVAL_OF_RESERVED_MATTERS: 'approval-of-reserved-matters',
 	PLANNING_AND_LISTED_BUILDING_CONSENT: 'planning-permission-and-listed-building-consent'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.ApplicationTypeCreateInput[]}
- */
-export const APPLICATION_TYPES = [
+export const APPLICATION_TYPES: Prisma.ApplicationTypeCreateInput[] = [
 	{
 		id: APPLICATION_TYPE_ID.PLANNING_PERMISSION,
 		displayName: 'Planning permission'
@@ -58,18 +51,12 @@ export const APPLICATION_TYPES = [
 	}
 ];
 
-/**
- * @type {Readonly<{PLANNING_PERMISSION: string, LISTED_BUILDING_CONSENT: string}>}
- */
 export const APPLICATION_SUB_TYPE_ID = Object.freeze({
 	PLANNING_PERMISSION: 'planning-permission',
 	LISTED_BUILDING_CONSENT: 'listed-building-consent'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.ApplicationSubTypeCreateInput[]}
- */
-export const APPLICATION_SUB_TYPES = [
+export const APPLICATION_SUB_TYPES: Prisma.ApplicationSubTypeCreateInput[] = [
 	{
 		id: APPLICATION_SUB_TYPE_ID.PLANNING_PERMISSION,
 		displayName: 'Planning permission'
@@ -79,20 +66,12 @@ export const APPLICATION_SUB_TYPES = [
 		displayName: 'Listed building consent (LBC)'
 	}
 ];
-/**
- *
- * @type {Readonly<{APPLICANT: string, AGENT: string}>}
- */
 export const ORGANISATION_ROLES_ID = Object.freeze({
 	APPLICANT: 'applicant',
 	AGENT: 'agent'
-});
+} as const);
 
-/**
- *
- * @type {import('@pins/crowndev-database').Prisma.CrownDevelopmentToOrganisationRoleCreateInput[]}
- */
-export const ORGANISATION_ROLES = [
+export const ORGANISATION_ROLES: Prisma.CrownDevelopmentToOrganisationRoleCreateInput[] = [
 	{
 		id: ORGANISATION_ROLES_ID.APPLICANT,
 		displayName: 'Applicant'
@@ -103,10 +82,7 @@ export const ORGANISATION_ROLES = [
 	}
 ];
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.ApplicationStatusCreateInput[]}
- */
-export const APPLICATION_STATUS = [
+export const APPLICATION_STATUS: Prisma.ApplicationStatusCreateInput[] = [
 	{
 		id: 'new',
 		displayName: 'New'
@@ -174,12 +150,9 @@ export const APPLICATION_STAGE_ID = Object.freeze({
 	INQUIRY: 'inquiry',
 	HEARING: 'hearing',
 	DECISION: 'decision'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.ApplicationStageCreateInput[]}
- */
-export const APPLICATION_STAGE = [
+export const APPLICATION_STAGE: Prisma.ApplicationStageCreateInput[] = [
 	{
 		id: APPLICATION_STAGE_ID.ACCEPTANCE,
 		// called complete to match the terminology in the draft order
@@ -211,19 +184,13 @@ export const APPLICATION_STAGE = [
 	}
 ];
 
-/**
- * @type {Readonly<{WRITTEN_REPS: string, HEARING: string, INQUIRY: string}>}
- */
 export const APPLICATION_PROCEDURE_ID = Object.freeze({
 	WRITTEN_REPS: 'written-reps',
 	HEARING: 'hearing',
 	INQUIRY: 'inquiry'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.ApplicationProcedureCreateInput[]}
- */
-export const APPLICATION_PROCEDURE = [
+export const APPLICATION_PROCEDURE: Prisma.ApplicationProcedureCreateInput[] = [
 	{
 		id: APPLICATION_PROCEDURE_ID.WRITTEN_REPS,
 		displayName: 'Written representations'
@@ -238,19 +205,13 @@ export const APPLICATION_PROCEDURE = [
 	}
 ];
 
-/**
- * @type {Readonly<{DRAFT: string, PUBLISHED: string, UNPUBLISHED: string}>}
- */
 export const APPLICATION_UPDATE_STATUS_ID = Object.freeze({
 	DRAFT: 'draft',
 	PUBLISHED: 'published',
 	UNPUBLISHED: 'unpublished'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.ApplicationUpdateStatusCreateInput[]}
- */
-export const APPLICATION_UPDATE_STATUS = [
+export const APPLICATION_UPDATE_STATUS: Prisma.ApplicationUpdateStatusCreateInput[] = [
 	{
 		id: APPLICATION_UPDATE_STATUS_ID.DRAFT,
 		displayName: 'Draft'
@@ -265,22 +226,15 @@ export const APPLICATION_UPDATE_STATUS = [
 	}
 ];
 
-/**
- * @type {Readonly<{SENDING: string, DELIVERED: string, PERMANENT_FAILURE: string, TEMPORARY_FAILURE: string, TECHNICAL_FAILURE: string}>}
- */
 export const NOTIFY_STATUS_ID = Object.freeze({
 	SENDING: 'sending',
 	DELIVERED: 'delivered',
 	PERMANENT_FAILURE: 'permanent-failure',
 	TEMPORARY_FAILURE: 'temporary-failure',
 	TECHNICAL_FAILURE: 'technical-failure'
-});
+} as const);
 
-/**
- *
- * @type {import('@pins/crowndev-database').Prisma.NotifyStatusCreateInput[]}
- */
-export const NOTIFY_STATUS = [
+export const NOTIFY_STATUS: Prisma.NotifyStatusCreateInput[] = [
 	{
 		id: NOTIFY_STATUS_ID.SENDING,
 		displayName: 'Sending'
@@ -306,23 +260,17 @@ export const NOTIFY_STATUS = [
 export const NOTIFICATION_SOURCE = Object.freeze({
 	REPRESENTATION: 'representation',
 	APPLICATION: 'application'
-});
+} as const);
 
-/**
- * @type {Readonly<{PHONE: string, EMAIL: string, POST: string, IN_PERSON: string, ONLINE: string}>}}>}
- */
 export const RECEIVED_METHOD_ID = Object.freeze({
 	ONLINE: 'online',
 	PHONE: 'phone',
 	EMAIL: 'email',
 	POST: 'post',
 	IN_PERSON: 'in-person'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.ReceivedMethodCreateInput[]}
- */
-export const RECEIVED_METHOD = [
+export const RECEIVED_METHOD: Prisma.RepresentationReceivedMethodCreateInput[] = [
 	{ id: RECEIVED_METHOD_ID.ONLINE, displayName: 'Online' },
 	{ id: RECEIVED_METHOD_ID.PHONE, displayName: 'Phone' },
 	{ id: RECEIVED_METHOD_ID.EMAIL, displayName: 'Email' },
@@ -330,18 +278,12 @@ export const RECEIVED_METHOD = [
 	{ id: RECEIVED_METHOD_ID.IN_PERSON, displayName: 'In person' }
 ];
 
-/**
- *
- * @type {Readonly<{CONSULTEES: string, INTERESTED_PARTIES: string}>}
- */
 export const REPRESENTATION_CATEGORY_ID = Object.freeze({
 	CONSULTEES: 'consultees',
 	INTERESTED_PARTIES: 'interested-parties'
-});
-/**
- * @type {import('@pins/crowndev-database').Prisma.RepresentationCategoryCreateInput[]}
- */
-export const REPRESENTATION_CATEGORY = [
+} as const);
+
+export const REPRESENTATION_CATEGORY: Prisma.RepresentationCategoryCreateInput[] = [
 	{
 		id: 'consultees',
 		displayName: 'Consultees'
@@ -351,17 +293,13 @@ export const REPRESENTATION_CATEGORY = [
 		displayName: 'Interested party'
 	}
 ];
-/**
- * @type {Readonly<{EMAIL: string, POST: string}>}
- */
+
 export const CONTACT_PREFERENCE_ID = Object.freeze({
 	EMAIL: 'email',
 	POST: 'post'
-});
-/**
- * @type {import('@pins/crowndev-database').Prisma.ContactPreferenceCreateInput[]}
- */
-export const CONTACT_PREFERENCE = [
+} as const);
+
+export const CONTACT_PREFERENCE: Prisma.ContactPreferenceCreateInput[] = [
 	{
 		id: CONTACT_PREFERENCE_ID.EMAIL,
 		displayName: 'Email'
@@ -372,18 +310,12 @@ export const CONTACT_PREFERENCE = [
 	}
 ];
 
-/**
- * @type {Readonly<{MYSELF: string, ON_BEHALF_OF: string}>}
- */
 export const REPRESENTATION_SUBMITTED_FOR_ID = Object.freeze({
 	MYSELF: 'myself',
 	ON_BEHALF_OF: 'on-behalf-of'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.RepresentationSubmittedForCreateInput[]}
- */
-export const REPRESENTATION_SUBMITTED_FOR = [
+export const REPRESENTATION_SUBMITTED_FOR: Prisma.RepresentationSubmittedForCreateInput[] = [
 	{
 		id: REPRESENTATION_SUBMITTED_FOR_ID.MYSELF,
 		displayName: 'Myself'
@@ -394,20 +326,14 @@ export const REPRESENTATION_SUBMITTED_FOR = [
 	}
 ];
 
-/**
- * @type {Readonly<{AWAITING_REVIEW: string, ACCEPTED: string, REJECTED: string}>}
- */
 export const REPRESENTATION_STATUS_ID = Object.freeze({
 	AWAITING_REVIEW: 'awaiting-review',
 	ACCEPTED: 'accepted',
 	REJECTED: 'rejected',
 	WITHDRAWN: 'withdrawn'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.RepresentationStatusCreateInput[]}
- */
-export const REPRESENTATION_STATUS = [
+export const REPRESENTATION_STATUS: Prisma.RepresentationStatusCreateInput[] = [
 	{
 		id: REPRESENTATION_STATUS_ID.AWAITING_REVIEW,
 		displayName: 'Awaiting review'
@@ -426,19 +352,13 @@ export const REPRESENTATION_STATUS = [
 	}
 ];
 
-/**
- * @type {Readonly<{PERSON: string, ORGANISATION: string, ORG_NOT_WORK_FOR: string}>}
- */
 export const REPRESENTED_TYPE_ID = Object.freeze({
 	PERSON: 'person',
 	ORGANISATION: 'organisation',
 	ORG_NOT_WORK_FOR: 'household'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.RepresentedTypeCreateInput[]}
- */
-export const REPRESENTED_TYPE = [
+export const REPRESENTED_TYPE: Prisma.RepresentedTypeCreateInput[] = [
 	{
 		id: REPRESENTED_TYPE_ID.PERSON,
 		displayName: 'A person'
@@ -453,20 +373,14 @@ export const REPRESENTED_TYPE = [
 	}
 ];
 
-/**
- * @type {Readonly<{CHANGE_OF_OPINION: string, MISTAKEN_SUBMISSION: string, MISUNDERSTANDING: string, PERSONAL_REASONS: string}>}
- */
 export const WITHDRAWAL_REASON_ID = Object.freeze({
 	CHANGE_OF_OPINION: 'change-of-opinion',
 	MISTAKEN_SUBMISSION: 'mistaken-submission',
 	MISUNDERSTANDING: 'misunderstanding',
 	PERSONAL_REASONS: 'personal-reasons'
-});
+} as const);
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.WithdrawalReasonCreateInput[]}
- */
-export const WITHDRAWAL_REASON = [
+export const WITHDRAWAL_REASON: Prisma.WithdrawalReasonCreateInput[] = [
 	{
 		id: WITHDRAWAL_REASON_ID.CHANGE_OF_OPINION,
 		displayName: 'Change of opinion',
@@ -490,13 +404,14 @@ export const WITHDRAWAL_REASON = [
 ];
 
 // this only works if the main categories are created first
-const majorParentConnection = { connect: { id: 'major' } };
-const nonMajorParentConnection = { connect: { id: 'non-major' } };
+const majorParentConnection: NonNullable<Prisma.CategoryCreateInput['ParentCategory']> = {
+	connect: { id: 'major' }
+};
+const nonMajorParentConnection: NonNullable<Prisma.CategoryCreateInput['ParentCategory']> = {
+	connect: { id: 'non-major' }
+};
 
-/**
- * @type {import('@pins/crowndev-database').Prisma.CategoryCreateInput[]}
- */
-export const CATEGORIES = [
+export const CATEGORIES: Prisma.CategoryCreateInput[] = [
 	{
 		id: 'major',
 		displayName: 'Major Development'
@@ -589,63 +504,86 @@ export const CATEGORIES = [
 	}
 ];
 
-/**
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationDecisionOutcomeDelegate} ApplicationDecisionOutcomeDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationTypeDelegate} ApplicationTypeDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationStageDelegate} ApplicationStageDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationStatusDelegate} ApplicationStatusDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationProcedureDelegate} ApplicationProcedureDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.RepresentationCategoryDelegate} RepresentationCategoryDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.RepresentationSubmittedForDelegate} RepresentationSubmittedForDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.RepresentationStatusDelegate} RepresentationStatusDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.RepresentedTypeDelegate} RepresentedTypeDelegate
- * @typedef {import('@pins/crowndev-database').Prisma.CategoryDelegate} CategoryDelegate
- */
+type UpsertReferenceDataArgs =
+	| {
+			delegate: Prisma.ApplicationDecisionOutcomeDelegate;
+			input: Prisma.ApplicationDecisionOutcomeCreateInput;
+	  }
+	| {
+			delegate: Prisma.ApplicationTypeDelegate;
+			input: Prisma.ApplicationTypeCreateInput;
+	  }
+	| {
+			delegate: Prisma.ApplicationSubTypeDelegate;
+			input: Prisma.ApplicationSubTypeCreateInput;
+	  }
+	| {
+			delegate: Prisma.ApplicationStageDelegate;
+			input: Prisma.ApplicationStageCreateInput;
+	  }
+	| {
+			delegate: Prisma.ApplicationStatusDelegate;
+			input: Prisma.ApplicationStatusCreateInput;
+	  }
+	| {
+			delegate: Prisma.ApplicationProcedureDelegate;
+			input: Prisma.ApplicationProcedureCreateInput;
+	  }
+	| {
+			delegate: Prisma.ApplicationUpdateStatusDelegate;
+			input: Prisma.ApplicationUpdateStatusCreateInput;
+	  }
+	| {
+			delegate: Prisma.RepresentationReceivedMethodDelegate;
+			input: Prisma.RepresentationReceivedMethodCreateInput;
+	  }
+	| {
+			delegate: Prisma.RepresentationCategoryDelegate;
+			input: Prisma.RepresentationCategoryCreateInput;
+	  }
+	| {
+			delegate: Prisma.RepresentationSubmittedForDelegate;
+			input: Prisma.RepresentationSubmittedForCreateInput;
+	  }
+	| {
+			delegate: Prisma.RepresentationStatusDelegate;
+			input: Prisma.RepresentationStatusCreateInput;
+	  }
+	| {
+			delegate: Prisma.RepresentedTypeDelegate;
+			input: Prisma.RepresentedTypeCreateInput;
+	  }
+	| {
+			delegate: Prisma.ContactPreferenceDelegate;
+			input: Prisma.ContactPreferenceCreateInput;
+	  }
+	| {
+			delegate: Prisma.NotifyStatusDelegate;
+			input: Prisma.NotifyStatusCreateInput;
+	  }
+	| {
+			delegate: Prisma.WithdrawalReasonDelegate;
+			input: Prisma.WithdrawalReasonCreateInput;
+	  }
+	| {
+			delegate: Prisma.CrownDevelopmentToOrganisationRoleDelegate;
+			input: Prisma.CrownDevelopmentToOrganisationRoleCreateInput;
+	  }
+	| {
+			delegate: Prisma.CategoryDelegate;
+			input: Prisma.CategoryCreateInput;
+	  };
 
-/**
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationDecisionOutcomeCreateInput} ApplicationDecisionOutcomeCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationTypeCreateInput} ApplicationTypeCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationStageCreateInput} ApplicationStageCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationStatusCreateInput} ApplicationStatusCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.ApplicationProcedureCreateInput} ApplicationProcedureCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.RepresentationCategoryCreateInput} RepresentationCategoryCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.RepresentationSubmittedForCreateInput} RepresentationSubmittedForCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.RepresentationStatusCreateInput} RepresentationStatusCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.RepresentedTypeCreateInput} RepresentedTypeCreateInput
- * @typedef {import('@pins/crowndev-database').Prisma.CategoryCreateInput} CategoryCreateInput
- */
-
-/**
- * @typedef {{delegate: ApplicationDecisionOutcomeDelegate, input: ApplicationDecisionOutcomeCreateInput}} ApplicationDecisionOutcomeArgs
- * @typedef {{delegate: ApplicationTypeDelegate, input: ApplicationTypeCreateInput}} ApplicationTypeArgs
- * @typedef {{delegate: ApplicationStageDelegate, input: ApplicationStageCreateInput}} ApplicationStageArgs
- * @typedef {{delegate: ApplicationStatusDelegate, input: ApplicationStatusCreateInput}} ApplicationStatusArgs
- * @typedef {{delegate: ApplicationProcedureDelegate, input: ApplicationProcedureCreateInput}} ApplicationProcedureArgs
- * @typedef {{delegate: RepresentationCategoryDelegate, input: RepresentationCategoryCreateInput}} RepresentationCategoryArgs
- * @typedef {{delegate: RepresentationSubmittedForDelegate, input: RepresentationSubmittedForCreateInput}} RepresentationSubmittedForArgs
- * @typedef {{delegate: RepresentationStatusDelegate, input: RepresentationStatusCreateInput}} RepresentationStatusArgs
- * @typedef {{delegate: RepresentedTypeDelegate, input: RepresentedTypeCreateInput}} RepresentedTypeArgs
- * @typedef {{delegate: CategoryDelegate, input: CategoryCreateInput}} CategoryArgs
- */
-
-/**
- * Upsert reference data with any of the given types
- *
- * @param {ApplicationDecisionOutcomeArgs|ApplicationTypeArgs|ApplicationStageArgs|ApplicationStatusArgs|ApplicationProcedureArgs|RepresentationCategoryArgs|RepresentationSubmittedForArgs|RepresentationStatusArgs|RepresentedTypeArgs|CategoryArgs} args
- * @returns {Promise<any>}
- */
-async function upsertReferenceData({ delegate, input }) {
-	return delegate.upsert({
+async function upsertReferenceData({ delegate, input }: UpsertReferenceDataArgs): Promise<void> {
+	const { upsert } = delegate as unknown as { upsert: (args: unknown) => Promise<unknown> };
+	await upsert({
 		create: input,
 		update: input,
 		where: { id: input.id }
 	});
 }
 
-/**
- * @param {import('@pins/crowndev-database').PrismaClient} dbClient
- */
-export async function seedStaticData(dbClient) {
+export async function seedStaticData(dbClient: PrismaClient) {
 	await Promise.all(
 		APPLICATION_DECISION_OUTCOME.map((input) =>
 			upsertReferenceData({ delegate: dbClient.applicationDecisionOutcome, input })

--- a/packages/database/src/seed/representations-data-dev.js
+++ b/packages/database/src/seed/representations-data-dev.js
@@ -4,7 +4,7 @@ import {
 	REPRESENTATION_STATUS_ID,
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	REPRESENTED_TYPE_ID
-} from './data-static.js';
+} from './data-static.ts';
 
 export const representationContactAddresses = [
 	{

--- a/packages/database/src/seed/representations-data-dev.ts
+++ b/packages/database/src/seed/representations-data-dev.ts
@@ -5,8 +5,9 @@ import {
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	REPRESENTED_TYPE_ID
 } from './data-static.ts';
+import type { Prisma, PrismaClient } from '@pins/crowndev-database/src/client/client.ts';
 
-export const representationContactAddresses = [
+export const representationContactAddresses: Prisma.AddressCreateInput[] = [
 	{
 		id: '7e238942-71b5-42b3-92c3-5be987cd1b2f',
 		line1: '10 Elm Street',
@@ -112,11 +113,11 @@ export const representationContactAddresses = [
 		postcode: 'OX1 4YZ'
 	}
 ];
-/**
- * @param {import('@pins/crowndev-database').PrismaClient} dbClient
- * @param {import('@pins/crowndev-database').Prisma.RepresentationCreateInput} representation
- */
-export async function persistWrittenRepresentation(dbClient, representation) {
+
+export async function persistWrittenRepresentation(
+	dbClient: PrismaClient,
+	representation: Prisma.RepresentationCreateInput
+) {
 	await dbClient.representation.upsert({
 		where: { reference: representation.reference },
 		create: representation,
@@ -125,10 +126,12 @@ export async function persistWrittenRepresentation(dbClient, representation) {
 }
 
 /**
- * @param {string} reference
- * @returns {import('@pins/crowndev-database').Prisma.RepresentationCreateInput}
+ * Generate a written representation
  */
-export function generateWrittenRepresentation(reference) {
+export function generateWrittenRepresentation(
+	reference: string,
+	applicationId: string
+): Prisma.RepresentationCreateInput {
 	return {
 		reference: reference,
 		comment: faker.lorem.sentence(),
@@ -139,23 +142,20 @@ export function generateWrittenRepresentation(reference) {
 		RepresentedType: { connect: { id: REPRESENTED_TYPE_ID.ORG_NOT_WORK_FOR } },
 		RepresentedContact: { connect: { id: repsBehalfOfPersonContacts[9].id } },
 		Status: { connect: { id: REPRESENTATION_STATUS_ID.ACCEPTED } },
-		containsAttachments: false
+		containsAttachments: false,
+		Application: { connect: { id: applicationId } }
 	};
 }
 
-/**
- * @returns {string} randomly generated representation reference
- */
-export function generateRandomRepresentationReference() {
+export function generateRandomRepresentationReference(): string {
 	return `${faker.string.alphanumeric(5).toUpperCase()}-${faker.string.alphanumeric(5).toUpperCase()}`;
 }
 
 /**
  * IDs here are just generated GUIDs
  * (e.g. run `node -e "console.log(require('crypto').randomUUID())"'`)
- * @type {import('@pins/crowndev-database').Prisma.ContactCreateInput[]}
  */
-export const repsContacts = [
+export const repsContacts: Prisma.ContactUncheckedCreateInput[] = [
 	{
 		id: '05fa5f0f-342d-466d-8d61-e837586d6a3d',
 		firstName: 'Person',
@@ -306,9 +306,8 @@ export const repsContacts = [
 /**
  * IDs here are just generated GUIDs
  * (e.g. run `node -e "console.log(require('crypto').randomUUID())"'`)
- * @type {import('@pins/crowndev-database').Prisma.ContactCreateInput[]}
  */
-export const repsOnBehalfOfOrgContacts = [
+export const repsOnBehalfOfOrgContacts: Prisma.ContactCreateInput[] = [
 	{ id: 'c561a9bb-a1c4-4836-9f6f-0ea904c79475', orgName: 'Org One' },
 	{ id: '1d421817-caa1-40e7-9f6c-e915309707c1', orgName: 'Org Two' },
 	{ id: 'f4a79154-a216-4263-81b1-2a8660e63376', orgName: 'Org Three' },
@@ -319,9 +318,8 @@ export const repsOnBehalfOfOrgContacts = [
 /**
  * IDs here are just generated GUIDs
  * (e.g. run `node -e "console.log(require('crypto').randomUUID())"'`)
- * @type {import('@pins/crowndev-database').Prisma.ContactCreateInput[]}
  */
-export const repsBehalfOfPersonContacts = [
+export const repsBehalfOfPersonContacts: Prisma.ContactCreateInput[] = [
 	{ id: '7c3619fb-81ff-4164-8edb-8baae3dfc087', firstName: 'Person', lastName: 'Alpha' },
 	{ id: 'f48bc3e9-87b2-4d9e-ad49-2fc48a48472f', firstName: 'Person', lastName: 'Beta' },
 	{ id: '562997bd-b50a-4902-8601-d0b347c839c3', firstName: 'Person', lastName: 'Gamma' },
@@ -334,7 +332,7 @@ export const repsBehalfOfPersonContacts = [
 	{ id: '8aa7a2ad-ff79-4355-a436-46e557971bb9', firstName: 'Person', lastName: 'Kappa' }
 ];
 
-export const repReferences = [
+export const repReferences: string[] = [
 	'84F02-B6D74',
 	'C6A72-D1B04',
 	'3D9F2-B8C10',
@@ -384,9 +382,8 @@ export const repReferences = [
 
 /**
  * References here are generated with generateNewReference function in have-your-say
- * @type {import('@pins/crowndev-database').Prisma.RepresentationCreateInput[]}
  */
-export const representations = [
+export const representations: Omit<Prisma.RepresentationCreateInput, 'Application'>[] = [
 	{
 		reference: '50315-3163D',
 		comment: 'Some comment about this application',
@@ -625,7 +622,7 @@ export const representations = [
 	}
 ];
 
-export const representationDocuments = [
+export const representationDocuments: Prisma.RepresentationDocumentCreateInput[] = [
 	{
 		id: 'c1b2d3e4-f5a6-7b8c-9d0e-f1a2b3c4d5e6',
 		Representation: { connect: { reference: representations[3].reference } },
@@ -652,7 +649,7 @@ export const representationDocuments = [
 	}
 ];
 
-export const applicationUpdates = [
+export const applicationUpdates: Omit<Prisma.ApplicationUpdateCreateInput, 'Application'>[] = [
 	{
 		id: 'fa5cb811-1d12-4674-b409-43b1c0a8609e',
 		details: 'An application update',

--- a/packages/database/src/seed/seed-dev.js
+++ b/packages/database/src/seed/seed-dev.js
@@ -1,5 +1,5 @@
 import { newDatabaseClient } from '../index.ts';
-import { seedStaticData } from './data-static.js';
+import { seedStaticData } from './data-static.ts';
 import { seedDev } from './data-dev.js';
 import { loadConfig } from '../configuration/config.js';
 import { seedDevLpas } from './data-lpa-dev.js';

--- a/packages/database/src/seed/seed-dev.ts
+++ b/packages/database/src/seed/seed-dev.ts
@@ -1,8 +1,8 @@
 import { newDatabaseClient } from '../index.ts';
 import { seedStaticData } from './data-static.ts';
-import { seedDev } from './data-dev.js';
-import { loadConfig } from '../configuration/config.js';
-import { seedDevLpas } from './data-lpa-dev.js';
+import { seedDev } from './data-dev.ts';
+import { loadConfig } from '../configuration/config.ts';
+import { seedDevLpas } from './data-lpa-dev.ts';
 
 async function run() {
 	const config = loadConfig();
@@ -20,4 +20,4 @@ async function run() {
 	}
 }
 
-run();
+void run();

--- a/packages/database/src/seed/seed-prod.js
+++ b/packages/database/src/seed/seed-prod.js
@@ -1,5 +1,5 @@
 import { newDatabaseClient } from '../index.js';
-import { seedStaticData } from './data-static.js';
+import { seedStaticData } from './data-static.ts';
 import { loadConfig } from '../configuration/config.js';
 import { seedProdLpas } from './data-lpa-prod.js';
 

--- a/packages/database/src/seed/seed-prod.ts
+++ b/packages/database/src/seed/seed-prod.ts
@@ -1,7 +1,7 @@
-import { newDatabaseClient } from '../index.js';
+import { newDatabaseClient } from '../index.ts';
 import { seedStaticData } from './data-static.ts';
-import { loadConfig } from '../configuration/config.js';
-import { seedProdLpas } from './data-lpa-prod.js';
+import { loadConfig } from '../configuration/config.ts';
+import { seedProdLpas } from './data-lpa-prod.ts';
 
 async function run() {
 	const config = loadConfig();
@@ -18,4 +18,4 @@ async function run() {
 	}
 }
 
-run();
+void run();

--- a/packages/lib/forms/custom-components/representation-attachments/question.js
+++ b/packages/lib/forms/custom-components/representation-attachments/question.js
@@ -1,5 +1,5 @@
 import { Question } from '@planning-inspectorate/dynamic-forms/src/questions/question.js';
-import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { JOURNEY_MAP } from './upload-documents.js';
 import nunjucks from 'nunjucks';
 

--- a/packages/lib/forms/representations/question-utils.js
+++ b/packages/lib/forms/representations/question-utils.js
@@ -3,7 +3,7 @@ import RequiredValidator from '@planning-inspectorate/dynamic-forms/src/validato
 import StringValidator from '@planning-inspectorate/dynamic-forms/src/validator/string-validator.js';
 import { COMPONENT_TYPES } from '@planning-inspectorate/dynamic-forms';
 import { referenceDataToRadioOptions } from '../../util/questions.js';
-import { CONTACT_PREFERENCE } from '@pins/crowndev-database/src/seed/data-static.js';
+import { CONTACT_PREFERENCE } from '@pins/crowndev-database/src/seed/data-static.ts';
 import AddressValidator from '@planning-inspectorate/dynamic-forms/src/validator/address-validator.js';
 import MultiFieldInputValidator from '@planning-inspectorate/dynamic-forms/src/validator/multi-field-input-validator.js';
 import DocumentUploadValidator from '@planning-inspectorate/dynamic-forms/src/validator/document-upload-validator.js';

--- a/packages/lib/forms/representations/questions.js
+++ b/packages/lib/forms/representations/questions.js
@@ -12,7 +12,7 @@ import {
 	REPRESENTATION_SUBMITTED_FOR,
 	REPRESENTED_TYPE,
 	WITHDRAWAL_REASON
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import {
 	referenceDataToRadioOptions,
 	referenceDataToRadioOptionsWithHintText

--- a/packages/lib/forms/representations/save.js
+++ b/packages/lib/forms/representations/save.js
@@ -6,7 +6,7 @@ import { uniqueReference } from '../../util/random-reference.js';
 import {
 	REPRESENTATION_STATUS_ID,
 	REPRESENTATION_SUBMITTED_FOR_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { deleteRepresentationAttachmentsFolder, moveAttachmentsToCaseFolder } from '../../util/handle-attachments.js';
 import { getSubmittedForId } from '../../util/questions.js';
 import { getAnswers } from '../../util/answers.js';

--- a/packages/lib/forms/representations/sections.js
+++ b/packages/lib/forms/representations/sections.js
@@ -9,7 +9,7 @@ import {
 	REPRESENTATION_STATUS_ID,
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	REPRESENTED_TYPE_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 
 /**

--- a/packages/lib/forms/representations/sections.test.js
+++ b/packages/lib/forms/representations/sections.test.js
@@ -6,7 +6,7 @@ import {
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	REPRESENTED_TYPE_ID,
 	REPRESENTATION_STATUS_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 import { Journey } from '@planning-inspectorate/dynamic-forms/src/journey/journey.js';
 import { addRepresentationSection, haveYourSayManageSections, haveYourSaySections } from './sections.js';

--- a/packages/lib/forms/representations/view-model.js
+++ b/packages/lib/forms/representations/view-model.js
@@ -8,7 +8,7 @@ import {
 	REPRESENTATION_STATUS_ID,
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	REPRESENTED_TYPE_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { optionalWhere } from '../../util/database.js';
 import { addressToViewModel, viewModelToAddressUpdateInput } from '../../util/address.ts';
 

--- a/packages/lib/forms/representations/view-model.test.js
+++ b/packages/lib/forms/representations/view-model.test.js
@@ -10,7 +10,7 @@ import {
 	REPRESENTATION_SUBMITTED_FOR_ID,
 	REPRESENTED_TYPE_ID,
 	RECEIVED_METHOD_ID
-} from '@pins/crowndev-database/src/seed/data-static.js';
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 
 /**

--- a/packages/lib/util/linked-case.js
+++ b/packages/lib/util/linked-case.js
@@ -1,5 +1,5 @@
 import { getAnswers } from '@pins/crowndev-lib/util/answers.js';
-import { APPLICATION_SUB_TYPE_ID, APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_SUB_TYPE_ID, APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { dateIsBeforeToday, dateIsToday } from '@planning-inspectorate/dynamic-forms/src/lib/date-utils.js';
 
 export function getLinkedCaseId(crownDevelopment) {

--- a/packages/lib/util/linked-case.test.js
+++ b/packages/lib/util/linked-case.test.js
@@ -1,6 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
-import { APPLICATION_SUB_TYPE_ID, APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { APPLICATION_SUB_TYPE_ID, APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import {
 	getLinkedCaseId,
 	getLinkedCaseLinkText,

--- a/packages/lib/util/questions.js
+++ b/packages/lib/util/questions.js
@@ -1,4 +1,4 @@
-import { REPRESENTATION_SUBMITTED_FOR_ID } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_SUBMITTED_FOR_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 const MAX_LENGTH = 500;
 

--- a/packages/lib/util/questions.test.js
+++ b/packages/lib/util/questions.test.js
@@ -8,7 +8,7 @@ import {
 	truncateComment,
 	truncatedReadMoreCommentLink
 } from './questions.js';
-import { REPRESENTATION_SUBMITTED_FOR_ID, WITHDRAWAL_REASON } from '@pins/crowndev-database/src/seed/data-static.js';
+import { REPRESENTATION_SUBMITTED_FOR_ID, WITHDRAWAL_REASON } from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('questions', () => {
 	describe('shouldTruncateComment', () => {


### PR DESCRIPTION
## Describe your changes

1. Migrate seed and static data to typescript, and update imports
2. Update `seed-dev` case to use LPA, status and current year in reference
3. `seedLpa` function in `data-lpa-prod.ts` now *returns* the transaction result [[1]](https://github.com/Planning-Inspectorate/crown-developments/pull/927/changes#diff-212c524af599b8cc86835f6e24845106d585d4579709ee4f09325ed5bc1a50d2L28). This should only affect the log of created LPAs [[2]](https://github.com/Planning-Inspectorate/crown-developments/blob/fa420bb1b81d0ff9b2e3e6daf2e955420abbf6b7/packages/database/src/seed/data-lpa-prod.ts#L12).
4. Add `void` to intentionally not await the result of the seed task [[3]](https://github.com/Planning-Inspectorate/crown-developments/pull/927/changes#diff-ca12d7a292e3a4037fd598f4d7df1813deecbd3c24f7775a263abb68973a7b1fR21)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1595