### PR TITLE
feat(manage): combine banner messages for representation view

### DIFF
--- a/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/edit/controller.js
@@ -205,7 +205,7 @@ async function addRepresentationFolderToSharepoint(sharePointDrive, logger, appl
 /**
  * Add a rep updated flag to the session
  *
- * @param {{session?: Object<string, any>}} req
+ * @param {import('express').Request} req
  * @param {string} id
  */
 function addRepUpdatedSession(req, id) {
@@ -215,9 +215,9 @@ function addRepUpdatedSession(req, id) {
 /**
  * Read a rep updated flag from the session
  *
- * @param {{session?: Object<string, any>}} req
+ * @param {import('express').Request} req
  * @param {string} id
- * @returns {string|boolean}
+ * @returns {boolean}
  */
 export function readRepUpdatedSession(req, id) {
 	return readSessionData(req, id, 'representationUpdated', false, 'representations');
@@ -226,7 +226,7 @@ export function readRepUpdatedSession(req, id) {
 /**
  * Clear a rep updated flag from the session
  *
- * @param {{session?: Object<string, any>}} req
+ * @param {import('express').Request} req
  * @param {string} id
  */
 export function clearRepUpdatedSession(req, id) {

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/controller.js
@@ -13,6 +13,57 @@ import {
 } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { getSubmittedForId } from '@pins/crowndev-lib/util/questions.js';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
+import { BannerBuilder } from '@pins/crowndev-lib/views/banner/banner-builder.ts';
+import { isSafeRelativeUrl, escapeHtml } from '@pins/crowndev-lib/util/string.ts';
+
+/**
+ * @typedef {import('@pins/crowndev-lib/views/banner/banner-builder').BannerMessage} BannerMessage
+ * @typedef {{representationUpdated: boolean}} GetBannerMessagesOptions
+ */
+
+/**
+ * Get all banner messages to display.
+ *
+ * @param {import('express').Response} res
+ * @param {import('express').Request} req
+ * @param {GetBannerMessagesOptions} options
+ * @return {BannerMessage|null}
+ */
+function getBannerMessages(res, req, options) {
+	const bannerBuilder = new BannerBuilder();
+
+	if (options.representationUpdated) {
+		bannerBuilder.addSuccessText('Representation has been updated');
+	}
+
+	const documentInfoBanner = getDocumentInfoBanner(res, req.baseUrl);
+
+	if (!documentInfoBanner) {
+		return bannerBuilder.build();
+	}
+
+	if (documentInfoBanner.name === 'awaitingReview') {
+		const safeHref = escapeHtml(isSafeRelativeUrl(documentInfoBanner.href) ? documentInfoBanner.href : '#');
+		return bannerBuilder
+			.addInfoTrustedSingleLineHtml(
+				`There are attachments awaiting review.
+			<a class="govuk-notification-banner__link" href="${safeHref}">Manage attachments</a>.`
+			)
+			.build();
+	}
+
+	if (documentInfoBanner.name === 'noAttachmentsAdded') {
+		const safeHref = escapeHtml(isSafeRelativeUrl(documentInfoBanner.href) ? documentInfoBanner.href : '#');
+		return bannerBuilder
+			.addInfoTrustedSingleLineHtml(
+				`There are no attachments added.
+			<a class="govuk-notification-banner__link" href="${safeHref}">Add attachments</a>.`
+			)
+			.build();
+	}
+
+	return bannerBuilder.build();
+}
 
 /**
  * @typedef {import('express').Handler} Handler
@@ -49,6 +100,11 @@ export function validateParams(params) {
  * @param {Object<string, *>} [viewData]
  */
 export async function renderRepresentation(req, res, viewData = {}) {
+	const id = req.params.id;
+	if (!id || typeof id !== 'string') {
+		throw new Error('id param is required');
+	}
+
 	const { representationRef } = validateParams(req.params);
 
 	// Show publish case validation errors
@@ -61,14 +117,15 @@ export async function renderRepresentation(req, res, viewData = {}) {
 	const representationUpdated = readRepUpdatedSession(req, representationRef);
 	clearRepUpdatedSession(req, representationRef);
 
+	const banner = getBannerMessages(res, req, { representationUpdated });
+
 	await list(req, res, '', {
 		representationRef,
-		representationUpdated,
 		requiresReview: res.locals?.journeyResponse?.answers?.requiresReview,
-		backLinkUrl: `/cases/${req.params.id}/manage-representations`,
+		backLinkUrl: `/cases/${id}/manage-representations`,
 		currentUrl: req.originalUrl,
 		representationStatus: res.locals?.journeyResponse?.answers?.statusId,
-		documentInfoBanner: getDocumentInfoBanner(res, req.baseUrl),
+		banner,
 		...viewData
 	});
 }
@@ -183,4 +240,6 @@ function getDocumentInfoBanner(res, currentUrl) {
 			href: `${trimmedUrl}/manage/task-list`
 		};
 	}
+
+	return null;
 }

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/controller.test.js
@@ -51,8 +51,7 @@ describe('controller', () => {
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
 			assert.strictEqual(viewData.requiresReview, true);
 			assert.strictEqual(viewData.representationRef, 'ref-1');
-			assert.strictEqual(viewData.representationUpdated, false);
-			assert.strictEqual(viewData.documentInfoBanner, undefined);
+			assert.strictEqual(viewData.banner, null);
 		});
 		it('should render the representation with no attachments added banner', async () => {
 			const journeyResponse = new JourneyResponse('id-1', 'id-2', {
@@ -65,7 +64,7 @@ describe('controller', () => {
 			const questions = getQuestions();
 			const mockReq = {
 				params: { id: 'case-1', representationRef: 'ref-1' },
-				baseUrl: 'case-1/manage-representations'
+				baseUrl: '/case-1/manage-representations'
 			};
 			const mockRes = {
 				render: mock.fn(),
@@ -77,10 +76,13 @@ describe('controller', () => {
 			await assert.doesNotReject(() => viewRepresentation(mockReq, mockRes));
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
-			assert.deepStrictEqual(viewData.documentInfoBanner, {
-				name: 'noAttachmentsAdded',
-				href: 'case-1/manage-representations/edit/myself/attachments'
-			});
+			assert.strictEqual(viewData.banner.type, 'info');
+			assert.strictEqual(viewData.banner.text, undefined);
+			assert.match(viewData.banner.html, /There are no attachments added\./);
+			assert.match(viewData.banner.html, /Add attachments/);
+			assert.match(viewData.banner.html, /class="govuk-notification-banner__link"/);
+			assert.match(viewData.banner.html, /case-1\/manage-representations\/edit\/myself\/attachments/);
+			assert.doesNotMatch(viewData.banner.html, /govuk-list--bullet/);
 		});
 		it('should render the representation with awaiting review document banner', async () => {
 			const journeyResponse = new JourneyResponse('id-1', 'id-2', {
@@ -103,7 +105,7 @@ describe('controller', () => {
 			const questions = getQuestions();
 			const mockReq = {
 				params: { id: 'case-1', representationRef: 'ref-1' },
-				baseUrl: 'case-1/manage-representations'
+				baseUrl: '/case-1/manage-representations'
 			};
 			const mockRes = {
 				render: mock.fn(),
@@ -115,10 +117,13 @@ describe('controller', () => {
 			await assert.doesNotReject(() => viewRepresentation(mockReq, mockRes));
 			assert.strictEqual(mockRes.render.mock.callCount(), 1);
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
-			assert.deepStrictEqual(viewData.documentInfoBanner, {
-				name: 'awaitingReview',
-				href: 'case-1/manage-representations/manage/task-list'
-			});
+			assert.strictEqual(viewData.banner.type, 'info');
+			assert.strictEqual(viewData.banner.text, undefined);
+			assert.match(viewData.banner.html, /There are attachments awaiting review\./);
+			assert.match(viewData.banner.html, /Manage attachments/);
+			assert.match(viewData.banner.html, /class="govuk-notification-banner__link"/);
+			assert.match(viewData.banner.html, /case-1\/manage-representations\/manage\/task-list/);
+			assert.doesNotMatch(viewData.banner.html, /govuk-list--bullet/);
 		});
 		it('should read & clear rep updated session data', async () => {
 			const journeyResponse = new JourneyResponse('id-1', 'id-2', {
@@ -143,7 +148,54 @@ describe('controller', () => {
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
 			assert.strictEqual(viewData.requiresReview, true);
 			assert.strictEqual(viewData.representationRef, 'ref-1');
-			assert.strictEqual(viewData.representationUpdated, true);
+			assert.deepStrictEqual(viewData.banner, { text: 'Representation has been updated', type: 'success' });
+			assert.strictEqual(mockReq.session.representations['ref-1'].representationUpdated, undefined);
+		});
+		it('should merge rep updated and awaiting review document messages into a single success banner', async () => {
+			const journeyResponse = new JourneyResponse('id-1', 'id-2', {
+				applicationReference: 'app-ref',
+				requiresReview: true,
+				statusId: 'accepted',
+				submittedForId: 'myself',
+				myselfContainsAttachments: 'yes',
+				myselfAttachments: [
+					{
+						fileName: 'test-pdf 1.pdf',
+						statusId: 'accepted'
+					},
+					{
+						fileName: 'test-pdf 2.pdf',
+						statusId: 'awaiting-review'
+					}
+				]
+			});
+			const questions = getQuestions();
+			const mockReq = {
+				params: { id: 'case-1', representationRef: 'ref-1' },
+				baseUrl: '/case-1/manage-representations',
+				session: { representations: { 'ref-1': { representationUpdated: true } } }
+			};
+			const mockRes = {
+				render: mock.fn(),
+				locals: {
+					journeyResponse: journeyResponse,
+					journey: createJourney(questions, journeyResponse, mockReq)
+				}
+			};
+			await assert.doesNotReject(() => viewRepresentation(mockReq, mockRes));
+			assert.strictEqual(mockRes.render.mock.callCount(), 1);
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.strictEqual(viewData.banner.type, 'success');
+			assert.strictEqual(viewData.banner.text, undefined);
+			assert.match(viewData.banner.html, /<ul class="govuk-list govuk-list--bullet">/);
+			assert.match(viewData.banner.html, /Representation has been updated/);
+			assert.match(viewData.banner.html, /There are attachments awaiting review\./);
+			assert.match(viewData.banner.html, /Manage attachments/);
+			assert.match(viewData.banner.html, /case-1\/manage-representations\/manage\/task-list/);
+			assert.ok(
+				viewData.banner.html.indexOf('Representation has been updated') <
+					viewData.banner.html.indexOf('There are attachments awaiting review.')
+			);
 			assert.strictEqual(mockReq.session.representations['ref-1'].representationUpdated, undefined);
 		});
 	});

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/view.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/view.njk
@@ -15,32 +15,12 @@
 {% endblock %}
 
 {% block content %}
-    {% if representationUpdated %}
-        {{ govukNotificationBanner({
-            text: "Representation has been updated",
-            type: "success"
-        }) }}
-    {% endif %}
-
-    {% if documentInfoBanner %}
-        {% if documentInfoBanner.name === "awaitingReview" %}
-            {% set html %}
-                <p class="govuk-notification-banner__heading">
-                    There are attachments awaiting review.
-                    <a class="govuk-notification-banner__link" href="{{ documentInfoBanner.href }}">Manage attachments</a>.
-                </p>
-            {% endset %}
-        {% elseif documentInfoBanner.name === "noAttachmentsAdded" %}
-            {% set html %}
-                <p class="govuk-notification-banner__heading">
-                    There are no attachments added.
-                    <a class="govuk-notification-banner__link" href="{{ documentInfoBanner.href }}">Add attachments</a>.
-                </p>
-            {% endset %}
-        {% endif %}
-        {{ govukNotificationBanner({
-            html: html
-        }) }}
+    {% if banner %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                {{ govukNotificationBanner(banner) }}
+            </div>
+        </div>
     {% endif %}
 
     <div class="govuk-grid-row">

--- a/packages/lib/util/string.test.ts
+++ b/packages/lib/util/string.test.ts
@@ -1,6 +1,14 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { camelCaseToUrlCase, camelCaseToSentenceCase, sentenceCase, isString, getFilenameStem } from './string.ts';
+import {
+	camelCaseToUrlCase,
+	camelCaseToSentenceCase,
+	sentenceCase,
+	isString,
+	getFilenameStem,
+	isSafeRelativeUrl,
+	escapeHtml
+} from './string.ts';
 
 describe('string util', () => {
 	describe('camelCaseToUrlCase', () => {
@@ -109,6 +117,141 @@ describe('string util', () => {
 
 		it('should return empty string for empty input', () => {
 			assert.deepStrictEqual(getFilenameStem(''), '');
+		});
+	});
+
+	describe('isSafeRelativeUrl', () => {
+		it('should accept a plain relative path', () => {
+			assert.strictEqual(isSafeRelativeUrl('/cases/123/manage-representations'), true);
+		});
+
+		it('should accept a relative path with a query string', () => {
+			assert.strictEqual(isSafeRelativeUrl('/cases/123?tab=reps'), true);
+		});
+
+		it('should reject an empty string', () => {
+			assert.strictEqual(isSafeRelativeUrl(''), false);
+		});
+
+		it('should reject a protocol-relative URL', () => {
+			assert.strictEqual(isSafeRelativeUrl('//evil.com/path'), false);
+		});
+
+		it('should reject an absolute URL', () => {
+			assert.strictEqual(isSafeRelativeUrl('https://evil.com'), false);
+		});
+
+		it('should reject a href containing a double-quote', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path"onmouseover=alert(1)'), false);
+		});
+
+		it('should reject a href containing a single-quote', () => {
+			assert.strictEqual(isSafeRelativeUrl("/path'onmouseover=alert(1)"), false);
+		});
+
+		it('should reject a href containing angle brackets', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path<script>'), false);
+		});
+
+		it('should accept a relative path with multiple query parameters (& without ; is not an entity)', () => {
+			assert.strictEqual(isSafeRelativeUrl('/cases/123?tab=reps&foo=bar'), true);
+		});
+
+		it('should reject &quot; entity-encoded double-quote', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&quot;onmouseover=alert(1)'), false);
+		});
+
+		it('should reject &#34; decimal entity for double-quote', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&#34;onmouseover=alert(1)'), false);
+		});
+
+		it('should reject &#x22; hex entity for double-quote', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&#x22;onmouseover=alert(1)'), false);
+		});
+
+		it('should reject &apos; entity-encoded single-quote', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&apos;onmouseover=alert(1)'), false);
+		});
+
+		it('should reject &#39; decimal entity for single-quote', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&#39;onmouseover=alert(1)'), false);
+		});
+
+		it('should reject &#x27; hex entity for single-quote', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&#x27;onmouseover=alert(1)'), false);
+		});
+
+		it('should reject &lt; / &gt; entity-encoded angle brackets', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&lt;script&gt;'), false);
+		});
+
+		it('should reject &#60; decimal entity for less-than', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&#60;script&#62;'), false);
+		});
+
+		it('should reject &#X3C; upper-case hex entity for less-than', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path&#X3C;script&#X3E;'), false);
+		});
+
+		it('should reject a href containing a null control character', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path\x00payload'), false);
+		});
+
+		it('should reject a href containing a newline control character', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path\npayload'), false);
+		});
+
+		it('should reject a href containing a carriage-return control character', () => {
+			assert.strictEqual(isSafeRelativeUrl('/path\rpayload'), false);
+		});
+	});
+
+	describe('escapeHtml', () => {
+		it('should escape ampersand character', () => {
+			assert.strictEqual(escapeHtml('cats & dogs'), 'cats &amp; dogs');
+		});
+
+		it('should escape less-than character', () => {
+			assert.strictEqual(escapeHtml('2 < 3'), '2 &lt; 3');
+		});
+
+		it('should escape greater-than character', () => {
+			assert.strictEqual(escapeHtml('3 > 2'), '3 &gt; 2');
+		});
+
+		it('should escape double-quote character', () => {
+			assert.strictEqual(escapeHtml('She said "hello"'), 'She said &quot;hello&quot;');
+		});
+
+		it('should escape single-quote character', () => {
+			assert.strictEqual(escapeHtml("It's working"), 'It&#39;s working');
+		});
+
+		it('should escape multiple different special characters in one string', () => {
+			assert.strictEqual(
+				escapeHtml('<script>alert("XSS")</script>'),
+				'&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;'
+			);
+		});
+
+		it('should escape multiple instances of the same special character', () => {
+			assert.strictEqual(escapeHtml('yes & no & maybe'), 'yes &amp; no &amp; maybe');
+		});
+
+		it('should return unchanged string when no special characters present', () => {
+			assert.strictEqual(escapeHtml('plain text'), 'plain text');
+		});
+
+		it('should handle empty string', () => {
+			assert.strictEqual(escapeHtml(''), '');
+		});
+
+		it('should handle string with only special characters', () => {
+			assert.strictEqual(escapeHtml('&<>"\''), '&amp;&lt;&gt;&quot;&#39;');
+		});
+
+		it('should preserve numbers and punctuation other than special HTML characters', () => {
+			assert.strictEqual(escapeHtml('Hello, world! 123 ... @#$%'), 'Hello, world! 123 ... @#$%');
 		});
 	});
 });

--- a/packages/lib/util/string.ts
+++ b/packages/lib/util/string.ts
@@ -46,6 +46,28 @@ export function getFilenameStem(filename: string): string {
 	return filename.slice(0, lastDot);
 }
 
+/**
+ * Returns true only for safe relative URLs: must start with `/`, must not
+ * contain any characters that are meaningful in an HTML attribute value
+ * (`"`, `'`, `<`, `>`), must not use a protocol-relative prefix (`//`),
+ * must not contain HTML entity references that would decode to those
+ * characters (e.g. `&quot;`, `&#34;`, `&#x22;`), and must not contain
+ * ASCII control characters.
+ */
+export function isSafeRelativeUrl(href: string): boolean {
+	// Must start with a single slash (not protocol-relative)
+	if (!/^\/(?!\/)/.test(href)) return false;
+	// Reject literal characters that break out of HTML attribute values
+	if (/["'<>]/.test(href)) return false;
+	// Reject HTML entity references (e.g. &quot; &#34; &#x22; &apos; &lt; &gt;)
+	// that an HTML parser would decode into dangerous characters
+	if (/&(?:#x?[\da-f]+|[a-z]+);/i.test(href)) return false;
+	// Reject ASCII control characters (U+0000–U+001F and U+007F)
+	// eslint-disable-next-line no-control-regex
+	if (/[\x00-\x1f\x7f]/.test(href)) return false;
+	return true;
+}
+
 const HTML_ESCAPES: Record<string, string> = {
 	'&': '&amp;',
 	'<': '&lt;',


### PR DESCRIPTION
## Describe your changes
Part of banner combination: combine all banners on manage individual reps. 

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1558
<img width="1031" height="209" alt="Screenshot 2026-06-01 164406" src="https://github.com/user-attachments/assets/8437b306-c066-4edd-9bda-f6713eb98fa0" />
<img width="1038" height="171" alt="Screenshot_1-6-2026_165916_localhost" src="https://github.com/user-attachments/assets/29c0bc00-af27-467f-9b56-34508e615e62" />

