### PR TITLE
fix(database): add defaults to required value migration

### DIFF
--- a/packages/database/src/migrations/20260507154757_make_required_data_model_fields_required_in_database/migration.sql
+++ b/packages/database/src/migrations/20260507154757_make_required_data_model_fields_required_in_database/migration.sql
@@ -12,6 +12,12 @@ BEGIN TRY
 
 BEGIN TRAN;
 
+-- Update existing NULLs to the default value
+UPDATE [dbo].[CrownDevelopment] SET [hasSecondaryLpa] = 0 WHERE [hasSecondaryLpa] IS NULL;
+UPDATE [dbo].[CrownDevelopment] SET [description] = '' WHERE [description] IS NULL;
+UPDATE [dbo].[CrownDevelopment] SET [expectedDateOfSubmission] = GETDATE() WHERE [expectedDateOfSubmission] IS NULL;
+UPDATE [dbo].[CrownDevelopment] SET [containsDistressingContent] = 0 WHERE [containsDistressingContent] IS NULL;
+
 -- AlterTable
 ALTER TABLE [dbo].[CrownDevelopment] ALTER COLUMN [description] NVARCHAR(2000) NOT NULL;
 ALTER TABLE [dbo].[CrownDevelopment] ALTER COLUMN [lpaId] UNIQUEIDENTIFIER NOT NULL;


### PR DESCRIPTION
## Describe your changes
Add default values for fields marked as required in migration in https://github.com/Planning-Inspectorate/crown-developments/pull/960
On the whole these fields should only be needed/used for seeded data on non-prod environments where the required fields are missing.

## Issue ticket number and link
N/A