### PR TITLE
feat(manage): add app history service

### DIFF
--- a/apps/manage/src/app/audit/README.md
+++ b/apps/manage/src/app/audit/README.md
@@ -1,0 +1,51 @@
+# Audit
+
+This directory contains the case history (audit) system, responsible for recording and displaying actions performed on a case.
+
+## How it works
+
+Significant actions produce an `AuditEntry`, which is persisted to the `ApplicationHistory` table. Events are shown on the case history page as a paginated table with date/time, details, and user columns. The case details page also shows a last-modified summary (date and user) sourced from the same data.
+
+## Service (`service.ts`)
+
+`buildAuditService(db, logger)` creates the audit service with the following methods:
+
+- `record()` — persists a single audit event, then updates the case's `updatedDate`/`updatedById`. Fire-and-forget: failures are logged but never thrown, so an audit failure can't break the user's operation.
+- `recordMany()` — persists multiple events plus a single case update in one transaction. Intended for operations that produce many entries at once.
+- `getAllForCase()` — retrieves paginated events for a case, newest first. Returns an empty array on failure so the history page can still render.
+- `countForCase()` — returns the total event count for a case. Returns 0 on failure.
+- `getLastModifiedInfo()` — returns the formatted last-modified date and resolved user display name for the case summary card.
+
+User identities are stored as raw Entra IDs. Display names are resolved at read time by matching the stored ID against Entra group members (case officers and inspectors); an unmatched ID falls back to the raw ID, then to "Unknown".
+
+## Actions & templates (`actions.ts`)
+
+- `AUDIT_ACTIONS` defines the available action types.
+- `AUDIT_TEMPLATES` maps each action to a human-readable template string with `{placeholder}` syntax.
+- `resolveTemplate()` replaces placeholders with values from the event's metadata at display time. Unknown placeholders are left as-is.
+
+Currently the only action is `CASE_CREATED` (`'{reference} was created'`).
+
+## Types (`types.ts`)
+
+- `AuditEntry` — input for recording an event. `metadata` is an intentionally loose key-value bag so different actions can carry different data without a schema migration per action type.
+- `AuditEvent` — an event as returned from the database, with parsed metadata.
+- `AuditQueryOptions` — pagination options (`skip`, `take`).
+
+## Example
+
+```typescript
+await audit.record({
+    caseId: 'case-123',
+    action: AUDIT_ACTIONS.CASE_CREATED,
+    userId: 'user-456',
+    metadata: { reference: 'CROWN/2026/0000001' }
+});
+// Produces: "CROWN/2026/0000001 was created"
+```
+
+## Adding a new audit action
+
+1. Add the action key to `AUDIT_ACTIONS` in `actions.ts`.
+2. Add a matching template to `AUDIT_TEMPLATES` in the same file, using `{placeholder}` syntax for any metadata values.
+3. Record it with metadata keys matching the template placeholders.

--- a/apps/manage/src/app/audit/actions.test.ts
+++ b/apps/manage/src/app/audit/actions.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveTemplate, AUDIT_ACTIONS } from './actions.ts';
+
+describe('resolveTemplate', () => {
+	it('should return template as-is when no metadata is provided', () => {
+		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED);
+		assert.strictEqual(result, '{reference} was created');
+	});
+
+	it('should return template as-is when metadata is undefined', () => {
+		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED, undefined);
+		assert.strictEqual(result, '{reference} was created');
+	});
+
+	it('should replace a placeholder with a metadata value', () => {
+		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED, { reference: 'DRT/PER/00015' });
+		assert.strictEqual(result, 'DRT/PER/00015 was created');
+	});
+
+	it('should leave placeholder as-is when metadata key is missing', () => {
+		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED, {});
+		assert.strictEqual(result, '{reference} was created');
+	});
+
+	it('should leave placeholder as-is when metadata value is undefined', () => {
+		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED, { reference: undefined });
+		assert.strictEqual(result, '{reference} was created');
+	});
+
+	it('should leave placeholder as-is when metadata value is null', () => {
+		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED, { reference: null });
+		assert.strictEqual(result, '{reference} was created');
+	});
+
+	it('should convert numeric metadata values to strings', () => {
+		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED, { reference: 42 });
+		assert.strictEqual(result, '42 was created');
+	});
+
+	it('should ignore metadata keys that are not placeholders in the template', () => {
+		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED, { reference: 'DRT/PER/00015', extra: 'ignored' });
+		assert.strictEqual(result, 'DRT/PER/00015 was created');
+	});
+});

--- a/apps/manage/src/app/audit/actions.ts
+++ b/apps/manage/src/app/audit/actions.ts
@@ -1,0 +1,61 @@
+/**
+ * Audit action definitions.
+ *
+ * Each action maps to a template string used to generate the human-readable
+ * "Details" column in the case history table. Templates can include
+ * placeholders like `{reference}` or `{fieldName}` which are resolved at
+ * display time from the event's metadata.
+ *
+ * Grouping follows the case history scenarios document.
+ */
+
+export const AUDIT_ACTIONS = {
+	// Case
+	CASE_CREATED: 'CASE_CREATED'
+} as const;
+
+export type AuditAction = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];
+
+/**
+ * Maps each action to the template shown in the "Details" column of the
+ * case history table.
+ *
+ * Placeholders are resolved from the event's metadata at display time.
+ * A dash `-` is used when there is no previous value (i.e. the field was empty).
+ *
+ * Metadata keys used across templates:
+ *   {reference}      – case reference (e.g. DRT/PER/00015)
+ */
+export const AUDIT_TEMPLATES: Record<AuditAction, string> = {
+	// Case
+	[AUDIT_ACTIONS.CASE_CREATED]: '{reference} was created'
+};
+
+/**
+ * Resolves a template string by replacing `{key}` placeholders with values
+ * from the supplied metadata.
+ *
+ * Unknown placeholders are left as-is so they're visible during development.
+ */
+export function resolveTemplate(action: AuditAction, metadata?: Record<string, unknown>): string {
+	const template = AUDIT_TEMPLATES[action];
+
+	if (!metadata) {
+		return template;
+	}
+
+	return template.replace(/\{(\w+)\}/g, (match: string, key: string) => {
+		const value = metadata[key];
+
+		if (value === undefined || value === null) {
+			return match;
+		}
+
+		if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+			return String(value);
+		}
+
+		// Non-primitive metadata can't be meaningfully interpolated — leave the placeholder.
+		return match;
+	});
+}

