### PR TITLE
feat(manage): combine banners into single banner for view case

### DIFF
--- a/apps/manage/src/app/views/cases/view/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/controller.test.js
@@ -241,7 +241,7 @@ describe('case details', () => {
 			assert.ok(viewData);
 			assert.strictEqual(viewData.reference, 'C/A/1');
 		});
-		it('should include caseUpdated if present in session', async () => {
+		it('should include case updated banner if present in session', async () => {
 			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
@@ -269,7 +269,7 @@ describe('case details', () => {
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
 			assert.ok(viewData);
-			assert.strictEqual(viewData.caseUpdated, true);
+			assert.strictEqual(viewData.banner.text, 'Application has been updated.');
 
 			// should also clear the session
 			assert.strictEqual(mockReq.session.cases['case-1'].updated, undefined);
@@ -309,6 +309,42 @@ describe('case details', () => {
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
 			assert.ok(viewData);
 			assert.strictEqual(viewData.casePublished, true);
+		});
+		it('should include case updated banner with published message if case is published', async () => {
+			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
+			const mockRes = newMockRes();
+			const mockReq = {
+				params: { id: 'case-1' },
+				baseUrl: 'case-1',
+				session: { cases: { 'case-1': { updated: true } } },
+				query: {}
+			};
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: 'case-1',
+						name: 'Case 1',
+						reference: 'REF/1',
+						publishDate: new Date('2020-12-17T03:24:00.000Z')
+					}))
+				}
+			};
+			const next = mock.fn();
+			const middleware = buildGetJourneyMiddleware({
+				db: mockDb,
+				logger: mockLogger(),
+				getEntraClient: mockGetEntraClient,
+				groupIds
+			});
+			await middleware(mockReq, mockRes, next);
+			const viewCaseDetails = buildViewCaseDetails({ db: mockDb, getSharePointDrive: () => null });
+			await assert.doesNotReject(() => viewCaseDetails(mockReq, mockRes));
+			assert.strictEqual(next.mock.callCount(), 1);
+			assert.strictEqual(mockRes.render.mock.callCount(), 1);
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.ok(viewData);
+			assert.match(viewData.banner.html, /Application has been updated./);
+			assert.match(viewData.banner.html, /Any updates made to this case will be automatically published./);
 		});
 		it('should display an unpublish button if publishDate is not defined', async () => {
 			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
@@ -441,7 +477,7 @@ describe('case details', () => {
 			assert.ok(viewData);
 			assert.strictEqual(viewData.sharePointLink, 'https://example.com');
 		});
-		it('should set hasLinkedCase and linkedCaseLink appropriately when there is case linked', async () => {
+		it('should set linked case banner appropriately when there is case linked', async () => {
 			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
@@ -477,13 +513,12 @@ describe('case details', () => {
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
 			assert.ok(viewData);
-			assert.strictEqual(viewData.hasLinkedCase, true);
 			assert.strictEqual(
-				viewData.linkedCaseLink,
-				`<a href="/cases/linked-case-id" class="govuk-link govuk-link--no-visited-state">Listed Building Consent (LBC) application</a>`
+				viewData.banner.html,
+				`<p class="govuk-notification-banner__heading">This application is connected to a <a href="/cases/linked-case-id" class="govuk-link govuk-link--no-visited-state">Listed Building Consent (LBC) application</a>.</p>`
 			);
 		});
-		it('should set casePublishSuccess when success=published and publishDate is today/past', async (context) => {
+		it('should set published banner when success=published and publishDate is today/past', async (context) => {
 			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T10:00:00.000Z') });
 			const nunjucksRes = newMockRes();
 			const mockReq = {
@@ -512,10 +547,9 @@ describe('case details', () => {
 			const viewCaseDetails = buildViewCaseDetails({ db: mockDb, getSharePointDrive: () => null });
 			await viewCaseDetails(mockReq, nunjucksRes);
 			const viewData = nunjucksRes.render.mock.calls[0].arguments[1];
-			assert.strictEqual(viewData.casePublishSuccess, true);
-			assert.strictEqual(viewData.caseUnpublishSuccess, false);
+			assert.strictEqual(viewData.banner.text, 'Application published');
 		});
-		it('should set caseUnpublishSuccess when success=unpublish and publishDate is null', async () => {
+		it('should set unpublished banner message when success=unpublish and publishDate is null', async () => {
 			const nunjucksRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-2' },
@@ -543,8 +577,7 @@ describe('case details', () => {
 			const viewCaseDetails = buildViewCaseDetails({ db: mockDb, getSharePointDrive: () => null });
 			await viewCaseDetails(mockReq, nunjucksRes);
 			const viewData = nunjucksRes.render.mock.calls[0].arguments[1];
-			assert.strictEqual(viewData.caseUnpublishSuccess, true);
-			assert.strictEqual(viewData.casePublishSuccess, false);
+			assert.strictEqual(viewData.banner.text, 'Application unpublished');
 		});
 	});
 	describe('helper coverage', () => {

--- a/apps/manage/src/app/views/cases/view/controller.ts
+++ b/apps/manage/src/app/views/cases/view/controller.ts
@@ -14,12 +14,12 @@ import { isValidUuidFormat } from '@pins/crowndev-lib/util/uuid.ts';
 import { getEntraGroupMembers } from '#util/entra-groups.ts';
 import { clearSessionData, readSessionData } from '@pins/crowndev-lib/util/session.ts';
 import { caseReferenceToFolderName } from '@pins/crowndev-lib/util/sharepoint-path.js';
-import { getLinkedCaseId, getLinkedCaseLinkText, hasLinkedCase } from '@pins/crowndev-lib/util/linked-case.ts';
+import { maybeGetLinkedCaseLink } from '@pins/crowndev-lib/util/linked-case.ts';
 import { APPLICATION_SUB_TYPE_ID, APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { filteredStagesToRadioOptions } from './question-utils.js';
 import { getApplicantOrganisationOptions } from '../util/applicant-organisation-options.js';
+import { BannerBuilder } from '@pins/crowndev-lib/views/banner/banner-builder.ts';
 import type { SharePointDrive } from '@pins/crowndev-sharepoint/src/sharepoint/drives/drives.js';
-import type { Prisma } from '@pins/crowndev-database/src/client/client.js';
 import type { Response, Request, Handler, NextFunction } from 'express';
 import type { ErrorSummaryItem } from '@pins/crowndev-lib/util/types.ts';
 import type { ManageService } from '#service';
@@ -31,12 +31,61 @@ function getJourneyAnswers(res: Response): CrownDevelopmentViewModel | undefined
 	return res.locals.journeyResponse?.answers;
 }
 
-type CrownDevelopmentWithLinkedCase = Prisma.CrownDevelopmentGetPayload<{
-	include: {
-		ParentCrownDevelopment: { select: { id: true } };
-		ChildrenCrownDevelopment: { select: { id: true } };
-	};
-}>;
+/**
+ * Get all banner messages to display.
+ */
+async function getBannerMessages(id: string, res: Response, req: Request, db: ManageService['db']) {
+	// Don't show success or info if there is an error
+	if (res.locals.errorSummary) {
+		return null;
+	}
+
+	const bannerBuilder = new BannerBuilder();
+
+	const crownDevelopment = await db.crownDevelopment.findUnique({
+		where: { id },
+		include: {
+			ParentCrownDevelopment: { select: { id: true } },
+			ChildrenCrownDevelopment: { select: { id: true } }
+		}
+	});
+
+	const linkedCaseLink = await maybeGetLinkedCaseLink(db, crownDevelopment, 'manage');
+	if (linkedCaseLink) {
+		bannerBuilder.addLinkedCase(linkedCaseLink);
+	}
+
+	const publishDate = res.locals?.journeyResponse?.answers?.publishDate;
+	const casePublished = publishDate && (dateIsToday(publishDate) || dateIsBeforeToday(publishDate));
+	const successParam = req.query.success;
+	const casePublishSuccess = successParam === 'published' && casePublished;
+	if (casePublishSuccess) {
+		bannerBuilder.addSuccessText('Application published');
+		return bannerBuilder.build();
+	}
+
+	const caseUnpublishSuccess = successParam === 'unpublish' && !casePublished;
+	if (caseUnpublishSuccess) {
+		bannerBuilder.addSuccessText('Application unpublished');
+		return bannerBuilder.build();
+	}
+
+	// immediately clear this so the banner only shows once
+	const caseUpdated = readCaseUpdatedSession(req, id);
+	clearCaseUpdatedSession(req, id);
+	clearAllSessionData(req, res, id);
+
+	if (caseUpdated) {
+		bannerBuilder.addSuccessText('Application has been updated.');
+
+		if (casePublished) {
+			bannerBuilder.addSuccessText('Any updates made to this case will be automatically published.');
+		}
+		return bannerBuilder.build();
+	}
+
+	return bannerBuilder.build();
+}
 
 /**
  * Controller for the case details page, which shows the case summary and the list of sections to manage.
@@ -60,65 +109,28 @@ export function buildViewCaseDetails({ db, getSharePointDrive, isApplicationUpda
 		}
 		clearSessionData(req, id, 'publishErrors', 'cases');
 
-		// immediately clear this so the banner only shows once
-		const caseUpdated = readCaseUpdatedSession(req, id);
-		clearCaseUpdatedSession(req, id);
-		clearAllSessionData(req, res, id);
-
 		const publishDate = getJourneyAnswers(res)?.publishDate;
 		const casePublished = publishDate && (dateIsToday(publishDate) || dateIsBeforeToday(publishDate));
 		const baseUrl = req.baseUrl;
-		const successParam = req.query.success;
-		const casePublishSuccess = successParam === 'published' && casePublished;
-		const caseUnpublishSuccess = successParam === 'unpublish' && !casePublished;
+
+		const banner = await getBannerMessages(id, res, req, db);
 		const sharePointDrive = getSharePointDrive(req.session);
 		let sharePointLink: string | undefined;
 		if (sharePointDrive) {
 			sharePointLink = await getSharePointFolderLink(sharePointDrive, caseReferenceToFolderName(reference));
 		}
 
-		const crownDevelopment = await db.crownDevelopment.findUnique({
-			where: { id },
-			include: {
-				ParentCrownDevelopment: { select: { id: true } },
-				ChildrenCrownDevelopment: { select: { id: true } }
-			}
-		});
-
 		await list(req, res, '', {
 			reference,
-			caseUpdated,
 			casePublished,
-			casePublishSuccess,
-			caseUnpublishSuccess,
 			baseUrl,
 			sharePointLink,
 			hideButton: true,
 			hideStatus: true,
 			isApplicationUpdatesLive,
-			hasLinkedCase: hasLinkedCase(crownDevelopment),
-			linkedCaseLink: await maybeGetLinkedCaseLink(db, crownDevelopment)
+			banner
 		});
 	};
-}
-
-/**
- * Get the linked case link HTML
- */
-async function maybeGetLinkedCaseLink(
-	db: ManageService['db'],
-	crownDevelopment: CrownDevelopmentWithLinkedCase | null | undefined
-): Promise<string | undefined> {
-	if (!hasLinkedCase(crownDevelopment)) {
-		return undefined;
-	}
-
-	const linkedCaseId = getLinkedCaseId(crownDevelopment);
-	if (!linkedCaseId) {
-		return undefined;
-	}
-
-	return `<a href="/cases/${linkedCaseId}" class="govuk-link govuk-link--no-visited-state">${await getLinkedCaseLinkText(db, crownDevelopment)} application</a>`;
 }
 
 /**

--- a/apps/manage/src/app/views/cases/view/view.njk
+++ b/apps/manage/src/app/views/cases/view/view.njk
@@ -17,37 +17,12 @@
 {% endblock %}
 
 {% block content %}
-    {% if casePublishSuccess %}
-        {{ govukNotificationBanner({
-            text: "Application published",
-            type: "success"
-        }) }}
-    {% endif %}
-    {% if caseUnpublishSuccess %}
-        {{ govukNotificationBanner({
-            text: "Application unpublished",
-            type: "success"
-        }) }}
-    {% endif %}
-    {% if hasLinkedCase %}
-        {{ govukNotificationBanner({
-            classes: "govuk-notification-banner__heading govuk-grid-column-two-thirds",
-            html: '<p class="govuk-notification-banner__heading">This application is connected to a ' + linkedCaseLink + '.</p>'
-        }) }}
-    {% endif %}
-    {% if caseUpdated and casePublished %}
-        {{ govukNotificationBanner({
-            classes: "govuk-notification-banner__heading govuk-grid-column-two-thirds",
-            text: "Any updates made to this case will be automatically published.",
-            type: "success"
-        }) }}
-    {% endif %}
-    {% if caseUpdated %}
-        {{ govukNotificationBanner({
-            classes: "govuk-notification-banner__heading govuk-grid-column-two-thirds",
-            text: "Application has been updated",
-            type: "success"
-        }) }}
+    {% if banner %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                {{ govukNotificationBanner(banner) }}
+            </div>
+        </div>
     {% endif %}
 
     <div class="govuk-grid-row">

--- a/packages/lib/util/linked-case.test.js
+++ b/packages/lib/util/linked-case.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import { APPLICATION_SUB_TYPE_ID, APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import {
 	getLinkedCaseId,
+	maybeGetLinkedCaseLink,
 	getLinkedCaseLinkText,
 	getSummaryWarningMessage,
 	hasLinkedCase,
@@ -127,6 +128,65 @@ describe('linked case util', () => {
 				linkedParentId: 'linked-case-id'
 			};
 			assert.strictEqual(await getLinkedCaseLinkText(mockDb, crownDevelopment), 'Listed Building Consent (LBC)');
+		});
+	});
+	describe('maybeGetLinkedCaseLink', () => {
+		it('should return undefined when linked case id is unavailable after linked case check', async () => {
+			let linkedParentReadCount = 0;
+			const crownDevelopment = {
+				get linkedParentId() {
+					linkedParentReadCount += 1;
+					return linkedParentReadCount === 1 ? 'linked-case-id' : undefined;
+				}
+			};
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn()
+				}
+			};
+
+			const result = await maybeGetLinkedCaseLink(mockDb, crownDevelopment, 'manage');
+
+			assert.strictEqual(result, undefined);
+		});
+
+		it('should return undefined for portal route when linked case is not published', async () => {
+			const tomorrow = new Date();
+			tomorrow.setDate(tomorrow.getDate() + 1);
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						publishDate: tomorrow
+					}))
+				}
+			};
+
+			const result = await maybeGetLinkedCaseLink(mockDb, { linkedParentId: 'linked-case-id' }, 'portal');
+
+			assert.strictEqual(result, undefined);
+		});
+
+		it('should return portal link html when linked case is published', async () => {
+			let findUniqueCallCount = 0;
+			const findUniqueMock = mock.fn(() => {
+				findUniqueCallCount += 1;
+				return findUniqueCallCount === 1
+					? { publishDate: new Date('2025-06-01T00:00:00.000Z') }
+					: { subTypeId: APPLICATION_SUB_TYPE_ID.PLANNING_PERMISSION };
+			});
+
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: findUniqueMock
+				}
+			};
+
+			const result = await maybeGetLinkedCaseLink(mockDb, { linkedParentId: 'linked-case-id' }, 'portal');
+
+			assert.strictEqual(
+				result,
+				'<a href="/applications/linked-case-id/application-information" class="govuk-link govuk-link--no-visited-state">planning permission application</a>'
+			);
 		});
 	});
 	describe('getSummaryWarningMessage', () => {

--- a/packages/lib/util/linked-case.ts
+++ b/packages/lib/util/linked-case.ts
@@ -69,3 +69,41 @@ export function getSummaryWarningMessage(res: Response): string {
 		? 'Clicking accept & submit will create a second case as part of the connected application'
 		: 'Clicking Accept & Submit will send a notification to the applicant / agent';
 }
+
+type LinkedCaseRouteType = 'manage' | 'portal';
+
+/**
+ * Get the URL for a single linked case depending on the route.
+ */
+function getLinkedCaseHref(linkedCaseId: string, routeType: LinkedCaseRouteType): string {
+	return routeType === 'portal' ? `/applications/${linkedCaseId}/application-information` : `/cases/${linkedCaseId}`;
+}
+
+/**
+ * Get the linked case link HTML.
+ */
+export async function maybeGetLinkedCaseLink(
+	db: PrismaClient,
+	crownDevelopment: CrownDevelopmentWithLinkedCase | null | undefined,
+	routeType: LinkedCaseRouteType = 'manage'
+): Promise<string | undefined> {
+	if (!hasLinkedCase(crownDevelopment)) {
+		return undefined;
+	}
+
+	const linkedCaseId = getLinkedCaseId(crownDevelopment);
+	if (!linkedCaseId) {
+		return undefined;
+	}
+
+	const isLinkedCasePublished = await linkedCaseIsPublished(db, crownDevelopment);
+
+	if (routeType === 'portal' && !isLinkedCasePublished) {
+		return undefined;
+	}
+
+	const linkText = await getLinkedCaseLinkText(db, crownDevelopment);
+	const href = getLinkedCaseHref(linkedCaseId, routeType);
+
+	return `<a href="${href}" class="govuk-link govuk-link--no-visited-state">${linkText} application</a>`;
+}

--- a/packages/lib/views/banner/banner-builder.test.ts
+++ b/packages/lib/views/banner/banner-builder.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { BannerBuilder } from './banner-builder.ts';
+
+describe('BannerBuilder', () => {
+	it('should return null when no messages are added', () => {
+		const result = new BannerBuilder().build();
+
+		assert.strictEqual(result, null);
+	});
+
+	it('should return single text message without html wrapping', () => {
+		const result = new BannerBuilder().addInfoText('Saved draft').build();
+
+		assert.deepStrictEqual(result, { type: 'info', text: 'Saved draft' });
+	});
+
+	it('should render single trusted single-line html as a heading paragraph', () => {
+		const result = new BannerBuilder()
+			.addInfoTrustedSingleLineHtml('<a href="https://test.com">Application linked</a>')
+			.build();
+
+		assert.deepStrictEqual(result, {
+			type: 'info',
+			html: '<p class="govuk-notification-banner__heading"><a href="https://test.com">Application linked</a></p>'
+		});
+	});
+
+	it('should render single trusted single-line html success as a heading paragraph', () => {
+		const result = new BannerBuilder().addSuccessTrustedSingleLineHtml('Application published').build();
+
+		assert.deepStrictEqual(result, {
+			type: 'success',
+			html: '<p class="govuk-notification-banner__heading">Application published</p>'
+		});
+	});
+
+	it('should escape text when rendering multiple messages', () => {
+		const result = new BannerBuilder().addInfoText('<b>Unsafe</b>').addInfoText('Safe').build();
+
+		assert.deepStrictEqual(result, {
+			type: 'info',
+			html: '<ul class="govuk-list govuk-list--bullet"><li><p class="govuk-body">&lt;b&gt;Unsafe&lt;/b&gt;</p></li><li><p class="govuk-body">Safe</p></li></ul>'
+		});
+	});
+
+	it('should prefer success type and order success messages before info messages', () => {
+		const result = new BannerBuilder()
+			.addInfoText('Info one')
+			.addSuccessText('Success one')
+			.addInfoText('Info two')
+			.addSuccessTrustedHtml('<strong>Success two</strong>')
+			.build();
+
+		assert.deepStrictEqual(result, {
+			type: 'success',
+			html: '<ul class="govuk-list govuk-list--bullet"><li><p class="govuk-body">Success one</p></li><li><strong>Success two</strong></li><li><p class="govuk-body">Info one</p></li><li><p class="govuk-body">Info two</p></li></ul>'
+		});
+	});
+
+	it('should render linked case message with trusted anchor html', () => {
+		const result = new BannerBuilder().addLinkedCase('<a href="/cases/1">case</a>').build();
+
+		assert.deepStrictEqual(result, {
+			type: 'info',
+			html: '<p class="govuk-notification-banner__heading">This application is connected to a <a href="/cases/1">case</a>.</p>'
+		});
+	});
+});

--- a/packages/lib/views/banner/banner-builder.ts
+++ b/packages/lib/views/banner/banner-builder.ts
@@ -1,0 +1,165 @@
+// Warnings/errors should not be handled with notificationBanner
+type BannerMessageType = 'info' | 'success';
+
+// A message must have exactly one of `text` or `html`.
+export type BannerMessage =
+	| { type: BannerMessageType; text: string; html?: never }
+	| { type: BannerMessageType; html: string; text?: never };
+
+type InternalHtmlMessage = {
+	kind: 'html';
+	type: BannerMessageType;
+	html: string;
+};
+
+type InternalTextMessage = {
+	kind: 'text';
+	type: BannerMessageType;
+	text: string;
+};
+
+type InternalSingleLineHtmlMessage = {
+	kind: 'singleLineHtml';
+	type: BannerMessageType;
+	html: string;
+};
+
+type InternalBannerMessage = InternalHtmlMessage | InternalSingleLineHtmlMessage | InternalTextMessage;
+
+const priority: Record<BannerMessageType, number> = {
+	success: 1,
+	info: 0
+};
+
+const HTML_ESCAPES: Record<string, string> = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;'
+};
+
+/**
+ * Escape a string so it can be safely rendered as HTML text.
+ */
+function escapeHtml(value: string): string {
+	return value.replace(/[&<>"']/g, (c) => HTML_ESCAPES[c]);
+}
+
+/**
+ * Builder for constructing a single banner message out of one or more informational or success messages.
+ */
+export class BannerBuilder {
+	#messages: InternalBannerMessage[] = [];
+
+	/**
+	 * Add a prebuilt internal banner message to the queue.
+	 */
+	addMessage(message: InternalBannerMessage): BannerBuilder {
+		this.#messages.push(message);
+		return this;
+	}
+
+	/**
+	 * Add an informational message containing trusted HTML.
+	 */
+	addInfoTrustedHtml(html: string): BannerBuilder {
+		return this.addMessage({ kind: 'html', type: 'info', html });
+	}
+
+	/**
+	 * Add an informational plain-text message.
+	 */
+	addInfoText(text: string): BannerBuilder {
+		return this.addMessage({ kind: 'text', type: 'info', text });
+	}
+
+	/**
+	 * Add an informational trusted HTML message intended for a single line.
+	 */
+	addInfoTrustedSingleLineHtml(html: string): BannerBuilder {
+		return this.addMessage({ kind: 'singleLineHtml', type: 'info', html });
+	}
+
+	/**
+	 * Add a success message containing trusted HTML.
+	 */
+	addSuccessTrustedHtml(html: string): BannerBuilder {
+		return this.addMessage({ kind: 'html', type: 'success', html });
+	}
+
+	/**
+	 * Add a success plain-text message.
+	 */
+	addSuccessText(text: string): BannerBuilder {
+		return this.addMessage({ kind: 'text', type: 'success', text });
+	}
+
+	/**
+	 * Add a success trusted HTML message intended for a single line.
+	 */
+	addSuccessTrustedSingleLineHtml(html: string): BannerBuilder {
+		return this.addMessage({ kind: 'singleLineHtml', type: 'success', html });
+	}
+
+	/**
+	 * Add a single-line informational message describing a linked case.
+	 */
+	addLinkedCase(linkedCaseLink: string): BannerBuilder {
+		// linkedCaseLink is a trusted HTML anchor produced server-side.
+		return this.addInfoTrustedSingleLineHtml(`This application is connected to a ${linkedCaseLink}.`);
+	}
+
+	/**
+	 * Render an internal banner message as HTML markup.
+	 */
+	#renderHtmlMessage(message: InternalBannerMessage, single: boolean): string {
+		switch (message.kind) {
+			case 'html':
+				return message.html;
+			case 'text':
+				return `<p class="govuk-body">${escapeHtml(message.text)}</p>`;
+			case 'singleLineHtml':
+				return this.#renderTrustedSingleLineHtml(message.html, single);
+		}
+	}
+
+	/**
+	 * Wrap trusted single-line HTML in the appropriate banner paragraph styling.
+	 */
+	#renderTrustedSingleLineHtml(html: string, single: boolean): string {
+		const cssClass = single ? 'govuk-notification-banner__heading' : 'govuk-body';
+		return `<p class="${cssClass}">${html}</p>`;
+	}
+
+	/**
+	 * Merge all success and info messages into a single banner message to avoid multiple banners showing.
+	 * Success styling overrides info. Returns null when there are no messages.
+	 */
+	build(): BannerMessage | null {
+		const messages = this.#messages;
+		if (messages.length === 0) {
+			return null;
+		}
+
+		const type: BannerMessageType = messages.some((m) => m.type === 'success') ? 'success' : 'info';
+
+		// Single message: render without a list wrapper.
+		if (messages.length === 1) {
+			const message = messages[0];
+			if (message.kind === 'text') {
+				return { type, text: message.text };
+			}
+			return { type, html: this.#renderHtmlMessage(message, true) };
+		}
+
+		// Multiple messages: sort by priority (success first) and render as a bullet list.
+		const sortedMessages = [...messages].sort((a, b) => priority[b.type] - priority[a.type]);
+		const items = sortedMessages.map((message) => `<li>${this.#renderHtmlMessage(message, false)}</li>`);
+
+		return {
+			type,
+			html: `<ul class="govuk-list govuk-list--bullet">${items.join('')}</ul>`
+		};
+	}
+}


### PR DESCRIPTION
## Describe your changes
This is the first of multiple PRs that will combine banners across the service.
This combines multiple info and success banner messages for a single case in manage. 

1. If a success message is included, it escalates the banner type to `success`; otherwise the default is `info`
2. A single message will display with heading styling, unless it is a full HTML message, in which case styling should be included
3. Multiple messages display as a bulleted list with paragraph styling (unless HTML styling is already included)

Parameters passed to nunjucks view have been removed in favour of passing a standard banner object. This banner is built with a new BannerBuilder class, which handles the message combining.

Linked case message calculation has been moved centrally so it can be used by both manage and portal (in future PRs).

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1558
