### PR TITLE
fix(session): add CSRF protection for file uploads and refactor session middleware

### DIFF
--- a/apps/manage/src/app/app.js
+++ b/apps/manage/src/app/app.js
@@ -7,9 +7,10 @@ import { buildRouter } from './router.js';
 import { configureNunjucks } from './nunjucks.js';
 import { buildLogRequestsMiddleware } from '@pins/crowndev-lib/middleware/log-requests.js';
 import { buildDefaultErrorHandlerMiddleware, notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
-import { initSessionMiddlewareWithCsrf } from '@pins/crowndev-lib/util/session.ts';
+import { initSessionMiddleware } from '@pins/crowndev-lib/util/session.ts';
 import { addLocalsConfiguration } from '#util/config-middleware.js';
 import { cleanEmptyQueryParams, trimEmptyQuery } from '@pins/crowndev-lib/middleware/query-middleware.js';
+import lusca from 'lusca';
 
 /**
  * @param {import('#service').ManageService} service
@@ -31,12 +32,25 @@ export function getApp(service) {
 	app.use(bodyParser.urlencoded({ extended: true }));
 	app.use(bodyParser.json());
 
-	const sessionMiddleware = initSessionMiddlewareWithCsrf({
+	const sessionMiddleware = initSessionMiddleware({
 		redis: service.redisClient,
 		secure: service.secureSession,
 		secret: service.sessionSecret
 	});
 	app.use(sessionMiddleware);
+
+	// CSRF protection middleware, with an exception for the file upload endpoint which uses Multer and multipart/form-data
+	// see https://github.com/krakenjs/lusca/issues/70
+	app.use((req, res, next) => {
+		if (req.path.endsWith('/upload-documents') && req.method === 'POST') {
+			// Multer multipart/form-data needs to be handled before Lusca CSRF check
+			// upload-documents is the POST API the file-upload component in our journeys, which uses Multer
+			next();
+		} else {
+			lusca.csrf()(req, res, next);
+		}
+	});
+
 	app.use(addLocalsConfiguration(service));
 
 	// Generate the nonce for each request

--- a/apps/manage/src/app/app.js
+++ b/apps/manage/src/app/app.js
@@ -19,6 +19,7 @@ import lusca from 'lusca';
 export function getApp(service) {
 	// create an express app, and configure it for our usage
 	const app = express();
+	const csrfMiddleware = lusca.csrf();
 
 	const logRequests = buildLogRequestsMiddleware(service.logger);
 
@@ -42,12 +43,12 @@ export function getApp(service) {
 	// CSRF protection middleware, with an exception for the file upload endpoint which uses Multer and multipart/form-data
 	// see https://github.com/krakenjs/lusca/issues/70
 	app.use((req, res, next) => {
-		if (req.path.endsWith('/upload-documents') && req.method === 'POST') {
+		if (/\/upload-documents\/?$/.test(req.path) && req.method === 'POST') {
 			// Multer multipart/form-data needs to be handled before Lusca CSRF check
 			// upload-documents is the POST API the file-upload component in our journeys, which uses Multer
 			next();
 		} else {
-			lusca.csrf()(req, res, next);
+			csrfMiddleware(req, res, next);
 		}
 	});
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/add/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/add/index.js
@@ -23,6 +23,7 @@ import {
 } from '@pins/crowndev-lib/forms/representations/question-utils.js';
 import { uploadDocumentQuestion } from '@pins/crowndev-lib/forms/custom-components/representation-attachments/upload-document-middleware.js';
 import { buildResetSessionMiddleware } from '@pins/crowndev-lib/middleware/session.js';
+import lusca from 'lusca';
 
 /**
  * @param {import('#service').ManageService} service
@@ -66,6 +67,8 @@ export function createRoutes(service) {
 		getJourneyResponse,
 		getJourney,
 		handleUploads.array('files[]'),
+		// Lusca CSRF check performed after Multer handles the multipart/form-data
+		lusca({ csrf: true }),
 		uploadDocuments
 	);
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/add/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/add/index.js
@@ -19,6 +19,7 @@ import {
 import {
 	ALLOWED_EXTENSIONS,
 	ALLOWED_MIME_TYPES,
+	MAX_FILE_NUMBER,
 	MAX_FILE_SIZE
 } from '@pins/crowndev-lib/forms/representations/question-utils.js';
 import { uploadDocumentQuestion } from '@pins/crowndev-lib/forms/custom-components/representation-attachments/upload-document-middleware.js';
@@ -41,7 +42,7 @@ export function createRoutes(service) {
 	const saveDataToSession = buildSaveDataToSession({ reqParam: 'id' });
 	const saveController = buildSaveRepresentationController(service);
 
-	const handleUploads = multer();
+	const handleUploads = multer({ limits: { fileSize: MAX_FILE_SIZE, files: MAX_FILE_NUMBER } });
 	const uploadDocuments = asyncHandler(
 		uploadDocumentsController(service, JOURNEY_ID, ALLOWED_EXTENSIONS, ALLOWED_MIME_TYPES, MAX_FILE_SIZE)
 	);
@@ -68,7 +69,7 @@ export function createRoutes(service) {
 		getJourney,
 		handleUploads.array('files[]'),
 		// Lusca CSRF check performed after Multer handles the multipart/form-data
-		lusca({ csrf: true }),
+		lusca.csrf(),
 		uploadDocuments
 	);
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/index.js
@@ -28,6 +28,7 @@ import {
 	successController
 } from './reinstate/controller.js';
 import { buildSave } from './edit/save.js';
+import lusca from 'lusca';
 
 /**
  * @param {import('#service').ManageService} service
@@ -86,6 +87,8 @@ export function createRoutes(service) {
 		'/edit/:section/:question/upload-documents',
 		getJourney,
 		handleUploads.array('files[]'),
+		// Lusca CSRF check performed after Multer handles the multipart/form-data
+		lusca({ csrf: true }),
 		uploadDocuments
 	);
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/index.js
@@ -20,6 +20,7 @@ import {
 import {
 	ALLOWED_EXTENSIONS,
 	ALLOWED_MIME_TYPES,
+	MAX_FILE_NUMBER,
 	MAX_FILE_SIZE
 } from '@pins/crowndev-lib/forms/representations/question-utils.js';
 import {
@@ -52,7 +53,7 @@ export function createRoutes(service) {
 	const updateRepFn = buildUpdateRepresentation(service);
 	const saveAnswer = buildSave(updateRepFn, true);
 
-	const handleUploads = multer();
+	const handleUploads = multer({ limits: { fileSize: MAX_FILE_SIZE, files: MAX_FILE_NUMBER } });
 	const uploadDocuments = asyncHandler(
 		uploadDocumentsController(
 			service,
@@ -88,7 +89,7 @@ export function createRoutes(service) {
 		getJourney,
 		handleUploads.array('files[]'),
 		// Lusca CSRF check performed after Multer handles the multipart/form-data
-		lusca({ csrf: true }),
+		lusca.csrf(),
 		uploadDocuments
 	);
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/task-list/attachment/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/task-list/attachment/index.js
@@ -10,9 +10,11 @@ import {
 import {
 	ALLOWED_EXTENSIONS,
 	ALLOWED_MIME_TYPES,
+	MAX_FILE_NUMBER,
 	MAX_FILE_SIZE
 } from '@pins/crowndev-lib/forms/representations/question-utils.js';
 import { buildDeleteRepresentationRedactedDocumentMiddleware } from './delete-attachment-middleware.js';
+import lusca from 'lusca';
 
 export function createRoutes(service, journeyId) {
 	const router = createRouter({ mergeParams: true });
@@ -24,7 +26,7 @@ export function createRoutes(service, journeyId) {
 	} = buildReviewControllers(service, journeyId);
 	const viewDocument = buildViewDocument(service);
 	const validateRedactedFileMiddleware = buildValidateRedactedFileMiddleware(service);
-	const handleUploads = multer();
+	const handleUploads = multer({ limits: { fileSize: MAX_FILE_SIZE, files: MAX_FILE_NUMBER } });
 	const uploadDocuments = asyncHandler(
 		uploadDocumentsController(
 			service,
@@ -49,6 +51,8 @@ export function createRoutes(service, journeyId) {
 	router.post(
 		'/redact/upload-documents',
 		handleUploads.array('files[]'),
+		// Lusca CSRF check performed after Multer handles the multipart/form-data
+		lusca.csrf(),
 		validateRedactedFileMiddleware,
 		uploadDocuments
 	);

--- a/apps/manage/src/app/views/cases/view/manage-reps/withdraw/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/withdraw/index.js
@@ -23,6 +23,7 @@ import { buildResetSessionMiddleware } from '@pins/crowndev-lib/middleware/sessi
 import { createJourney, JOURNEY_ID } from './journey.js';
 import { buildSaveController, successController } from './controller.js';
 import { getQuestions } from '@pins/crowndev-lib/forms/representations/questions.js';
+import lusca from 'lusca';
 
 /**
  * @param {import('#service').ManageService} service
@@ -74,6 +75,8 @@ export function createRoutes(service, viewOrReview) {
 		getJourneyResponse,
 		getJourney,
 		handleUploads.array('files[]'),
+		// Lusca CSRF check performed after Multer handles the multipart/form-data
+		lusca({ csrf: true }),
 		uploadDocuments
 	);
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/withdraw/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/withdraw/index.js
@@ -7,6 +7,7 @@ import {
 import {
 	ALLOWED_EXTENSIONS,
 	ALLOWED_MIME_TYPES,
+	MAX_FILE_NUMBER,
 	MAX_FILE_SIZE
 } from '@pins/crowndev-lib/forms/representations/question-utils.js';
 import { uploadDocumentQuestion } from '@pins/crowndev-lib/forms/custom-components/representation-attachments/upload-document-middleware.js';
@@ -41,7 +42,7 @@ export function createRoutes(service, viewOrReview) {
 	const getJourneyResponse = buildGetJourneyResponseFromSession(JOURNEY_ID, 'representationRef');
 	const saveDataToSession = buildSaveDataToSession({ reqParam: 'representationRef' });
 
-	const handleUploads = multer();
+	const handleUploads = multer({ limits: { fileSize: MAX_FILE_SIZE, files: MAX_FILE_NUMBER } });
 	const uploadDocuments = asyncHandler(
 		uploadDocumentsController(
 			service,
@@ -76,7 +77,7 @@ export function createRoutes(service, viewOrReview) {
 		getJourney,
 		handleUploads.array('files[]'),
 		// Lusca CSRF check performed after Multer handles the multipart/form-data
-		lusca({ csrf: true }),
+		lusca.csrf(),
 		uploadDocuments
 	);
 

--- a/apps/portal/src/app/app.js
+++ b/apps/portal/src/app/app.js
@@ -5,11 +5,12 @@ import { buildRouter } from './router.js';
 import { configureNunjucks } from './nunjucks.js';
 import { buildLogRequestsMiddleware } from '@pins/crowndev-lib/middleware/log-requests.js';
 import { buildDefaultErrorHandlerMiddleware, notFoundHandler } from '@pins/crowndev-lib/middleware/errors.js';
-import { initSessionMiddlewareWithCsrf } from '@pins/crowndev-lib/util/session.ts';
+import { initSessionMiddleware } from '@pins/crowndev-lib/util/session.ts';
 import { addLocalsConfiguration } from '#util/config-middleware.js';
 import { initContentSecurityPolicyMiddlewares } from '#util/csp-middleware.js';
 import { buildAnalyticsCookiesMiddleware } from '#util/cookies.js';
 import { cleanEmptyQueryParams, trimEmptyQuery } from '@pins/crowndev-lib/middleware/query-middleware.js';
+import lusca from 'lusca';
 
 /**
  * @param {import('#service').PortalService} service
@@ -29,12 +30,24 @@ export function getApp(service) {
 	app.use(bodyParser.urlencoded({ extended: true }));
 	app.use(bodyParser.json());
 
-	const sessionMiddleware = initSessionMiddlewareWithCsrf({
+	const sessionMiddleware = initSessionMiddleware({
 		redis: service.redisClient,
 		secure: service.secureSession,
 		secret: service.sessionSecret
 	});
 	app.use(sessionMiddleware);
+
+	// CSRF protection middleware, with an exception for the file upload endpoint which uses Multer and multipart/form-data
+	// see https://github.com/krakenjs/lusca/issues/70
+	app.use((req, res, next) => {
+		if (req.path.endsWith('/upload-documents') && req.method === 'POST') {
+			// Multer multipart/form-data needs to be handled before Lusca CSRF check
+			// upload-documents is the POST API the file-upload component in our journeys, which uses Multer
+			next();
+		} else {
+			lusca.csrf()(req, res, next);
+		}
+	});
 
 	app.use(addLocalsConfiguration(service));
 	app.use(buildAnalyticsCookiesMiddleware(service));

--- a/apps/portal/src/app/app.js
+++ b/apps/portal/src/app/app.js
@@ -19,7 +19,7 @@ import lusca from 'lusca';
 export function getApp(service) {
 	// create an express app, and configure it for our usage
 	const app = express();
-
+	const csrfMiddleware = lusca.csrf();
 	const logRequests = buildLogRequestsMiddleware(service.logger);
 	// middleware to clean empty query params and trim empty query values
 	app.use(cleanEmptyQueryParams, trimEmptyQuery);
@@ -40,12 +40,12 @@ export function getApp(service) {
 	// CSRF protection middleware, with an exception for the file upload endpoint which uses Multer and multipart/form-data
 	// see https://github.com/krakenjs/lusca/issues/70
 	app.use((req, res, next) => {
-		if (req.path.endsWith('/upload-documents') && req.method === 'POST') {
+		if (/\/upload-documents\/?$/.test(req.path) && req.method === 'POST') {
 			// Multer multipart/form-data needs to be handled before Lusca CSRF check
 			// upload-documents is the POST API the file-upload component in our journeys, which uses Multer
 			next();
 		} else {
-			lusca.csrf()(req, res, next);
+			csrfMiddleware(req, res, next);
 		}
 	});
 

--- a/apps/portal/src/app/views/applications/view/have-your-say/index.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/index.js
@@ -31,6 +31,7 @@ import {
 } from '@pins/crowndev-lib/forms/representations/question-utils.js';
 import { uploadDocumentQuestion } from '@pins/crowndev-lib/forms/custom-components/representation-attachments/upload-document-middleware.js';
 import { buildResetSessionMiddleware } from '@pins/crowndev-lib/middleware/session.js';
+import lusca from 'lusca';
 
 const applicationIdParam = 'applicationId';
 
@@ -80,6 +81,8 @@ export function createHaveYourSayRoutes(service) {
 		getJourneyResponse,
 		getJourney,
 		handleUploads.array('files[]'),
+		// Lusca CSRF check performed after Multer handles the multipart/form-data
+		lusca({ csrf: true }),
 		uploadDocuments
 	);
 

--- a/apps/portal/src/app/views/applications/view/have-your-say/index.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/index.js
@@ -27,6 +27,7 @@ import multer from 'multer';
 import {
 	ALLOWED_EXTENSIONS,
 	ALLOWED_MIME_TYPES,
+	MAX_FILE_NUMBER,
 	MAX_FILE_SIZE
 } from '@pins/crowndev-lib/forms/representations/question-utils.js';
 import { uploadDocumentQuestion } from '@pins/crowndev-lib/forms/custom-components/representation-attachments/upload-document-middleware.js';
@@ -53,7 +54,7 @@ export function createHaveYourSayRoutes(service) {
 	const redirectToHaveYourSayJourney = startHaveYourSayJourney(service);
 	const saveDataToSession = buildSaveDataToSession({ reqParam: applicationIdParam });
 	const saveRepresentation = asyncHandler(buildSaveHaveYourSayController(service));
-	const handleUploads = multer();
+	const handleUploads = multer({ limits: { fileSize: MAX_FILE_SIZE, files: MAX_FILE_NUMBER } });
 	const uploadDocuments = asyncHandler(
 		uploadDocumentsController(service, JOURNEY_ID, ALLOWED_EXTENSIONS, ALLOWED_MIME_TYPES, MAX_FILE_SIZE)
 	);
@@ -82,7 +83,7 @@ export function createHaveYourSayRoutes(service) {
 		getJourney,
 		handleUploads.array('files[]'),
 		// Lusca CSRF check performed after Multer handles the multipart/form-data
-		lusca({ csrf: true }),
+		lusca.csrf(),
 		uploadDocuments
 	);
 

--- a/packages/lib/forms/custom-components/representation-attachments/index.njk
+++ b/packages/lib/forms/custom-components/representation-attachments/index.njk
@@ -83,12 +83,12 @@
             {% set uploadForm = "upload-form" %}
 
             <form id={{ uploadForm }} method="post" enctype="multipart/form-data" action="{{ currentUrl }}/upload-documents">
+                <input type="hidden" name="_csrf" value="{{ _csrf }}">
                 <div id="uploadingBar" class="govuk-notification-banner govuk-notification-banner--info uploading-bar--hidden" aria-live="polite" aria-hidden="true" role="region">
                     <div class="govuk-notification-banner__content">
                         <strong>Uploading...</strong>
                     </div>
                 </div>
-                <input type="hidden" name="_csrf" value="{{ _csrf }}">
                 {{ govukFileUpload({
                     id: question.fieldName,
                     name: "files[]",

--- a/packages/lib/forms/representations/question-utils.js
+++ b/packages/lib/forms/representations/question-utils.js
@@ -20,6 +20,7 @@ export const ALLOWED_MIME_TYPES = [
 	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 ];
 export const MAX_FILE_SIZE = 20 * 1024 * 1024;
+export const MAX_FILE_NUMBER = 10;
 
 /**
  *

--- a/packages/lib/util/session.ts
+++ b/packages/lib/util/session.ts
@@ -1,7 +1,6 @@
 import session from 'express-session';
-import lusca from 'lusca';
 import type { RedisClient } from '../redis/redis-client.js';
-import type { Request, RequestHandler } from 'express';
+import type { Request } from 'express';
 
 type SessionFieldData = Record<string, Record<string, unknown>>;
 type SessionRecord = Record<string, SessionFieldData>;
@@ -14,7 +13,7 @@ function isUnsafeObjectKey(key: string): boolean {
 /**
  * Initialise session middleware, using Redis if available, otherwise falling back to in-memory store
  */
-function initSessionMiddleware({
+export function initSessionMiddleware({
 	redis,
 	secure,
 	secret
@@ -36,17 +35,6 @@ function initSessionMiddleware({
 			maxAge: 86_400_000
 		}
 	});
-}
-
-/**
- * Initialise session middleware with CSRF included
- */
-export function initSessionMiddlewareWithCsrf(opts: {
-	redis: RedisClient | null;
-	secret: string;
-	secure: boolean;
-}): RequestHandler[] {
-	return [initSessionMiddleware(opts), lusca.csrf()];
 }
 
 /**


### PR DESCRIPTION
## Describe your changes
This pull request introduces a fix to CSRF protection in both the Manage and Portal applications. The main change is the switch from handling CSRF within the session middleware to using the `lusca` middleware directly, allowing better compatibility with file uploads (handled by Multer) that use `multipart/form-data`. The CSRF middleware is now applied after Multer processes uploads, and a hidden CSRF input is ensured in the upload form. Additionally, related code has been simplified by removing the combined session-and-CSRF middleware.

**CSRF Middleware Fix:**

* Reverted the `initSessionMiddlewareWithCsrf` function to `initSessionMiddleware`, removing CSRF handling from the session layer and instead applying the `lusca` CSRF middleware directly in the main app setup for both the Manage and Portal apps. This allows for more flexible CSRF handling, particularly for endpoints that handle file uploads. [[1]](diffhunk://#diff-8a334319052fb21ea81e773e2cebb6e6d4997dbc2e9f0ab02bfb7d8dda578891L10-R13) [[2]](diffhunk://#diff-5ba0453f012b2515fa367d48538dbf51604627c1ffbb85d6adc2d2b61aaf8986L8-R13) [[3]](diffhunk://#diff-16d50753971935f089363d927bf571e8343a04faaea69b550071356a86950318L2-R3) [[4]](diffhunk://#diff-16d50753971935f089363d927bf571e8343a04faaea69b550071356a86950318L17-R16) [[5]](diffhunk://#diff-16d50753971935f089363d927bf571e8343a04faaea69b550071356a86950318L41-L51)
* Added conditional application of the `lusca` CSRF middleware in the main app files to skip CSRF checks for file upload endpoints using Multer, fixing issues with multipart/form-data requests. [[1]](diffhunk://#diff-8a334319052fb21ea81e773e2cebb6e6d4997dbc2e9f0ab02bfb7d8dda578891L34-R53) [[2]](diffhunk://#diff-5ba0453f012b2515fa367d48538dbf51604627c1ffbb85d6adc2d2b61aaf8986L32-R51)

**File Upload Route Updates:**

* Updated all relevant file upload routes in both Manage and Portal apps to explicitly apply the `lusca` CSRF middleware after Multer handles the upload, ensuring CSRF protection is enforced immediately after file parsing. [[1]](diffhunk://#diff-ce9ed806b82182befef75e29953de1e8f24f175c9c4ed5d5c6054137ff13094cR26) [[2]](diffhunk://#diff-ce9ed806b82182befef75e29953de1e8f24f175c9c4ed5d5c6054137ff13094cR70-R71) [[3]](diffhunk://#diff-d3beea54292d2075250e349f698d1a3cdec064a64ea651146c813fa593395a73R31) [[4]](diffhunk://#diff-d3beea54292d2075250e349f698d1a3cdec064a64ea651146c813fa593395a73R90-R91) [[5]](diffhunk://#diff-740fa8bbe9f5aa0417fd520d2a057db3bb307924899f5984f9b1fdb5fd6258fcR26) [[6]](diffhunk://#diff-740fa8bbe9f5aa0417fd520d2a057db3bb307924899f5984f9b1fdb5fd6258fcR78-R79) [[7]](diffhunk://#diff-3ace57cc18dda26873fbe1a664d8c016c137a18cecc871896ec0a04ba92409fcR34) [[8]](diffhunk://#diff-3ace57cc18dda26873fbe1a664d8c016c137a18cecc871896ec0a04ba92409fcR84-R85)

**Template Update:**

* Moved the hidden CSRF input field to the top of the upload form in the `representation-attachments` component to ensure the CSRF token is always included in POST requests.

## Issue ticket number and link