--- a/apps/manage/src/app/audit/index.ts
+++ b/apps/manage/src/app/audit/index.ts
@@ -1,0 +1,3 @@
+export { buildAuditService, type AuditService } from './service.ts';
+export { AUDIT_ACTIONS, AUDIT_TEMPLATES, resolveTemplate, type AuditAction } from './actions.ts';
+export type { AuditEntry, AuditEvent, AuditQueryOptions } from './types.ts';

--- a/apps/manage/src/app/audit/resolvers/README.md
+++ b/apps/manage/src/app/audit/resolvers/README.md
@@ -1,0 +1,33 @@
+# Audit Resolvers
+
+This directory is for **resolvers** that translate raw database and form data into human-readable audit entries.
+
+> **Status: not yet implemented.** This directory is currently empty. The audit
+> system today records only simple, self-describing events (e.g. `CASE_CREATED`)
+> whose metadata is supplied directly at the call site. Resolvers will be added
+> when the audit trail is extended to cover field-level and list changes. This
+> README describes the intended pattern for that work — it does not describe code
+> that exists yet.
+
+## Why resolvers will exist
+
+When a user saves a form, the raw data is database IDs, field keys, and values. An audit trail should read _"Status was updated from New to Accepted"_, not _"statusId was updated from new to accepted"_. A resolver knows how to translate one type of field from raw data into something a person can read.
+
+## Intended pattern
+
+### Field resolvers (scalar fields)
+
+For simple scalar fields on the `CrownDevelopment` model (status, procedure, case officer, etc.), a field resolver would take the old DB value and the new form value and return display-friendly `{ oldValue, newValue }` strings. Fields without a specific resolver would fall through to a default that stringifies the raw value.
+
+### List resolvers (one-to-many relationships)
+
+For one-to-many relationships, a list resolver would compare the old and new lists, determine what was added, removed, or changed, and produce the appropriate audit entries for each difference. Each entity type would get its own resolver.
+
+## When you add resolver support for a new field or entity
+
+1. **Add audit action(s)** in `audit/actions.ts` (e.g. `MY_ENTITY_ADDED`, `MY_ENTITY_UPDATED`, `MY_ENTITY_DELETED`).
+2. **Add matching templates** in `AUDIT_TEMPLATES` in the same file.
+3. **Create the resolver here** — a field resolver for a scalar field, or a new list resolver for a new entity type.
+4. **Wire it into the relevant save/update controller** so the resolver runs after the database write and the resulting entries are passed to `audit.recordMany()`.
+
+Update this README's status note once the first resolver lands.

--- a/apps/manage/src/app/audit/resolvers/index.ts
+++ b/apps/manage/src/app/audit/resolvers/index.ts
@@ -1,0 +1,1 @@
+// Barrel export

