### PR TITLE
fix(manage): validation errors fixed with added kebabCase

### DIFF
--- a/apps/manage/src/app/nunjucks.js
+++ b/apps/manage/src/app/nunjucks.js
@@ -43,5 +43,22 @@ export function configureNunjucks() {
 	env.addGlobal('buildPageUrl', buildPageUrl);
 	env.addGlobal('buildItemsPerPageUrl', buildItemsPerPageUrl);
 
+	// Add kebab-case filter for HTML IDs
+	env.addFilter('kebabCase', (str) => {
+		return (
+			String(str)
+				.trim()
+				.toLowerCase()
+				// Replace spaces and underscores with hyphens
+				.replace(/[\s_]+/g, '-')
+				// Remove any characters that aren't alphanumeric or hyphens
+				.replace(/[^a-z0-9-]/g, '')
+				// Replace multiple consecutive hyphens with a single hyphen
+				.replace(/-+/g, '-')
+				// Remove leading/trailing hyphens
+				.replace(/^-+|-+$/g, '')
+		);
+	});
+
 	return env;
 }

--- a/apps/manage/src/app/views/cases/view/view.njk
+++ b/apps/manage/src/app/views/cases/view/view.njk
@@ -64,7 +64,7 @@
                 {% for section in summaryListData.sections %}
                     {% if section.list.rows.length %}
                         <li>
-                            <a href="#{{ section.heading | lower }}"
+                            <a href="#{{ section.heading | kebabCase }}"
                                class="govuk-link govuk-link--no-visited-state">{{ section.heading }}</a>
                         </li>
                     {% endif %}
@@ -116,7 +116,7 @@
                             title: {
                                 text: section.heading
                             },
-                            attributes: {id: section.heading | lower}
+                            attributes: {id: section.heading | kebabCase}
                         },
                         rows: section.list.rows
                     }) }}


### PR DESCRIPTION
## Describe your changes

This pull request introduces a new Nunjucks filter to consistently generate kebab-case HTML IDs from section headings and updates the relevant template code to use this filter. This ensures that all generated IDs are valid, consistent, and free from problematic characters.

**Template filter addition:**

* Added a new `kebabCase` filter to Nunjucks in `nunjucks.js` to convert strings to kebab-case, suitable for HTML IDs.

**Template usage updates:**

* Updated `view.njk` to use the new `kebabCase` filter for generating anchor link `href` attributes and section IDs, replacing the previous use of the `lower` filter [[1]](diffhunk://#diff-8e00175704c357e01fcbec675c519b0af3754c21c34727da1bdddd81aa02c482L67-R67) [[2]](diffhunk://#diff-8e00175704c357e01fcbec675c519b0af3754c21c34727da1bdddd81aa02c482L119-R119).

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1610
<img width="933" height="766" alt="image" src="https://github.com/user-attachments/assets/6dca9941-4d25-429b-bc4c-48b7ef4ded64" />
<img width="515" height="54" alt="image" src="https://github.com/user-attachments/assets/d70f8424-1178-4086-8635-16d4e6dcbdb4" />
