### PR TITLE
fix(manage): remove non-multiple entities functionality

### DIFF
--- a/apps/manage/src/app/views/cases/create-a-case/save.js
+++ b/apps/manage/src/app/views/cases/create-a-case/save.js
@@ -269,10 +269,8 @@ function extractAgentParty(answers) {
 		return null;
 	}
 
-	// For the old flow - hasAgent might be true without multiple agent contacts
-	// TODO - throw error after migration CROWN-1509
 	if (!hasAnswers(answers, 'manageAgentContactDetails')) {
-		return null;
+		throw new Error('Agent contacts are required when the case has an agent');
 	}
 
 	if (!hasAnswers(answers, 'agentOrganisationName')) {
@@ -448,38 +446,6 @@ export function toCreateInput(answers, reference, subType, options = {}) {
 		}
 	}
 
-	// TODO remove once multiple entities complete CROWN-1509
-	if (hasAnswersBeginningWith(answers, ORGANISATION_ROLES_ID.APPLICANT)) {
-		input.ApplicantContact = {
-			create: {
-				orgName: answers.applicantName,
-				email: answers.applicantEmail,
-				telephoneNumber: answers.applicantTelephoneNumber
-			}
-		};
-		if (answers.applicantAddress) {
-			input.ApplicantContact.create.Address = {
-				create: toAddressInput(answers.applicantAddress)
-			};
-		}
-	}
-
-	// TODO remove once multiple entities complete CROWN-1509
-	if (hasAnswersBeginningWith(answers, ORGANISATION_ROLES_ID.AGENT)) {
-		input.AgentContact = {
-			create: {
-				orgName: answers.agentName,
-				email: answers.agentEmail,
-				telephoneNumber: answers.agentTelephoneNumber
-			}
-		};
-		if (answers.agentAddress) {
-			input.AgentContact.create.Address = {
-				create: toAddressInput(answers.agentAddress)
-			};
-		}
-	}
-
 	return input;
 }
 
@@ -495,20 +461,6 @@ function toAddressInput(address) {
 		county: address.county,
 		postcode: address.postcode
 	};