--- a/apps/manage/src/app/audit/service.test.ts
+++ b/apps/manage/src/app/audit/service.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, mock, type Mock } from 'node:test';
+import assert from 'node:assert';
+import type { PrismaClient } from '@pins/crowndev-database/src/client/client.ts';
+import { buildAuditService } from './service.ts';
+import type { AuditEntry } from './types.ts';
+import type { EntraGroupMembers } from '../../util/entra-groups.ts';
+import type { GroupMember } from '@pins/crowndev-lib/graph/types.js';
+import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
+import type { Logger } from 'pino';
+
+// mockLogger() returns a logger whose methods are node:test mock fns.
+// This exposes the `.mock` surface the assertions rely on, without `any`.
+type MockLogger = {
+	error: Mock<(...args: unknown[]) => void>;
+	info: Mock<(...args: unknown[]) => void>;
+	warn: Mock<(...args: unknown[]) => void>;
+	debug: Mock<(...args: unknown[]) => void>;
+};
+
+// Narrows a recorded mock call's first argument to an expected shape.
+// Tests are where a focused cast is least objectionable: the assertion
+// immediately verifies the shape declared here.
+const firstArg = <T>(call: { arguments: unknown[] }): T => call.arguments[0] as T;
+
+describe('Audit Service', () => {
+	const createMockDb = () => ({
+		applicationHistory: {
+			create: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			createMany: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			findMany: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			findFirst: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			count: mock.fn<(...args: unknown[]) => Promise<unknown>>()
+		},
+		crownDevelopment: {
+			create: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			findMany: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			findFirst: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			count: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			findUnique: mock.fn<(...args: unknown[]) => Promise<unknown>>(),
+			update: mock.fn<(...args: unknown[]) => Promise<unknown>>()
+		},
+		$transaction: mock.fn(async (arg: unknown) => {
+			// record() passes an array of promises; recordMany() passes a callback
+			if (typeof arg === 'function') {
+				return arg(mockDbForTx);
+			}
+			return Promise.all(arg as Promise<unknown>[]);
+		})
+	});
+
+	// The interactive transaction callback in recordMany receives a tx client.
+	// For these unit tests it can be the same mock surface as the top-level db.
+	let mockDbForTx: ReturnType<typeof createMockDb>;
+
+	// Build the service from a mock DB. The mock only implements the handful of
+	// delegates the service touches, so route through `unknown` to the real type
+	// rather than leaking `any` through the suite.
+	const buildService = (mockDb: ReturnType<typeof createMockDb>) => {
+		mockDbForTx = mockDb;
+		const logger = mockLogger() as unknown as MockLogger;
+		const service = buildAuditService(mockDb as unknown as PrismaClient, logger as unknown as Logger);
+		return { service, logger };
+	};
+
+	// Helper to build a GroupMember without repeating the full Graph shape.
+	const member = (id: string, displayName: string): GroupMember => ({ id, displayName }) as GroupMember;
+
+	describe('record', () => {
+		it('should create an audit event with correct data', async () => {
+			const mockDb = createMockDb();
+			mockDb.applicationHistory.create.mock.mockImplementationOnce(() => Promise.resolve({ id: 'event-1' }));
+			mockDb.crownDevelopment.update.mock.mockImplementationOnce(() => Promise.resolve({ id: 'case-123' }));
+
+			const { service } = buildService(mockDb);
+
+			const entry: AuditEntry = {
+				caseId: 'case-123',
+				action: 'CASE_CREATED',
+				userId: 'user-456',
+				metadata: { caseName: 'Test Case' }
+			};
+
+			await service.record(entry);
+
+			const { data } = firstArg<{
+				data: { Application: unknown; action: string; userId: string; metadata: string };
+			}>(mockDb.applicationHistory.create.mock.calls[0]);
+
+			assert.deepStrictEqual(data.Application, { connect: { id: 'case-123' } });
+			assert.strictEqual(data.action, 'CASE_CREATED');
+			assert.strictEqual(data.userId, 'user-456');
+			assert.strictEqual(data.metadata, JSON.stringify({ caseName: 'Test Case' }));
+		});
+
+		it('should update the case updatedDate and updatedById', async () => {
+			const mockDb = createMockDb();
+			mockDb.applicationHistory.create.mock.mockImplementationOnce(() => Promise.resolve({ id: 'event-1' }));
+			mockDb.crownDevelopment.update.mock.mockImplementationOnce(() => Promise.resolve({ id: 'case-123' }));
+
+			const { service } = buildService(mockDb);
+
+			await service.record({
+				caseId: 'case-123',
+				action: 'CASE_CREATED',
+				userId: 'user-456'
+			});
+
+			const update = firstArg<{
+				where: { id: string };
+				data: { updatedDate: Date; updatedById: string };
+			}>(mockDb.crownDevelopment.update.mock.calls[0]);
+
+			assert.deepStrictEqual(update.where, { id: 'case-123' });
+			assert.strictEqual(update.data.updatedById, 'user-456');
+			assert.ok(update.data.updatedDate instanceof Date);
+		});
+
+		it('should handle metadata being undefined', async () => {
+			const mockDb = createMockDb();
+			mockDb.applicationHistory.create.mock.mockImplementationOnce(() => Promise.resolve({ id: 'event-1' }));
+			mockDb.crownDevelopment.update.mock.mockImplementationOnce(() => Promise.resolve({ id: 'case-123' }));
+
+			const { service } = buildService(mockDb);
+
+			await service.record({
+				caseId: 'case-123',
+				action: 'CASE_CREATED',
+				userId: 'user-456'
+			});
+
+			const { data } = firstArg<{ data: { metadata: string } }>(mockDb.applicationHistory.create.mock.calls[0]);
+			assert.strictEqual(data.metadata, '{}');
+		});
+
+		it('should log error but not throw when database fails', async () => {
+			const mockDb = createMockDb();
+			const dbError = new Error('Database connection failed');
+			mockDb.applicationHistory.create.mock.mockImplementationOnce(() => Promise.reject(dbError));
+
+			const { service, logger } = buildService(mockDb);
+
+			// Should not throw
+			await assert.doesNotReject(() =>
+				service.record({
+					caseId: 'case-123',
+					action: 'CASE_CREATED',
+					userId: 'user-456'
+				})
+			);
+
+			assert.strictEqual(logger.error.mock.callCount(), 1);
+			const errorCall = logger.error.mock.calls[0];
+			const errorObj = firstArg<{ error: Error; caseId: string }>(errorCall);
+			assert.strictEqual(errorObj.error, dbError);
+			assert.strictEqual(errorObj.caseId, 'case-123');
+			assert.strictEqual(errorCall.arguments[1], 'Failed to record audit event');
+		});
+	});
+
+	describe('recordMany', () => {
+		it('should return early for an empty array without touching the db', async () => {
+			const mockDb = createMockDb();
+			const { service } = buildService(mockDb);
+
+			await service.recordMany([]);
+
+			assert.strictEqual(mockDb.applicationHistory.createMany.mock.callCount(), 0);
+			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 0);
+		});
+
+		it('should create many history rows and update the case once', async () => {
+			const mockDb = createMockDb();
+			mockDb.applicationHistory.createMany.mock.mockImplementationOnce(() => Promise.resolve({ count: 2 }));
+			mockDb.crownDevelopment.update.mock.mockImplementationOnce(() => Promise.resolve({ id: 'case-123' }));
+
+			const { service } = buildService(mockDb);
+
+			const entries: AuditEntry[] = [
+				{ caseId: 'case-123', action: 'CASE_CREATED', userId: 'user-456', metadata: { caseName: 'abc' } },
+				{ caseId: 'case-123', action: 'CASE_CREATED', userId: 'user-456', metadata: { caseName: 'def' } }
+			];
+
+			await service.recordMany(entries);
+
+			const { data: rows } = firstArg<{ data: Array<{ userId: string; metadata: string }> }>(
+				mockDb.applicationHistory.createMany.mock.calls[0]
+			);
+			assert.strictEqual(rows.length, 2);
+			assert.strictEqual(rows[0].userId, 'user-456');
+			assert.strictEqual(rows[0].metadata, JSON.stringify({ caseName: 'abc' }));
+
+			const update = firstArg<{ data: { updatedById: string } }>(mockDb.crownDevelopment.update.mock.calls[0]);
+			assert.strictEqual(update.data.updatedById, 'user-456');
+			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
+		});
+
+		it('should log error but not throw when the transaction fails', async () => {
+			const mockDb = createMockDb();
+			const dbError = new Error('Transaction failed');
+			mockDb.applicationHistory.createMany.mock.mockImplementationOnce(() => Promise.reject(dbError));
+
+			const { service, logger } = buildService(mockDb);
+
+			await assert.doesNotReject(() =>
+				service.recordMany([{ caseId: 'case-123', action: 'CASE_CREATED', userId: 'user-456' }])
+			);
+
+			assert.strictEqual(logger.error.mock.callCount(), 1);
+			const errorCall = logger.error.mock.calls[0];
+			assert.strictEqual(firstArg<{ error: Error }>(errorCall).error, dbError);
+			assert.strictEqual(errorCall.arguments[1], 'Failed to record audit events');
+		});
+	});
+
+	describe('getAllForCase', () => {
+		it('should retrieve and parse audit events', async () => {
+			const mockDb = createMockDb();
+			mockDb.applicationHistory.findMany.mock.mockImplementationOnce(() =>
+				Promise.resolve([
+					{
+						id: 'event-1',
+						caseId: 'case-123',
+						action: 'CASE_CREATED',
+						metadata: '{"caseName":"Test"}',
+						userId: 'user-1',
+						createdAt: new Date('2025-01-01')
+					},
+					{
+						id: 'event-2',
+						caseId: 'case-123',
+						action: 'CASE_UPDATED',
+						metadata: null,
+						userId: 'user-2',
+						createdAt: new Date('2025-01-02')
+					}
+				])
+			);
+
+			const { service } = buildService(mockDb);
+
+			const events = await service.getAllForCase('case-123');
+
+			assert.strictEqual(events.length, 2);
+			assert.deepStrictEqual(events[0].metadata, { caseName: 'Test' });
+			assert.strictEqual(events[0].userId, 'user-1');
+			assert.strictEqual(events[1].metadata, null);
+		});
+
+		it('should use default pagination options', async () => {
+			const mockDb = createMockDb();
+			mockDb.applicationHistory.findMany.mock.mockImplementationOnce(() => Promise.resolve([]));
+
+			const { service } = buildService(mockDb);
+
+			await service.getAllForCase('case-123');
+
+			const args = firstArg<{ skip: number; take: number }>(mockDb.applicationHistory.findMany.mock.calls[0]);
+			assert.strictEqual(args.skip, 0);
+			assert.strictEqual(args.take, 50);
+		});
+
+		it('should accept custom pagination options', async () => {
+			const mockDb = createMockDb();
+			mockDb.applicationHistory.findMany.mock.mockImplementationOnce(() => Promise.resolve([]));
+
+			const { service } = buildService(mockDb);
+
+			await service.getAllForCase('case-123', { skip: 10, take: 20 });
+
+			const args = firstArg<{ skip: number; take: number }>(mockDb.applicationHistory.findMany.mock.calls[0]);
+			assert.strictEqual(args.skip, 10);
+			assert.strictEqual(args.take, 20);
+		});
+
+		it('should return empty array and log error on failure', async () => {
+			const mockDb = createMockDb();
+			const dbError = new Error('Query failed');
+			mockDb.applicationHistory.findMany.mock.mockImplementationOnce(() => Promise.reject(dbError));
+
+			const { service, logger } = buildService(mockDb);
+
+			const events = await service.getAllForCase('case-123');
+
+			assert.deepStrictEqual(events, []);
+			assert.strictEqual(logger.error.mock.callCount(), 1);
+			const errorCall = logger.error.mock.calls[0];
+			assert.strictEqual(firstArg<{ error: Error }>(errorCall).error, dbError);
+			assert.strictEqual(errorCall.arguments[1], 'Failed to fetch audit events');
+		});
+	});
+
+	describe('countForCase', () => {
+		it('should return the count of audit events', async () => {
+			const mockDb = createMockDb();
+			mockDb.applicationHistory.count.mock.mockImplementationOnce(() => Promise.resolve(42));
+
+			const { service } = buildService(mockDb);
+
+			const count = await service.countForCase('case-123');
+
+			assert.strictEqual(count, 42);
+			assert.strictEqual(mockDb.applicationHistory.count.mock.callCount(), 1);
+		});
+
+		it('should return 0 and log error on failure', async () => {
+			const mockDb = createMockDb();
+			const dbError = new Error('Count failed');
+			mockDb.applicationHistory.count.mock.mockImplementationOnce(() => Promise.reject(dbError));
+
+			const { service, logger } = buildService(mockDb);
+
+			const count = await service.countForCase('case-123');
+
+			assert.strictEqual(count, 0);
+			assert.strictEqual(logger.error.mock.callCount(), 1);
+		});
+	});
+
+	describe('getLastModifiedInfo', () => {
+		it('should return formatted date and user display name', async () => {
+			const mockDb = createMockDb();
+			mockDb.crownDevelopment.findUnique.mock.mockImplementationOnce(() =>
+				Promise.resolve({
+					updatedDate: new Date('2025-01-15T14:30:00Z'),
+					updatedById: 'user-123'
+				})
+			);
+
+			const { service } = buildService(mockDb);
+
+			const groupMembers: EntraGroupMembers = {
+				caseOfficers: [member('user-123', 'John Smith'), member('user-456', 'Jane Doe')],
+				inspectors: []
+			};
+
+			const info = await service.getLastModifiedInfo('case-123', groupMembers);
+
+			assert.strictEqual(info.updatedDate, '15 January 2025 2:30pm');
+			assert.strictEqual(info.by, 'John Smith');
+		});
+
+		it('should find a user in the inspectors group too', async () => {
+			const mockDb = createMockDb();
+			mockDb.crownDevelopment.findUnique.mock.mockImplementationOnce(() =>
+				Promise.resolve({
+					updatedDate: new Date('2025-01-15T14:30:00Z'),
+					updatedById: 'user-456'
+				})
+			);
+
+			const { service } = buildService(mockDb);
+
+			const groupMembers: EntraGroupMembers = {
+				caseOfficers: [member('user-123', 'John Smith')],
+				inspectors: [member('user-456', 'Jane Doe')]
+			};
+
+			const info = await service.getLastModifiedInfo('case-123', groupMembers);
+
+			assert.strictEqual(info.by, 'Jane Doe');
+		});
+
+		it('should return the Entra ID in plain text if user not found in group members', async () => {
+			const mockDb = createMockDb();
+			mockDb.crownDevelopment.findUnique.mock.mockImplementationOnce(() =>
+				Promise.resolve({
+					updatedDate: new Date('2025-01-15T14:30:00Z'),
+					updatedById: 'user-999'
+				})
+			);
+
+			const { service } = buildService(mockDb);
+
+			const groupMembers: EntraGroupMembers = {
+				caseOfficers: [member('user-123', 'John Smith')],
+				inspectors: []
+			};
+
+			const info = await service.getLastModifiedInfo('case-123', groupMembers);
+
+			assert.strictEqual(info.by, 'user-999');
+		});
+
+		it('should return null values and log error if case row does not exist', async () => {
+			const mockDb = createMockDb();
+			mockDb.crownDevelopment.findUnique.mock.mockImplementationOnce(() => Promise.resolve(null));
+
+			const { service, logger } = buildService(mockDb);
+
+			const groupMembers: EntraGroupMembers = { caseOfficers: [], inspectors: [] };
+
+			const info = await service.getLastModifiedInfo('case-123', groupMembers);
+
+			assert.strictEqual(info.updatedDate, null);
+			assert.strictEqual(info.by, null);
+			assert.strictEqual(logger.error.mock.callCount(), 1);
+		});
+
+		it('should handle a case with null date / user fields gracefully', async () => {
+			const mockDb = createMockDb();
+			mockDb.crownDevelopment.findUnique.mock.mockImplementationOnce(() =>
+				Promise.resolve({
+					updatedDate: null,
+					updatedById: null
+				})
+			);
+
+			const { service } = buildService(mockDb);
+
+			const groupMembers: EntraGroupMembers = { caseOfficers: [], inspectors: [] };
+
+			const info = await service.getLastModifiedInfo('case-123', groupMembers);
+
+			assert.strictEqual(info.updatedDate, null);
+			assert.strictEqual(info.by, 'Unknown');
+		});
+
+		it('should return null values and log error on database failure', async () => {
+			const mockDb = createMockDb();
+			const dbError = new Error('Query failed');
+			mockDb.crownDevelopment.findUnique.mock.mockImplementationOnce(() => Promise.reject(dbError));
+
+			const { service, logger } = buildService(mockDb);
+
+			const groupMembers: EntraGroupMembers = { caseOfficers: [], inspectors: [] };
+
+			const info = await service.getLastModifiedInfo('case-123', groupMembers);
+
+			assert.strictEqual(info.updatedDate, null);
+			assert.strictEqual(info.by, null);
+			assert.strictEqual(logger.error.mock.callCount(), 1);
+		});
+
+		it('should find a user when inspectors is empty but caseOfficers has them', async () => {
+			const mockDb = createMockDb();
+			mockDb.crownDevelopment.findUnique.mock.mockImplementationOnce(() =>
+				Promise.resolve({
+					updatedDate: new Date('2025-01-15T14:30:00Z'),
+					updatedById: 'user-123'
+				})
+			);
+
+			const { service } = buildService(mockDb);
+
+			const groupMembers: EntraGroupMembers = {
+				caseOfficers: [member('user-123', 'John Smith')],
+				inspectors: []
+			};
+
+			const info = await service.getLastModifiedInfo('case-123', groupMembers);
+
+			assert.strictEqual(info.by, 'John Smith');
+		});
+	});
+});

