### PR TITLE
fix(manage): update hint for distressing content warning

### DIFF
--- a/apps/manage/src/app/views/cases/create-a-case/questions.js
+++ b/apps/manage/src/app/views/cases/create-a-case/questions.js
@@ -278,7 +278,7 @@ export function getQuestions(journeyResponse, isQuestionView = false) {
 			type: COMPONENT_TYPES.BOOLEAN,
 			title: 'Distressing content',
 			question: 'Does this application involve potentially distressing content?',
-			hint: "If you select 'Yes', this will trigger a warning on the portal",
+			hint: "If you select 'Yes', this will trigger a warning on the front office",
 			fieldName: 'containsDistressingContent',
 			url: 'distressing-content',
 			validators: [new RequiredValidator('Select whether this application involves potentially distressing content')]

--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -968,7 +968,7 @@ export function getQuestions(
 			type: COMPONENT_TYPES.BOOLEAN,
 			title: 'Distressing content',
 			question: 'Does this application involve potentially distressing content?',
-			hint: "If you select 'Yes', this will trigger a warning on the portal",
+			hint: "If you select 'Yes', this will trigger a warning on the front office",
 			fieldName: 'containsDistressingContent',
 			url: 'distressing-content',
 			validators: [new RequiredValidator('Select whether this application involves potentially distressing content')]


### PR DESCRIPTION
## Describe your changes
This pull request updates the hint text for the "Distressing content" question in both the case creation and case view workflows to clarify that selecting "Yes" will trigger a warning on the "front office" rather than the "portal".

Content and messaging updates:

* Updated the hint text in `apps/manage/src/app/views/cases/create-a-case/questions.js` to specify that a warning will be triggered on the "front office" if distressing content is indicated.
* Made the same hint text update in `apps/manage/src/app/views/cases/view/questions.js` for consistency in the case view workflow.
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1535
<img width="1251" height="541" alt="image" src="https://github.com/user-attachments/assets/2a50ff39-f9c4-4eb6-bb53-30a2308a3845" />