-}
-
-/**
- * Have any of the answers with a given prefix got an answer?
- * TODO: Because this uses startsWith(prefix) it doesn't infer types well - replace with hasAnswers where possible CROWN-1509
- *
- * @param {import('./types.d.ts').CreateCaseAnswers} answers
- * @param {string} prefix
- * @returns {boolean}
- */
-function hasAnswersBeginningWith(answers, prefix) {
-	return Object.entries(answers)
-		.filter(([k]) => k.startsWith(prefix))
-		.some(([, v]) => Boolean(v));
 }
 
 /**
@@ -576,34 +528,6 @@ function idFromReference(reference = '') {
 }
 
 /**
- *
- * @param {SharePointDrive} sharePointDrive
- * @param {import('./types.d.ts').CreateCaseAnswers} answers
- * @param {string} folderName
- * @returns {Promise<import('@microsoft/microsoft-graph-types').Permission>}
- */
-async function grantUsersAccess(sharePointDrive, answers, folderName) {
-	const applicantReceivedFolderId = await getSharePointReceivedPathId(sharePointDrive, {
-		caseRootName: folderName,
-		user: 'Applicant'
-	});
-
-	const users = [];
-	if (hasAnswersBeginningWith(answers, ORGANISATION_ROLES_ID.APPLICANT) && answers.applicantEmail) {
-		users.push({ email: answers.applicantEmail, id: '' });
-	}
-
-	if (hasAnswersBeginningWith(answers, ORGANISATION_ROLES_ID.AGENT) && answers.agentEmail) {
-		users.push({ email: answers.agentEmail, id: '' });
-	}
-
-	await sharePointDrive.addItemPermissions(applicantReceivedFolderId, { role: 'write', users: users });
-	// todo: Add LPA permissions too.
-
-	return await sharePointDrive.fetchUserInviteLink(applicantReceivedFolderId);
-}
-
-/**
  * Grant Sharepoint access to all relevant users for a case, including multiple applicants if applicable.
  *
  * @param {SharePointDrive} sharePointDrive
@@ -640,31 +564,6 @@ async function grantUsersAccessV2(sharePointDrive, answers, folderName) {
 	// todo: Add LPA permissions too.
 
 	return sharePointDrive.fetchUserInviteLink(applicantReceivedFolderId);
-}
-
-/**
- * TODO remove when multiple applicants is live CROWN-1509
- *
- * @param {SharePointDrive} sharePointDrive
- * @param {string} caseTemplateId
- * @param {string} folderName
- * @param {import('./types.d.ts').CreateCaseAnswers} answers
- * @returns {Promise<NotificationDataOne>}
- */
-async function createCaseSharePointActions(sharePointDrive, caseTemplateId, folderName, answers) {
-	// Copy template folder structure and rename to %folderName%
-	await sharePointDrive.copyDriveItem({
-		copyItemId: caseTemplateId,
-		newItemName: folderName
-	});
-	// Grant write access to applicant and agent as required
-	const inviteLink = await grantUsersAccess(sharePointDrive, answers, folderName);
-
-	return {
-		kind: 'one',
-		recipientEmail: yesNoToBoolean(answers.hasAgent) ? answers.agentEmail : answers.applicantEmail,
-		sharePointLink: inviteLink.link.webUrl
-	};
 }
 
 /**
@@ -757,17 +656,10 @@ async function getNotificationData(service, appSharePointDrive, reference, answe
 		);
 	}
 
-	return service.isMultipleApplicantsLive
-		? await createCaseSharePointActionsV2(
-				appSharePointDrive,
-				service.sharePointCaseTemplateId,
-				caseReferenceToFolderName(reference),
-				answers
-			)
-		: await createCaseSharePointActions(
-				appSharePointDrive,
-				service.sharePointCaseTemplateId,
-				caseReferenceToFolderName(reference),
-				answers
-			);
+	return await createCaseSharePointActionsV2(
+		appSharePointDrive,
+		service.sharePointCaseTemplateId,
+		caseReferenceToFolderName(reference),
+		answers
+	);
 }

--- a/apps/manage/src/app/views/cases/create-a-case/save.test.js
+++ b/apps/manage/src/app/views/cases/create-a-case/save.test.js
@@ -158,11 +158,18 @@ describe('save', () => {
 			};
 			const service = mockService();
 			service.appSharePointDrive = sharepointDrive;
-			service.isMultipleApplicantsLive = false;
 			const { db } = service;
 			const save = buildSaveController(service);
 			const answers = {
-				applicantEmail: 'applicant@test.com',
+				manageApplicantDetails: [{ id: 'org-1', organisationName: 'Test Applicant Org' }],
+				manageApplicantContactDetails: [
+					{
+						applicantContactOrganisation: 'org-1',
+						applicantContactEmail: 'applicant@test.com',
+						applicantFirstName: 'Test',
+						applicantLastName: 'User'
+					}
+				],
 				developmentDescription: 'Project One',
 				typeOfApplication: 'planning-permission-and-listed-building-consent',
 				lpaId: 'lpa-1'
@@ -197,11 +204,11 @@ describe('save', () => {
 			assert.strictEqual(sharepointDrive.addItemPermissions.mock.callCount(), 2);
 			assert.deepStrictEqual(sharepointDrive.addItemPermissions.mock.calls[0].arguments[1], {
 				role: 'write',
-				users: [{ email: answers.applicantEmail, id: '' }]
+				users: [{ email: answers.manageApplicantContactDetails[0].applicantContactEmail, id: '' }]
 			});
 			assert.deepStrictEqual(sharepointDrive.addItemPermissions.mock.calls[1].arguments[1], {
 				role: 'write',
-				users: [{ email: answers.applicantEmail, id: '' }]
+				users: [{ email: answers.manageApplicantContactDetails[0].applicantContactEmail, id: '' }]
 			});
 		});
 
@@ -236,10 +243,18 @@ describe('save', () => {
 			const save = buildSaveController(service);
 
 			const answers = {
+				manageApplicantDetails: [{ id: 'org-1', organisationName: 'Test Applicant Org' }],
+				manageApplicantContactDetails: [
+					{
+						applicantContactOrganisation: 'org-1',
+						applicantContactEmail: 'applicantEmail',
+						applicantFirstName: 'Test',
+						applicantLastName: 'User'
+					}
+				],
 				developmentDescription: 'Project One',
 				typeOfApplication: 'application-type-1',
-				lpaId: 'lpa-1',
-				applicantEmail: 'applicantEmail'
+				lpaId: 'lpa-1'
 			};
 			const res = {
 				redirect: mock.fn(),
@@ -258,7 +273,7 @@ describe('save', () => {
 			assert.strictEqual(sharepointDrive.addItemPermissions.mock.callCount(), 1);
 			assert.deepStrictEqual(sharepointDrive.addItemPermissions.mock.calls[0].arguments[1], {
 				role: 'write',
-				users: [{ email: answers.applicantEmail, id: '' }]
+				users: [{ email: answers.manageApplicantContactDetails[0].applicantContactEmail, id: '' }]
 			});
 		});
 		it('should call copyDriveItem and grant write access to the applicant and agent when sharepoint is enabled and an agentEmail was provided', async () => {
@@ -292,11 +307,29 @@ describe('save', () => {
 			const save = buildSaveController(service);
 
 			const answers = {
+				manageApplicantDetails: [{ id: 'org-1', organisationName: 'Test Applicant Org' }],
+				manageApplicantContactDetails: [
+					{
+						applicantContactOrganisation: 'org-1',
+						applicantContactEmail: 'applicantEmail',
+						applicantFirstName: 'Test',
+						applicantLastName: 'User'
+					}
+				],
+				hasAgent: true,
+				agentOrganisationName: 'Test Agent Org',
+				manageAgentDetails: { id: 'agent-org-1', organisationName: 'Test Agent Org' },
+				manageAgentContactDetails: [
+					{
+						agentContactOrganisation: 'agent-org-1',
+						agentContactEmail: 'agentEmail',
+						agentFirstName: 'Agent',
+						agentLastName: 'User'
+					}
+				],
 				developmentDescription: 'Project One',
 				typeOfApplication: 'application-type-1',
-				lpaId: 'lpa-1',
-				applicantEmail: 'applicantEmail',
-				agentEmail: 'agentEmail'
+				lpaId: 'lpa-1'
 			};
 			const res = {
 				redirect: mock.fn(),
@@ -316,8 +349,8 @@ describe('save', () => {
 			assert.deepStrictEqual(sharepointDrive.addItemPermissions.mock.calls[0].arguments[1], {
 				role: 'write',
 				users: [
-					{ email: answers.applicantEmail, id: '' },
-					{ email: answers.agentEmail, id: '' }
+					{ email: answers.manageApplicantContactDetails[0].applicantContactEmail, id: '' },
+					{ email: answers.manageAgentContactDetails[0].agentContactEmail, id: '' }
 				]
 			});
 		});
@@ -345,7 +378,7 @@ describe('save', () => {
 				})
 			};
 			const notifyClient = {
-				sendAcknowledgePreNotification: mock.fn()
+				sendAcknowledgePreNotificationToMany: mock.fn()
 			};
 			const service = mockService();
 			service.appSharePointDrive = sharepointDrive;
@@ -357,20 +390,25 @@ describe('save', () => {
 				session: {
 					forms: {
 						'create-a-case': {
-							hasAgent: false,
-							applicantEmail: 'applicantEmail@mail.com',
-							agentEmail: 'agentEmail@mail.com'
+							hasAgent: false
 						}
 					}
 				}
 			};
 			const answers = {
+				manageApplicantDetails: [{ id: 'org-1', organisationName: 'Test Applicant Org' }],
+				manageApplicantContactDetails: [
+					{
+						applicantContactOrganisation: 'org-1',
+						applicantContactEmail: 'applicantEmail@mail.com',
+						applicantFirstName: 'Test',
+						applicantLastName: 'User'
+					}
+				],
 				developmentDescription: 'Project One',
 				typeOfApplication: 'application-type-1',
 				lpaId: 'lpa-1',
-				hasAgent: false,
-				applicantEmail: 'applicantEmail@mail.com',
-				agentEmail: 'agentEmail@mail.com'
+				hasAgent: false
 			};
 			const res = {
 				redirect: mock.fn(),
@@ -384,9 +422,9 @@ describe('save', () => {
 			await save(req, res, mock.fn());
 
 			assert.strictEqual(res.redirect.mock.callCount(), 1);
-			assert.strictEqual(notifyClient.sendAcknowledgePreNotification.mock.callCount(), 1);
-			assert.deepStrictEqual(notifyClient.sendAcknowledgePreNotification.mock.calls[0].arguments, [
-				'applicantEmail@mail.com',
+			assert.strictEqual(notifyClient.sendAcknowledgePreNotificationToMany.mock.callCount(), 1);
+			assert.deepStrictEqual(notifyClient.sendAcknowledgePreNotificationToMany.mock.calls[0].arguments, [
+				['applicantEmail@mail.com'],
 				{
 					reference: mockReference,
 					sharePointLink: 'https://sharepoint.com/:f:/s/site/random_id',
@@ -394,7 +432,7 @@ describe('save', () => {
 				}
 			]);
 		});
-		it('should send email to the agent when there is an agent on the case', async () => {
+		it('should send emails to agent contacts when there is an agent on the case', async () => {
 			const sharepointDrive = {
 				copyDriveItem: mock.fn(),
 				getItemsByPath: mock.fn(() => {
@@ -418,7 +456,7 @@ describe('save', () => {
 				})
 			};
 			const notifyClient = {
-				sendAcknowledgePreNotification: mock.fn()
+				sendAcknowledgePreNotificationToMany: mock.fn()
 			};
 			const service = mockService();
 			service.appSharePointDrive = sharepointDrive;
@@ -429,20 +467,35 @@ describe('save', () => {
 				session: {
 					forms: {
 						'create-a-case': {
-							hasAgent: true,
-							applicantEmail: 'applicantEmail@mail.com',
-							agentEmail: 'agentEmail@mail.com'
+							hasAgent: true
 						}
 					}
 				}
 			};
 			const answers = {
+				manageApplicantDetails: [{ id: 'org-1', organisationName: 'Test Applicant Org' }],
+				manageApplicantContactDetails: [
+					{
+						applicantContactOrganisation: 'org-1',
+						applicantContactEmail: 'applicantEmail@mail.com',
+						applicantFirstName: 'Test',
+						applicantLastName: 'User'
+					}
+				],
+				hasAgent: true,
+				agentOrganisationName: 'Test Agent Org',
+				manageAgentDetails: { id: 'agent-org-1', organisationName: 'Test Agent Org' },
+				manageAgentContactDetails: [
+					{
+						agentContactOrganisation: 'agent-org-1',
+						agentContactEmail: 'agentEmail@mail.com',
+						agentFirstName: 'Agent',
+						agentLastName: 'User'
+					}
+				],
 				developmentDescription: 'Project One',
 				typeOfApplication: 'application-type-1',
-				lpaId: 'lpa-1',
-				hasAgent: true,
-				applicantEmail: 'applicantEmail@mail.com',
-				agentEmail: 'agentEmail@mail.com'
+				lpaId: 'lpa-1'
 			};
 			const res = {
 				redirect: mock.fn(),
@@ -456,9 +509,9 @@ describe('save', () => {
 			await save(req, res, mock.fn());
 
 			assert.strictEqual(res.redirect.mock.callCount(), 1);
-			assert.strictEqual(notifyClient.sendAcknowledgePreNotification.mock.callCount(), 1);
-			assert.deepStrictEqual(notifyClient.sendAcknowledgePreNotification.mock.calls[0].arguments, [
-				'agentEmail@mail.com',
+			assert.strictEqual(notifyClient.sendAcknowledgePreNotificationToMany.mock.callCount(), 1);
+			assert.deepStrictEqual(notifyClient.sendAcknowledgePreNotificationToMany.mock.calls[0].arguments, [
+				['agentEmail@mail.com', 'applicantEmail@mail.com'],
 				{
 					reference: mockReference,
 					sharePointLink: 'https://sharepoint.com/:f:/s/site/random_id',
@@ -491,22 +544,17 @@ describe('save', () => {
 				link: { webUrl: 'https://sharepoint.com/:f:/s/site/lbc_link' }
 			}));
 			const notifyClient = {
-				sendAcknowledgePreNotification: mock.fn()
+				sendAcknowledgePreNotificationToMany: mock.fn()
 			};
 			const service = mockService();
 			service.appSharePointDrive = sharepointDrive;
 			service.notifyClient = notifyClient;
-			service.isMultipleApplicantsLive = false;
 			const save = buildSaveController(service);
 
 			const req = {
 				session: {
 					forms: {
-						'create-a-case': {
-							hasAgent: false,
-							applicantEmail: 'applicantEmail@mail.com',
-							agentEmail: 'agentEmail@mail.com'
-						}
+						'create-a-case': {}
 					}
 				}
 			};
@@ -514,9 +562,16 @@ describe('save', () => {
 				developmentDescription: 'Project One',
 				typeOfApplication: 'planning-permission-and-listed-building-consent',
 				lpaId: 'lpa-1',
-				hasAgent: false,
-				applicantEmail: 'applicantEmail@mail.com',
-				agentEmail: 'agentEmail@mail.com'
+				hasAgent: 'no',
+				manageApplicantDetails: [{ id: 'org-1', organisationName: 'Test Org' }],
+				manageApplicantContactDetails: [
+					{
+						applicantContactOrganisation: 'org-1',
+						applicantContactEmail: 'applicantEmail@mail.com',
+						applicantFirstName: 'Test',
+						applicantLastName: 'User'
+					}
+				]
 			};
 			const res = {
 				redirect: mock.fn(),
@@ -530,17 +585,17 @@ describe('save', () => {
 			await save(req, res, mock.fn());
 
 			assert.strictEqual(res.redirect.mock.callCount(), 1);
-			assert.strictEqual(notifyClient.sendAcknowledgePreNotification.mock.callCount(), 2);
-			assert.deepStrictEqual(notifyClient.sendAcknowledgePreNotification.mock.calls[0].arguments, [
-				'applicantEmail@mail.com',
+			assert.strictEqual(notifyClient.sendAcknowledgePreNotificationToMany.mock.callCount(), 2);
+			assert.deepStrictEqual(notifyClient.sendAcknowledgePreNotificationToMany.mock.calls[0].arguments, [
+				['applicantEmail@mail.com'],
 				{
 					reference: mockReference,
 					sharePointLink: 'https://sharepoint.com/:f:/s/site/planning_link',
 					isLbcCase: false
 				}
 			]);
-			assert.deepStrictEqual(notifyClient.sendAcknowledgePreNotification.mock.calls[1].arguments, [
-				'applicantEmail@mail.com',
+			assert.deepStrictEqual(notifyClient.sendAcknowledgePreNotificationToMany.mock.calls[1].arguments, [
+				['applicantEmail@mail.com'],
 				{
 					reference: `${mockReference}/LBC`,
 					sharePointLink: 'https://sharepoint.com/:f:/s/site/lbc_link',

--- a/apps/manage/src/app/views/cases/create-a-case/types.d.ts
+++ b/apps/manage/src/app/views/cases/create-a-case/types.d.ts
@@ -27,16 +27,7 @@ export interface CreateCaseAnswers {
 	lpaId?: string;
 	hasSecondaryLpa?: YesNo;
 	secondaryLpaId?: string;
-	// TODO single applicant/agent when we fully switch over to V2 CROWN-1509
-	applicantName?: string;
-	applicantAddress?: Address;
-	applicantEmail?: string;
-	applicantTelephoneNumber?: string;
 	hasAgent?: YesNo;
-	agentName?: string;
-	agentAddress?: Address;
-	agentEmail?: string;
-	agentTelephoneNumber?: string;
 	siteAddress?: Address;
 	siteNorthing?: string;
 	siteEasting?: string;
@@ -46,8 +37,7 @@ export interface CreateCaseAnswers {
 	agentOrganisationName?: string;
 	agentOrganisationAddress?: Address;
 	manageAgentContactDetails?: AgentContact[];
-	// TODO make this required when we fully switch over to V2 CROWN-1509
-	manageApplicantDetails?: ApplicantOrganisation[];
+	manageApplicantDetails: ApplicantOrganisation[];
 	manageApplicantContactDetails?: ApplicantContact[];
 	containsDistressingContent?: YesNo;
 }

--- a/apps/manage/src/app/views/cases/view/controller.js
+++ b/apps/manage/src/app/views/cases/view/controller.js
@@ -183,8 +183,6 @@ export function buildGetJourneyMiddleware(service, isQuestionView = false) {
 		const crownDevelopment = await db.crownDevelopment.findUnique({
 			where: { id },
 			include: {
-				ApplicantContact: { include: { Address: true } },
-				AgentContact: { include: { Address: true } },
 				Category: { include: { ParentCategory: true } },
 				Event: true,
 				Lpa: { include: { Address: true } },

--- a/packages/database/src/migrations/20260508133048_remove_old_multiple_entities_journey_from_db/migration.sql
+++ b/packages/database/src/migrations/20260508133048_remove_old_multiple_entities_journey_from_db/migration.sql
@@ -1,0 +1,33 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `agentContactId` on the `CrownDevelopment` table. All the data in the column will be lost.
+  - You are about to drop the column `applicantContactId` on the `CrownDevelopment` table. All the data in the column will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropForeignKey
+ALTER TABLE [dbo].[CrownDevelopment] DROP CONSTRAINT [CrownDevelopment_agentContactId_fkey];
+
+-- DropForeignKey
+ALTER TABLE [dbo].[CrownDevelopment] DROP CONSTRAINT [CrownDevelopment_applicantContactId_fkey];
+
+-- AlterTable
+ALTER TABLE [dbo].[CrownDevelopment] DROP COLUMN [agentContactId],
+[applicantContactId];
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -51,13 +51,6 @@ model CrownDevelopment {
   Organisations            CrownDevelopmentToOrganisation[]
 
   /// Applicant contact details (To be migrated to ApplicantContacts)
-  ///TODO: Remove applicantContactId and ApplicantContact relation after migration CROWN-1509
-  applicantContactId                  String?                     @db.UniqueIdentifier
-  ApplicantContact                    Contact?                    @relation("ApplicantContact", fields: [applicantContactId], references: [id], onUpdate: NoAction, onDelete: NoAction)
-  /// Agent contact details (To be migrated to AgentContacts)
-  ///TODO: Remove agentContactId and AgentContact relation after migration CROWN-1509
-  agentContactId                      String?                     @db.UniqueIdentifier
-  AgentContact                        Contact?                    @relation("AgentContact", fields: [agentContactId], references: [id], onUpdate: NoAction, onDelete: NoAction)
   /// Address of the site, if known
   siteAddressId                       String?                     @db.UniqueIdentifier
   SiteAddress                         Address?                    @relation(fields: [siteAddressId], references: [id], onUpdate: NoAction, onDelete: NoAction)
@@ -220,16 +213,11 @@ model Contact {
   ContactPreference   ContactPreference? @relation(fields: [contactPreferenceId], references: [id])
 
   /// Used for written-representation on behalf of an organisation
-  orgName        String?
-  jobTitleOrRole String?
+  orgName                          String?
+  jobTitleOrRole                   String?
   /// Used for written-representation contact preference 'post'
-  addressId      String?  @db.UniqueIdentifier
-  Address        Address? @relation(fields: [addressId], references: [id])
-
-  /// TODO: Remove  after migrating CrownDevelopment applicant and agent contacts to OrganisationToContact CROWN-1509
-  CrownDevelopmentApplicant CrownDevelopment[] @relation("ApplicantContact")
-  CrownDevelopmentAgent     CrownDevelopment[] @relation("AgentContact")
-
+  addressId                        String?                 @db.UniqueIdentifier
+  Address                          Address?                @relation(fields: [addressId], references: [id])
   RepresentationSubmittedByContact Representation[]        @relation("RepresentationSubmittedByContact")
   Representation                   Representation[]        @relation("RepresentedContact")
   NotifyEmail                      NotifyEmail[]


### PR DESCRIPTION
## Describe your changes
Changes include eliminating old code paths, enforcing new required fields, updating notification logic, and cleaning up the database model.

**Migration to multiple applicants/agents:**

* Removed legacy code for single applicant/agent support, including old input handling (`applicantEmail`, `agentEmail`), SharePoint permissions, and notification logic in `save.js` and related helper functions. Now, only the new multiple applicant/agent data structures are used. [[1]](diffhunk://#diff-c9f32035ccc6643be09a45933eb06fac87dbfdb8444e50d858edafce397c2399L451-L482) [[2]](diffhunk://#diff-c9f32035ccc6643be09a45933eb06fac87dbfdb8444e50d858edafce397c2399L500-L513) [[3]](diffhunk://#diff-c9f32035ccc6643be09a45933eb06fac87dbfdb8444e50d858edafce397c2399L578-L605) [[4]](diffhunk://#diff-c9f32035ccc6643be09a45933eb06fac87dbfdb8444e50d858edafce397c2399L645-L669)
* Enforced that agent contact details must be present if the case has an agent, throwing an error if missing.

**Notification and permissions logic:**

* Updated SharePoint permissions and notification logic to collect emails from all applicant and agent contacts, and to use the new `sendAcknowledgePreNotificationToMany` method for batch notifications. [[1]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L200-R211) [[2]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1R310-R332) [[3]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L319-R353) [[4]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L348-R381) [[5]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L360-R411) [[6]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L387-R435) [[7]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L421-R459) [[8]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L432-R498) [[9]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L459-R514) [[10]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L494-R574) [[11]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L533-R598)

**Test updates:**

* Refactored tests to use the new applicant/agent data structures and to verify that notifications and permissions are correctly applied to all relevant contacts. [[1]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L161-R172) [[2]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1R246-R257) [[3]](diffhunk://#diff-24230c01da5f0ebb8ce934d0140763c407e479382528ef894ccf2bcf83e5f0b1L261-R276)

**Database schema and query cleanup:**

* Removed the legacy `ApplicantContact` and `AgentContact` relations from the Prisma schema and from case view queries, as these are now handled via the new structure. [[1]](diffhunk://#diff-6100503ab4b111db0ac47cee279704372fa93f83b3e84c3f944e5f77f86325a5L54-L60) [[2]](diffhunk://#diff-66cc94bb1517d32801917b38ff3e2b2833dc2298dfc92190135787e31d52c25bL186-L187)

These changes fully remove support for the old single-applicant/agent model, enforce the new requirements, and ensure all relevant users are notified and granted permissions.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1509