--- a/apps/manage/src/app/audit/service.ts
+++ b/apps/manage/src/app/audit/service.ts
@@ -1,0 +1,219 @@
+import type { PrismaClient } from '@pins/crowndev-database/src/client/client.ts';
+import type { Logger } from 'pino';
+import { parseMetadata, type AuditEntry, type AuditEvent, type AuditQueryOptions } from './types.ts';
+import type { EntraGroupMembers } from '../../util/entra-groups.ts';
+import { formatDateTime } from '@pins/crowndev-lib/util/audit-formatters.ts';
+
+/**
+ * Builds the audit service used to record and retrieve case history events.
+ *
+ * Design notes:
+ *   - `record()` is fire-and-forget: audit failures are logged but never
+ *     thrown so they can't break the user's actual operation.
+ */
+export function buildAuditService(db: PrismaClient, logger: Logger) {
+	return {
+		/**
+		 * Persist a single audit event.
+		 *
+		 * Safe to call without awaiting if the caller doesn't need
+		 * confirmation, but awaiting is fine too
+		 */
+		async record(entry: AuditEntry): Promise<void> {
+			try {
+				if (!entry.userId) {
+					throw new Error('Cannot record audit event without a userId');
+				}
+
+				await db.$transaction([
+					db.applicationHistory.create({
+						data: {
+							Application: {
+								connect: { id: entry.caseId }
+							},
+							action: entry.action,
+							metadata: JSON.stringify(entry.metadata ?? {}),
+							userId: entry.userId
+						}
+					}),
+					// updatedDate / updatedById stored as their own columns on CrownDevelopment
+					db.crownDevelopment.update({
+						where: { id: entry.caseId },
+						data: {
+							updatedDate: new Date(),
+							updatedById: entry.userId
+						}
+					})
+				]);
+			} catch (error) {
+				logger.error(
+					{
+						error,
+						action: entry.action,
+						caseId: entry.caseId
+					},
+					'Failed to record audit event'
+				);
+			}
+		},
+
+		/**
+		 * Persist multiple audit entries in a single transaction.
+		 *
+		 * This avoids deadlocks that occur when many concurrent transactions
+		 * each try to update the same CrownDevelopment row (e.g. bulk file
+		 * moves with up to 100 files, or case updates that produce many
+		 * field-level audit entries).
+		 *
+		 * All caseHistory rows are created individually, then a single
+		 * crownDevelopment.update sets updatedDate/updatedById once at the end.
+		 */
+		async recordMany(entries: AuditEntry[]): Promise<void> {
+			if (entries.length === 0) return;
+
+			try {
+				const caseId = entries[0].caseId;
+				const userId = entries[0].userId;
+
+				const missingUser = entries.find((e) => !e.userId);
+				if (missingUser) {
+					throw new Error(`Cannot record audit events: entry for case ${missingUser.caseId} has no userId`);
+				}
+
+				await db.$transaction([
+					db.applicationHistory.createMany({
+						data: entries.map((entry) => ({
+							applicationId: entry.caseId,
+							action: entry.action,
+							metadata: JSON.stringify(entry.metadata ?? {}),
+							userId: entry.userId as string
+						}))
+					}),
+					db.crownDevelopment.update({
+						where: { id: caseId },
+						data: {
+							updatedDate: new Date(),
+							updatedById: userId
+						}
+					})
+				]);
+			} catch (error) {
+				logger.error(
+					{
+						error,
+						caseId: entries[0].caseId,
+						entryCount: entries.length
+					},
+					'Failed to record audit events'
+				);
+			}
+		},
+
+		/**
+		 * Retrieve audit events for a case, newest first.
+		 */
+		async getAllForCase(caseId: string, options?: AuditQueryOptions): Promise<AuditEvent[]> {
+			const { skip = 0, take = 50 } = options ?? {};
+
+			try {
+				const events = await db.applicationHistory.findMany({
+					where: { applicationId: caseId },
+					orderBy: { createdAt: 'desc' },
+					skip,
+					take
+				});
+
+				// Parse the metadata JSON string into an object
+				return events.map((event) => ({
+					...event,
+					metadata: parseMetadata(event.metadata)
+				}));
+			} catch (error) {
+				logger.error(
+					{
+						error,
+						caseId
+					},
+					'Failed to fetch audit events'
+				);
+
+				// Returns an empty array on failure so the history page can still
+				// render (with an appropriate message) rather than 500-ing.
+				return [];
+			}
+		},
+
+		/**
+		 * Count total audit events for a case.
+		 */
+		async countForCase(caseId: string): Promise<number> {
+			try {
+				return await db.applicationHistory.count({
+					where: { applicationId: caseId }
+				});
+			} catch (error) {
+				logger.error(
+					{
+						error,
+						caseId
+					},
+					'Failed to count audit events'
+				);
+
+				return 0;
+			}
+		},
+
+		/**
+		 * Get last modified information for display in case summary.
+		 * Returns formatted data ready for the UI.
+		 */
+		async getLastModifiedInfo(
+			caseId: string,
+			groupMembers: EntraGroupMembers
+		): Promise<{
+			updatedDate: string | null;
+			by: string | null;
+		}> {
+			try {
+				const caseRow = await db.crownDevelopment.findUnique({
+					where: { id: caseId },
+					select: {
+						updatedDate: true,
+						updatedById: true
+					}
+				});
+
+				if (!caseRow) {
+					throw new Error(`No case found for id: ${caseId}`);
+				}
+
+				const updatedDate = caseRow.updatedDate ? formatDateTime(caseRow.updatedDate) : null;
+
+				const allMembers = [...groupMembers.caseOfficers, ...groupMembers.inspectors];
+				const user = allMembers.find((member) => member.id === caseRow.updatedById);
+
+				// 1. Try and get a user from entra and show their name
+				// 2. Otherwise just show the updatedById (Entra ID) in plain text
+				// 3. Otherwise show Unknown
+				const userName = user?.displayName || caseRow.updatedById || 'Unknown';
+
+				return {
+					updatedDate,
+					by: userName
+				};
+			} catch (error) {
+				logger.error(
+					{
+						error,
+						caseId
+					},
+					'Failed to fetch last modified info'
+				);
+				return { updatedDate: null, by: null };
+			}
+		}
+	};
+}
+
+export type AuditService = ReturnType<typeof buildAuditService>;

