### PR TITLE
feat(portal): implement fieldset element for filter inputs

### DIFF
--- a/packages/lib/views/filter-accordion/filter-accordion.njk
+++ b/packages/lib/views/filter-accordion/filter-accordion.njk
@@ -30,7 +30,13 @@
                                     idPrefix: section.name + suffix,
                                     items: section.options.items,
                                     classes: "govuk-checkboxes--small",
-                                    hint: { text: section.options.hintText }
+                                    hint: { text: section.options.hintText },
+                                    fieldset: {
+                                        legend: {
+                                            text: section.title,
+                                            classes: "govuk-visually-hidden"
+                                        }
+                                    }
                                 }) }}
                             {% endif %}
                             {% if section.type == 'date-input' and section.dateInputs %}


### PR DESCRIPTION
## Describe your changes
This pull request introduces an accessibility improvement to the `filter-accordion.njk` template by adding a visually hidden legend to the checkbox group. This ensures that screen readers can properly announce the group label, improving usability for users with assistive technologies.

Accessibility enhancement:

* Added a visually hidden `legend` (using the `govuk-visually-hidden` class) to the checkbox group's `fieldset`, ensuring the group label is accessible to screen readers. (`packages/lib/views/filter-accordion/filter-accordion.njk`)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1597