### PR TITLE
feat(manage): combine banner messages for representation management

### DIFF
--- a/apps/manage/src/app/views/cases/view/manage-reps/list/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/list/controller.js
@@ -4,6 +4,48 @@ import { REPRESENTATION_STATUS } from '@pins/crowndev-database/src/seed/data-sta
 import { createWhereClause, splitStringQueries } from '@pins/crowndev-lib/util/search-queries.js';
 import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.ts';
 import { getPageData, getPaginationParams } from '@pins/crowndev-lib/views/pagination/pagination-utils.js';
+import { BannerBuilder } from '@pins/crowndev-lib/views/banner/banner-builder.ts';
+
+/**
+ * @typedef {import('@pins/crowndev-lib/views/banner/banner-builder').BannerMessage} BannerMessage
+ * @typedef {{caseHasDistressingContent: boolean, repsHaveDistressingContent: boolean}} GetBannerMessagesOptions
+ */
+
+/**
+ * Get all banner messages to display.
+ *
+ * @param {string} id
+ * @param {import('express').Request} req
+ * @param {GetBannerMessagesOptions} options
+ * @return {BannerMessage|null}
+ */
+function getBannerMessages(id, req, options) {
+	const bannerBuilder = new BannerBuilder();
+
+	const repReviewed = readRepReviewedSession(req, id);
+	clearRepReviewedSession(req, id);
+
+	if (!repReviewed) {
+		return bannerBuilder.build();
+	}
+
+	const hasDistressingRepsMismatch = !options.caseHasDistressingContent && options.repsHaveDistressingContent;
+
+	if (hasDistressingRepsMismatch) {
+		bannerBuilder.addInfoText(
+			`You set this representation as potentially distressing, but the application is not set as potentially distressing.`
+		);
+
+		bannerBuilder.addInfoTrustedHtml(
+			`<p class="govuk-body"><a class="govuk-notification-banner__link" href="/cases/${encodeURIComponent(id)}/details/distressing-content">Set the
+			application as potentially distressing</a>.</p>`
+		);
+	}
+
+	bannerBuilder.addSuccessText(`Representation has been ${repReviewed}`);
+
+	return bannerBuilder.build();
+}
 
 /**
  * Return a handler to show the list of representations
@@ -14,12 +56,12 @@ import { getPageData, getPaginationParams } from '@pins/crowndev-lib/views/pagin
 export function buildListReps({ db }) {
 	return async (req, res) => {
 		const id = req.params.id;
-		if (!id) {
+		if (!id || typeof id !== 'string') {
 			throw new Error('id param is required');
 		}
 		const queryFilters = getQueryFilters(req.query);
 
-		const cd = await db.crownDevelopment.findUnique({
+		const crownDevelopment = await db.crownDevelopment.findUnique({
 			where: { id },
 			include: {
 				Representation: {
@@ -28,8 +70,12 @@ export function buildListReps({ db }) {
 			}
 		});
 
+		if (!crownDevelopment) {
+			return notFoundHandler(req, res);
+		}
+
 		const counts = statusCounts(
-			cd.Representation,
+			crownDevelopment.Representation,
 			REPRESENTATION_STATUS.map((status) => status.id)
 		);
 
@@ -90,19 +136,16 @@ export function buildListReps({ db }) {
 			pageNumber
 		);
 
-		const repReviewed = readRepReviewedSession(req, id);
-		clearRepReviewedSession(req, id);
-
-		// to show distressing content banner on save
-		const showDistressingContentBanner = Boolean(
-			repReviewed &&
-			!cd.containsDistressingContent &&
-			cd.Representation?.some((rep) => rep.distressingContentInRepresentation === true)
-		);
+		const banner = getBannerMessages(id, req, {
+			caseHasDistressingContent: crownDevelopment.containsDistressingContent,
+			repsHaveDistressingContent: Boolean(
+				crownDevelopment.Representation?.some((rep) => rep.distressingContentInRepresentation === true)
+			)
+		});
 
 		res.render('views/cases/view/manage-reps/list/view.njk', {
 			backLink: `/cases/${req.params.id}`,
-			pageCaption: cd.reference,
+			pageCaption: crownDevelopment.reference,
 			pageTitle: 'Manage representations',
 			baseUrl: req.baseUrl,
 			currentUrl: req.originalUrl,
@@ -111,7 +154,6 @@ export function buildListReps({ db }) {
 			filters,
 			counts,
 			...representationsToViewModel(filteredRepresentations),
-			repReviewed,
 			selectedItemsPerPage,
 			totalFilteredRepresentations,
 			pageNumber,
@@ -119,8 +161,7 @@ export function buildListReps({ db }) {
 			resultsStartNumber,
 			resultsEndNumber,
 			queryParams: req.query && Object.keys(req.query).length > 0 ? req.query : undefined,
-			showDistressingContentBanner,
-			id
+			banner
 		});
 	};
 }

--- a/apps/manage/src/app/views/cases/view/manage-reps/list/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/list/controller.test.js
@@ -100,6 +100,7 @@ describe('list representations', () => {
 				backLink: '/cases/id-1',
 				pageCaption: 'CROWN/2025/0000001',
 				pageTitle: 'Manage representations',
+				banner: null,
 				baseUrl: '/manage-representations',
 				currentUrl: '/manage-representations',
 				queryParams: undefined,
@@ -114,7 +115,6 @@ describe('list representations', () => {
 					{ text: 'Withdrawn (1)', value: 'withdrawn', checked: false }
 				],
 				filtersValue: undefined,
-				id: 'id-1',
 				counts: { 'awaiting-review': 1, accepted: 1, rejected: 0, withdrawn: 1 },
 				searchValue: '',
 				reps: [
@@ -143,12 +143,10 @@ describe('list representations', () => {
 						review: true
 					}
 				],
-				repReviewed: false,
 				pageNumber: 1,
 				resultsEndNumber: 3,
 				resultsStartNumber: 1,
 				selectedItemsPerPage: 25,
-				showDistressingContentBanner: false,
 				totalFilteredRepresentations: 3,
 				totalPages: 1
 			});
@@ -177,6 +175,7 @@ describe('list representations', () => {
 				backLink: '/cases/id-1',
 				pageCaption: 'CROWN/2025/0000001',
 				pageTitle: 'Manage representations',
+				banner: null,
 				baseUrl: '/manage-representations',
 				currentUrl: '/manage-representations',
 				queryParams: { filters: 'awaiting-review' },
@@ -191,7 +190,6 @@ describe('list representations', () => {
 					{ text: 'Withdrawn (1)', value: 'withdrawn', checked: false }
 				],
 				filtersValue: '&filters=awaiting-review',
-				id: 'id-1',
 				counts: { 'awaiting-review': 1, accepted: 1, rejected: 0, withdrawn: 1 },
 				searchValue: '',
 				reps: [
@@ -220,12 +218,10 @@ describe('list representations', () => {
 						review: true
 					}
 				],
-				repReviewed: false,
 				pageNumber: 1,
 				resultsEndNumber: 3,
 				resultsStartNumber: 1,
 				selectedItemsPerPage: 25,
-				showDistressingContentBanner: false,
 				totalFilteredRepresentations: 3,
 				totalPages: 1
 			});
@@ -253,6 +249,7 @@ describe('list representations', () => {
 				backLink: '/cases/id-1',
 				pageCaption: 'CROWN/2025/0000001',
 				pageTitle: 'Manage representations',
+				banner: null,
 				baseUrl: '/manage-representations',
 				currentUrl: '/manage-representations',
 				queryParams: { filters: ['awaiting-review', 'rejected', 'withdrawn', 'accepted'] },
@@ -267,7 +264,6 @@ describe('list representations', () => {
 					{ text: 'Withdrawn (1)', value: 'withdrawn', checked: true }
 				],
 				filtersValue: '&filters=awaiting-review&filters=rejected&filters=withdrawn&filters=accepted',
-				id: 'id-1',
 				counts: { 'awaiting-review': 1, accepted: 1, rejected: 0, withdrawn: 1 },
 				searchValue: '',
 				reps: [
@@ -296,12 +292,10 @@ describe('list representations', () => {
 						review: true
 					}
 				],
-				repReviewed: false,
 				pageNumber: 1,
 				resultsEndNumber: 3,
 				resultsStartNumber: 1,
 				selectedItemsPerPage: 25,
-				showDistressingContentBanner: false,
 				totalFilteredRepresentations: 3,
 				totalPages: 1
 			});
@@ -339,7 +333,7 @@ describe('list representations', () => {
 			await controller(mockReq, mockRes);
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const ctx = mockRes.render.mock.calls[0].arguments[1];
-			assert.strictEqual(ctx.showDistressingContentBanner, false);
+			assert.strictEqual(ctx.banner, null);
 		});
 		it('should show distressing content banner when saving with mismatch', async () => {
 			const representations = [
@@ -374,7 +368,11 @@ describe('list representations', () => {
 			await controller(mockReq, mockRes);
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const ctx = mockRes.render.mock.calls[0].arguments[1];
-			assert.strictEqual(ctx.showDistressingContentBanner, true);
+			assert.ok(ctx.banner);
+			assert.match(
+				ctx.banner.html,
+				/You set this representation as potentially distressing, but the application is not set as potentially distressing./
+			);
 		});
 		it('should not show distressing content banner when representation is marked distressing but case-level flag is true', async () => {
 			const representations = [
@@ -408,7 +406,8 @@ describe('list representations', () => {
 			await controller(mockReq, mockRes);
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const ctx = mockRes.render.mock.calls[0].arguments[1];
-			assert.strictEqual(ctx.showDistressingContentBanner, false);
+			assert.ok(ctx.banner);
+			assert.strictEqual(ctx.banner.html, undefined);
 		});
 		it('should not show distressing content banner when no representation is marked distressing even if case flag is false', async () => {
 			const representations = [
@@ -449,7 +448,8 @@ describe('list representations', () => {
 			await controller(mockReq, mockRes);
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const ctx = mockRes.render.mock.calls[0].arguments[1];
-			assert.strictEqual(ctx.showDistressingContentBanner, false);
+			assert.ok(ctx.banner);
+			assert.strictEqual(ctx.banner.html, undefined);
 		});
 		it('should not show distressing content banner when representations are missing from crown development record', async () => {
 			const mockDbLocal = {
@@ -474,7 +474,7 @@ describe('list representations', () => {
 			await controller(mockReq, mockRes);
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const ctx = mockRes.render.mock.calls[0].arguments[1];
-			assert.strictEqual(ctx.showDistressingContentBanner, false);
+			assert.strictEqual(ctx.banner, null);
 		});
 		it('should not treat string "yes" as distressing with the current representation check (only boolean true triggers)', async () => {
 			const representations = [
@@ -508,7 +508,7 @@ describe('list representations', () => {
 			await controller(mockReq, mockRes);
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const ctx = mockRes.render.mock.calls[0].arguments[1];
-			assert.strictEqual(ctx.showDistressingContentBanner, false);
+			assert.strictEqual(ctx.banner, null);
 		});
 	});
 });

--- a/apps/manage/src/app/views/cases/view/manage-reps/list/view.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/list/view.njk
@@ -8,26 +8,12 @@
 {% import "pagination/pagination-options.njk" as paginationOptions %}
 
 {% block pageContent %}
-    {% if showDistressingContentBanner %}
-        {% set html %}
-            <p class="govuk-notification-banner__heading">Representation has been accepted</p>
-            <p class="govuk-body">
-                You set this representation as potentially distressing, but the application is not set as potentially
-                distressing.</p>
-            <p class="govuk-body">
-                <a class="govuk-notification-banner__link" href="/cases/{{ id }}/details/distressing-content">Set the
-                    application as potentially distressing</a>.
-            </p>
-        {% endset %}
-        {{ govukNotificationBanner({
-            titleText: "Important",
-            html: html
-        }) }}
-    {% elif repReviewed %}
-        {{ govukNotificationBanner({
-            text: "Representation has been " + repReviewed,
-            type: "success"
-        }) }}
+    {% if banner %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                {{ govukNotificationBanner(banner) }}
+            </div>
+        </div>
     {% endif %}
 
     <form id="search-filter-form" method="GET">


### PR DESCRIPTION
## Describe your changes
Part of banner combination: combine all banners on manage reps endpoint. Here the messages are changes in representation status, and if the a representation contains distressing content but the case is not marked as doing so.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1558
<img width="1012" height="310" alt="Screenshot 2026-06-01 163643" src="https://github.com/user-attachments/assets/9522c56d-931a-4205-bc0d-5ce6731772d1" />