--- a/apps/manage/src/app/audit/types.ts
+++ b/apps/manage/src/app/audit/types.ts
@@ -1,0 +1,66 @@
+import type { AuditAction } from './actions.ts';
+
+/**
+ * Input for recording a single audit event.
+ *
+ * This is what callers pass to `audit.record()`. The service adds the
+ * timestamp automatically.
+ */
+export interface AuditEntry {
+	/** The case this event belongs to */
+	caseId: string;
+
+	/** The action that was performed (from AUDIT_ACTIONS) */
+	action: AuditAction;
+
+	/**
+	 * Flexible key-value bag for template placeholders and any extra
+	 * context we want to store (e.g. fieldName, reference, oldValue,
+	 * newValue, fileName, folderId).
+	 *
+	 * Kept loose intentionally — different actions need different data and
+	 * we don't want schema migrations every time we audit something new.
+	 */
+	metadata?: Record<string, unknown>;
+
+	/** Entra ID of the user who performed the action */
+	userId?: string;
+}
+
+/**
+ * An audit event as stored in the database and returned by queries.
+ */
+export interface AuditEvent {
+	id: string;
+	applicationId: string;
+	action: string;
+	metadata: Record<string, unknown> | null;
+	/** Entra ID of the user who performed the action */
+	userId: string | null;
+	createdAt: Date;
+}
+
+/**
+ * Options for paginating audit event queries.
+ */
+export interface AuditQueryOptions {
+	/** Number of records to skip (for offset pagination) */
+	skip?: number;
+
+	/** Number of records to return */
+	take?: number;
+}
+
+export function parseMetadata(metadata: string | null): Record<string, unknown> | null {
+	if (!metadata) {
+		return null;
+	}
+
+	const parsed: unknown = JSON.parse(metadata);
+
+	if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+		return parsed as Record<string, unknown>;
+	}
+
+	return null;
+}

--- a/apps/manage/src/app/service.js
+++ b/apps/manage/src/app/service.js
@@ -5,6 +5,7 @@ import { MapCache } from '@pins/crowndev-lib/util/map-cache.js';
 import { buildInitEntraClient } from '@pins/crowndev-lib/graph/cached-entra-client.js';
 import { initLogger } from '@pins/crowndev-lib/util/logger.ts';
 import { initGovNotify } from '@pins/crowndev-lib/govnotify/index.js';
+import { buildAuditService } from './audit/index.ts';
 import { TextAnalyticsClient } from '@azure/ai-text-analytics';
 import { DefaultAzureCredential } from '@azure/identity';
 import { DEFAULT_CATEGORIES } from '#util/azure-language-redaction.js';
@@ -28,6 +29,10 @@ export class ManageService {
 	 * @type {import('@pins/crowndev-database/src/client/client.ts').PrismaClient}
 	 */
 	dbClient;
+	/**
+	 * @type {import('./audit/index.js').AuditService}
+	 */
+	audit;
 	/**
 	 * @type {import('@pins/crowndev-lib/redis/redis-client.ts').RedisClient|null}
 	 */
@@ -61,6 +66,7 @@ export class ManageService {
 		const logger = initLogger(config);
 		this.logger = logger;
 		this.dbClient = initDatabaseClient(config, logger);
+		this.audit = buildAuditService(this.db, logger);
 		this.redisClient = initRedis(config.session, logger);
 		const graphClient = Client.initWithMiddleware({
 			authProvider: new TokenCredentialAuthenticationProvider(new DefaultAzureCredential(), {

--- a/packages/lib/util/audit-formatters.test.ts
+++ b/packages/lib/util/audit-formatters.test.ts
@@ -1,0 +1,168 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { formatAddress, formatDate, formatValue, formatNumber } from './audit-formatters.ts';
+
+describe('Audit Formatters', () => {
+	describe('formatAddress', () => {
+		it('should return a comma-separated string from DB-shaped address', () => {
+			const address = {
+				line1: '221b Baker Street',
+				line2: 'Marylebone',
+				townCity: 'London',
+				county: 'Greater London',
+				postcode: 'NW1 6XE'
+			};
+
+			assert.strictEqual(formatAddress(address), '221b Baker Street, Marylebone, London, Greater London, NW1 6XE');
+		});
+
+		it('should return a comma-separated string from form-shaped address', () => {
+			const address = {
+				addressLine1: 'Buckingham Palace',
+				addressLine2: '',
+				townCity: 'London',
+				county: '',
+				postcode: 'SW1A 1AA'
+			};
+
+			assert.strictEqual(formatAddress(address), 'Buckingham Palace, London, SW1A 1AA');
+		});
+
+		it('should skip null/undefined/empty fields', () => {
+			const address = {
+				line1: '10 Downing Street',
+				line2: null,
+				townCity: 'London',
+				county: undefined,
+				postcode: 'SW1A 2AA'
+			};
+
+			assert.strictEqual(formatAddress(address), '10 Downing Street, London, SW1A 2AA');
+		});
+
+		it('should return "-" for null input', () => {
+			assert.strictEqual(formatAddress(null), '-');
+		});
+
+		it('should return "-" for undefined input', () => {
+			assert.strictEqual(formatAddress(undefined), '-');
+		});
+
+		it('should return "-" for an empty object', () => {
+			assert.strictEqual(formatAddress({}), '-');
+		});
+
+		it('should prefer DB-shaped fields over form-shaped fields', () => {
+			const address = {
+				line1: 'DB Line 1',
+				addressLine1: 'Form Line 1',
+				townCity: 'London',
+				postcode: 'SW1'
+			};
+
+			assert.strictEqual(formatAddress(address), 'DB Line 1, London, SW1');
+		});
+	});
+
+	describe('formatDate', () => {
+		it('should format a Date object', () => {
+			const date = new Date('2026-10-10T00:00:00.000Z');
+
+			assert.strictEqual(formatDate(date), '10 October 2026');
+		});
+
+		it('should format an ISO date string', () => {
+			assert.strictEqual(formatDate('2025-01-15T00:00:00.000Z'), '15 January 2025');
+		});
+
+		it('should format a date-only string', () => {
+			assert.strictEqual(formatDate('2024-03-27'), '27 March 2024');
+		});
+
+		it('should return "-" for null', () => {
+			assert.strictEqual(formatDate(null), '-');
+		});
+
+		it('should return "-" for undefined', () => {
+			assert.strictEqual(formatDate(undefined), '-');
+		});
+
+		it('should return "-" for an empty string', () => {
+			assert.strictEqual(formatDate(''), '-');
+		});
+
+		it('should return "-" for an invalid date string', () => {
+			assert.strictEqual(formatDate('not-a-date'), '-');
+		});
+	});
+
+	describe('formatValue', () => {
+		it('should return "-" for null', () => {
+			assert.strictEqual(formatValue(null), '-');
+		});
+
+		it('should return "-" for undefined', () => {
+			assert.strictEqual(formatValue(undefined), '-');
+		});
+
+		it('should return "-" for an empty string', () => {
+			assert.strictEqual(formatValue(''), '-');
+		});
+
+		it('should format a Date object using formatDate', () => {
+			const date = new Date('2026-10-10T00:00:00.000Z');
+
+			assert.strictEqual(formatValue(date), '10 October 2026');
+		});
+
+		it('should return "Yes" for true', () => {
+			assert.strictEqual(formatValue(true), 'Yes');
+		});
+
+		it('should return "No" for false', () => {
+			assert.strictEqual(formatValue(false), 'No');
+		});
+
+		it('should stringify a number', () => {
+			assert.strictEqual(formatValue(42), '42');
+		});
+
+		it('should stringify a string value', () => {
+			assert.strictEqual(formatValue('hello'), 'hello');
+		});
+
+		it('should stringify zero', () => {
+			assert.strictEqual(formatValue(0), '0');
+		});
+	});
+
+	describe('formatNumber', () => {
+		it('should return "-" for null', () => {
+			assert.strictEqual(formatNumber(null), '-');
+		});
+
+		it('should return "-" for undefined', () => {
+			assert.strictEqual(formatNumber(undefined), '-');
+		});
+
+		it('should return "-" for an empty string', () => {
+			assert.strictEqual(formatNumber(''), '-');
+		});
+
+		it('should stringify a number', () => {
+			assert.strictEqual(formatNumber(5), '5');
+		});
+
+		it('should stringify a decimal number', () => {
+			assert.strictEqual(formatNumber(0.5), '0.5');
+		});
+
+		it('should stringify zero', () => {
+			assert.strictEqual(formatNumber(0), '0');
+		});
+
+		it('should stringify a numeric string', () => {
+			assert.strictEqual(formatNumber('10'), '10');
+		});
+	});
+});

--- a/packages/lib/util/audit-formatters.ts
+++ b/packages/lib/util/audit-formatters.ts
@@ -1,0 +1,151 @@
+import { formatInTimeZone } from 'date-fns-tz';
+
+/**
+ * Formats an address object into a comma-separated string for audit display.
+ */
+export function formatAddress(address: Record<string, unknown> | null | undefined): string {
+	if (!address) {
+		return '-';
+	}
+
+	const parts = [
+		address.line1 || address.addressLine1,
+		address.line2 || address.addressLine2,
+		address.townCity,
+		address.county,
+		address.postcode
+	].filter(Boolean);
+
+	return parts.length > 0 ? parts.join(', ') : '-';
+}
+
+/**
+ * Formats a date + time value for audit display.
+ */
+export function formatDateTime(value: Date | string | null | undefined): string {
+	return formatDate(value, true);
+}
+
+/**
+ * Formats a date (and optionally time) for audit display, in UK time.
+ *
+ * @param value - the date to format
+ * @param includeTime - when true, appends the time unless the time is midnight
+ *   (midnight is treated as "date only", since it usually means a date with no
+ *   meaningful time component)
+ */
+export function formatDate(value: Date | string | null | undefined, includeTime = false): string {
+	if (!value) {
+		return '-';
+	}
+
+	const date = value instanceof Date ? value : new Date(value);
+
+	if (isNaN(date.getTime())) {
+		return '-';
+	}
+
+	const datePart = formatInTimeZone(date, 'Europe/London', 'd MMMM yyyy');
+
+	if (!includeTime) {
+		return datePart;
+	}
+
+	// Suppress the time when it's midnight UK time — treat as date-only.
+	const timeInUK = formatInTimeZone(date, 'Europe/London', 'HH:mm');
+	if (timeInUK === '00:00') {
+		return datePart;
+	}
+
+	return formatInTimeZone(date, 'Europe/London', 'd MMMM yyyy h:mmaaa');
+}
+
+/**
+ * Formats a single value for audit display.
+ * Returns `-` for null/undefined/empty.
+ */
+export function formatValue(value: unknown): string {
+	if (value === null || value === undefined || value === '') {
+		return '-';
+	}
+
+	if (value instanceof Date) {
+		return formatDate(value);
+	}
+
+	if (typeof value === 'boolean') {
+		return value ? 'Yes' : 'No';
+	}
+
+	if (typeof value === 'string' || typeof value === 'number') {
+		return String(value);
+	}
+
+	// Non-primitive values can't be meaningfully displayed
+	return '-';
+}
+
+/**
+ * Formats a numeric value for audit display.
+ */
+export function formatNumber(value: unknown): string {
+	if (value === null || value === undefined || value === '') {
+		return '-';
+	}
+
+	if (typeof value === 'number' || typeof value === 'string') {
+		return String(value);
+	}
+
+	return '-';
+}
+
+/**
+ * Formats a boolean to Yes/No for audit display.
+ * Returns `-` for null/undefined to indicate no previous value.
+ */
+export function formatBoolean(value: boolean | null | undefined): string {
+	if (value === null || value === undefined) {
+		return '-';
+	}
+
+	return value ? 'Yes' : 'No';
+}
+
+/**
+ * Normalises a 'yes'/'no' form string to 'Yes'/'No' for audit display.
+ * The form submits lowercase strings; this ensures consistent comparison
+ * against the boolean values from the DB.
+ */
+export function formatYesNo(value: string | null | undefined): string {
+	if (!value) {
+		return '-';
+	}
+
+	return value.toLowerCase() === 'yes' ? 'Yes' : 'No';
+}
+
+/**
+ * Takes a value and formats it strictly as a GBP monetary unit.
+ * Handles leading zeros, forces 2 decimal places, and adds comma separators.
+ * A lot of this is blocked by validation already, but its worth doing here
+ * as not all of it is blocked
+ * e.g. 1234.5 -> £1,234.50
+ * e.g. "00012.345" -> £12.35
+ */
+export function formatMonetaryValue(value: unknown): string {
+	if (value === null || value === undefined || value === '') {
+		return '-';
+	}
+
+	const numericValue = Number(value);
+
+	if (Number.isNaN(numericValue)) return '-';
+
+	return new Intl.NumberFormat('en-GB', {
+		style: 'currency',
+		currency: 'GBP',
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2
+	}).format(numericValue);
+}


### PR DESCRIPTION
## Describe your changes
Introduces the audit service layer - the core capability for recording and retrieving case history (audit) events against a CrownDevelopment. This is the foundation for the case-history feature; it adds the ability to record and query audit events but does not yet wire it into any user-facing flow (the history page and event recording on case actions come in follow-up PRs).

- Audit service (audit/service.ts) — record, recordMany, getAllForCase, countForCase, and getLastModifiedInfo. record/recordMany are fire-and-forget: audit failures are logged but never thrown, so they can't break the user operation that triggered them. Reads fail soft (empty array / zero) so the history page can still render.
- Types (audit/types.ts) — AuditEntry (input contract, keyed on caseId), AuditEvent (the stored row shape, keyed on applicationId to match the schema), and AuditQueryOptions for pagination.
- Actions & templates (audit/actions.ts) — the action definitions and the resolveTemplate helper that turns an action + metadata into the human-readable "Details" string shown in the history table.
- Audit formatters (packages/lib/util/audit-formatters.ts) — display formatters used by the service, including formatDateTime for last-modified display.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PEAS-6