### PR TITLE
feat(update-case): convert update-case.js to TypeScript

### DIFF
--- a/apps/manage/src/app/views/cases/view/index.js
+++ b/apps/manage/src/app/views/cases/view/index.js
@@ -8,7 +8,7 @@ import { createRoutes as createCasePublishRoutes } from './publish/index.js';
 import { createRoutes as createCaseUnpublishRoutes } from './unpublish/index.js';
 import { createRoutes as createRepsRoutes } from './manage-reps/index.js';
 import { createRoutes as createApplicationUpdatesRoutes } from './application-updates/index.js';
-import { buildUpdateCase } from './update-case.js';
+import { buildUpdateCase } from './update-case.ts';
 import { createRoutes as createCaseHistoryRoutes } from '../case-history/index.ts';
 import {
 	buildGetJourneyResponseFromSession,

--- a/apps/manage/src/app/views/cases/view/linked-case-updates.ts
+++ b/apps/manage/src/app/views/cases/view/linked-case-updates.ts
@@ -14,7 +14,6 @@ import type {
 } from './view-model.ts';
 import type { CrownDevelopmentPlanningPayload } from './payload-contracts.ts';
 import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
-import type { ManageService } from '#service';
 
 type CaseUpdateWritePlan = {
 	scalarCaseUpdates: { caseIds: string[]; updateInput: Prisma.CrownDevelopmentUpdateInput };
@@ -473,7 +472,7 @@ export function buildCaseUpdateWritePlan({
 /**
  * Execute a write plan inside a Prisma interactive transaction.
  */
-export async function executeCaseUpdateWritePlan(plan: CaseUpdateWritePlan, tx: ManageService['db']) {
+export async function executeCaseUpdateWritePlan(plan: CaseUpdateWritePlan, tx: Prisma.TransactionClient) {
 	const createdOrgIds: Map<string, string> = new Map();
 	const resolveOrgId = (id: string) => createdOrgIds.get(id) || id;
 

--- a/apps/manage/src/app/views/cases/view/update-case.test.js
+++ b/apps/manage/src/app/views/cases/view/update-case.test.js
@@ -1,5 +1,5 @@
 import { describe, it, mock } from 'node:test';
-import { buildUpdateCase } from './update-case.js';
+import { buildUpdateCase } from './update-case.ts';
 import assert from 'node:assert';
 import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
 import { APPLICATION_PROCEDURE_ID, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
@@ -69,7 +69,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					description: 'My new application description'
@@ -278,7 +277,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					description: 'My new application description'
@@ -313,7 +311,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					description: 'My new application description'
@@ -352,7 +349,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					statusId: 'acceptance'
@@ -396,7 +392,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					manageApplicantDetails: [
@@ -459,7 +454,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					manageApplicantDetails: [
@@ -521,7 +515,6 @@ describe('case details', () => {
 					}
 				}
 			};
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					siteAddress: {
@@ -592,7 +585,6 @@ describe('case details', () => {
 					}
 				}
 			};
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					siteAddress: {
@@ -662,7 +654,6 @@ describe('case details', () => {
 					}
 				}
 			};
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					siteAddress: {
@@ -733,7 +724,6 @@ describe('case details', () => {
 					}
 				}
 			};
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					siteAddress: {
@@ -787,7 +777,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					siteAddress: {
@@ -833,7 +822,6 @@ describe('case details', () => {
 					}
 				}
 			};
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					inquiryVenue: 'some place'
@@ -887,7 +875,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					lpaQuestionnaireReceivedDate: date
@@ -955,7 +942,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					lpaQuestionnaireReceivedDate: date
@@ -1025,7 +1011,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					lpaQuestionnaireReceivedDate: date
@@ -1078,7 +1063,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					applicationReceivedDate: date
@@ -1153,7 +1137,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					applicationReceivedDate: date
@@ -1207,7 +1190,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					applicationReceivedDate: date
@@ -1260,7 +1242,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					applicationReceivedDate: date
@@ -1306,7 +1287,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					applicationReceivedDate: date
@@ -1371,7 +1351,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					applicationReceivedDate: date
@@ -1421,7 +1400,6 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					turnedAwayDate: date
@@ -1491,7 +1469,7 @@ describe('case details', () => {
 				}
 			};
 			const date = new Date('2025-01-02');
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
+
 			const data = {
 				answers: {
 					turnedAwayDate: date
@@ -1517,7 +1495,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					description: 'My new application description'
@@ -1549,17 +1526,43 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
+
 			const data = {
 				answers: {
-					description: 'My new application description'
+					siteNorthing: '000123'
 				}
 			};
 			await updateCase({ req: mockReq, res: mockRes, data });
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
 			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
-			assert.strictEqual(updateArg.data.description, null);
+			assert.strictEqual(updateArg.data.siteNorthing, null);
+		});
+		it('should delete save key if key is not clearable and clearAnswer is true', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00.000Z') });
+			const logger = mockLogger();
+			const mockDb = {
+				$transaction: mock.fn(() => Promise.resolve()),
+				crownDevelopment: {
+					update: mock.fn(),
+					findUnique: mock.fn(() => ({}))
+				}
+			};
+			makeTransactionInteractive(mockDb);
+			const updateCase = buildUpdateCase({ db: mockDb, logger }, true);
+			const mockReq = {
+				params: { id: 'case1' },
+				session: {}
+			};
+			const mockRes = { locals: {} };
+
+			const data = {
+				answers: {
+					description: 'the description'
+				}
+			};
+			await updateCase({ req: mockReq, res: mockRes, data });
+			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 0);
 		});
 
 		it('should throw an error if LPA Questionnaire Sent Notification fails', async () => {
@@ -1624,7 +1627,6 @@ describe('case details', () => {
 				session: {}
 			};
 			const mockRes = { locals: {} };
-			/** @type {{answers: import('./types.js').CrownDevelopmentViewModel}} */
 			const data = {
 				answers: {
 					lpaQuestionnaireSentDate: new Date('2025-01-02')

--- a/apps/manage/src/app/views/cases/view/update-case.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.ts
@@ -1,48 +1,105 @@
-import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 import {
 	sendApplicationNotOfNationalImportanceNotification,
 	sendApplicationReceivedNotification,
 	sendLpaAcknowledgeReceiptOfQuestionnaireNotification,
 	sendLpaQuestionnaireSentNotification
 } from './notification.js';
-import { editsToDatabaseUpdates, crownDevelopmentToViewModel } from './view-model.ts';
+import { CLEARABLE_SAVE_KEYS, editsToDatabaseUpdates, crownDevelopmentToViewModel } from './view-model.ts';
 import {
 	hasOrganisationWriteEdits,
 	buildCaseUpdateWritePlan,
 	executeCaseUpdateWritePlan
 } from './linked-case-updates.ts';
+import { CROWN_DEVELOPMENT_VIEW_INCLUDE, CROWN_DEVELOPMENT_PLANNING_INCLUDE } from './payload-contracts.ts';
 import { wrapPrismaError } from '@pins/crowndev-lib/util/database.js';
 import { APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { addSessionData } from '@pins/crowndev-lib/util/session.ts';
+import type { ManageService } from '#service';
+import { BOOLEAN_OPTIONS, type SaveDataFn } from '@planning-inspectorate/dynamic-forms';
+import type { Request, Response } from 'express';
+import type {
+	CrownDevelopmentClearableKey,
+	CrownDevelopmentViewModel,
+	CrownDevelopmentSaveModel
+} from './view-model.ts';
+import type { CrownDevelopmentPlanningPayload } from './payload-contracts.ts';
+import type { ErrorSummaryItem } from '@pins/crowndev-lib/util/types.ts';
+import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
+
+function typedObjectKeys<T extends object>(obj: T): Array<keyof T> {
+	return Object.keys(obj) as Array<keyof T>;
+}
+
+function typedObjectEntries<T extends object>(obj: T): Array<[keyof T, T[keyof T]]> {
+	return Object.entries(obj) as Array<[keyof T, T[keyof T]]>;
+}
+
+function setSaveAnswer<K extends keyof CrownDevelopmentSaveModel>(
+	answers: CrownDevelopmentSaveModel,
+	key: K,
+	value: CrownDevelopmentSaveModel[K]
+): void {
+	answers[key] = value;
+}
+
+function setViewModelAnswer<K extends keyof CrownDevelopmentViewModel>(
+	answers: CrownDevelopmentViewModel,
+	key: K,
+	value: CrownDevelopmentViewModel[K]
+): void {
+	answers[key] = value;
+}
+
+const CLEARABLE_SAVE_KEY_SET = new Set<CrownDevelopmentClearableKey>(CLEARABLE_SAVE_KEYS);
+
+function isClearableSaveKey(key: keyof CrownDevelopmentSaveModel): key is CrownDevelopmentClearableKey {
+	return CLEARABLE_SAVE_KEY_SET.has(key as CrownDevelopmentClearableKey);
+}
+
+type ErrorWithSummary = Error & { errorSummary: ErrorSummaryItem[] };
+
+function buildSummaryError(message: string, errorSummary: ErrorSummaryItem[]): ErrorWithSummary {
+	const error = new Error(message) as ErrorWithSummary;
+	error.errorSummary = errorSummary;
+	return error;
+}
 
 /**
- * @param {import('#service').ManageService} service
- * @param {boolean} [clearAnswer=false] - whether to clear the answer before saving
- * @returns {import('@planning-inspectorate/dynamic-forms/src/controller.js').SaveDataFn}
+ * Applies updates to a case based on the provided data.
+ *
+ * @param service - the manage service instance
+ * @param clearAnswer - whether to clear the answer before saving
  */
-export function buildUpdateCase(service, clearAnswer = false) {
-	return async ({ req, res, data }) => {
+export function buildUpdateCase(service: ManageService, clearAnswer: boolean = false): SaveDataFn {
+	return async ({ req, res, data }: { req: Request; res: Response; data: { answers?: CrownDevelopmentSaveModel } }) => {
 		const { db, logger } = service;
 		const { id } = req.params;
-		if (!id || typeof id !== 'string') {
+		if (!id) {
 			throw new Error(`invalid update case request, id param required (id:${id})`);
 		}
+		if (typeof id !== 'string') {
+			throw new Error(`invalid update case request, multiple id params given`);
+		}
+
 		logger.info({ id }, 'case update');
-		/** @type {import('./view-model').CrownDevelopmentSaveModel} */
-		const toSave = data?.answers || {};
+
+		const toSave: CrownDevelopmentSaveModel = data?.answers || {};
 		if (clearAnswer) {
 			// clear the answer if requested
-			Object.keys(toSave).forEach((key) => {
-				toSave[key] = null;
+			typedObjectKeys(toSave).forEach((key) => {
+				if (isClearableSaveKey(key)) {
+					setSaveAnswer(toSave, key, null);
+					return;
+				}
+				delete toSave[key];
 			});
 		}
 		if (Object.keys(toSave).length === 0) {
 			logger.info({ id }, 'no case updates to apply');
 			return;
 		}
-		/** @type {import('./view-model').CrownDevelopmentViewModel} */
 		const fullViewModel = res.locals?.journeyResponse?.answers || {};
-		const originalAnswers = res.locals?.originalAnswers || {};
+		const originalAnswers: Partial<CrownDevelopmentViewModel> = res.locals?.originalAnswers || {};
 
 		await customUpdateCaseActions(service, id, toSave, fullViewModel);
 
@@ -67,20 +124,7 @@ export function buildUpdateCase(service, clearAnswer = false) {
 			await db.$transaction(async (tx) => {
 				const crownDevelopment = await tx.crownDevelopment.findUnique({
 					where: { id },
-					include: {
-						ParentCrownDevelopment: { select: { id: true, siteAddressId: true } },
-						ChildrenCrownDevelopment: { select: { id: true, siteAddressId: true } },
-						Organisations: {
-							include: {
-								Organisation: {
-									include: {
-										Address: true,
-										OrganisationToContact: { include: { Contact: true } }
-									}
-								}
-							}
-						}
-					}
+					include: CROWN_DEVELOPMENT_VIEW_INCLUDE
 				});
 				if (!crownDevelopment) {
 					throw new Error('Crown Development case not found');
@@ -88,17 +132,16 @@ export function buildUpdateCase(service, clearAnswer = false) {
 
 				// Fresh DB view model gives correct relation ids (organisationRelationId / organisationToContactRelationId)
 				const dbViewModel = crownDevelopmentToViewModel(crownDevelopment);
-				/** @type {import('./view-model').CrownDevelopmentViewModel} */
-				const viewModelForUpdates = { ...dbViewModel };
-				for (const [key, value] of Object.entries(originalAnswers)) {
+				const viewModelForUpdates: CrownDevelopmentViewModel = { ...dbViewModel };
+				for (const [key, value] of typedObjectEntries(originalAnswers)) {
 					if (viewModelForUpdates[key] === undefined || viewModelForUpdates[key] === null) {
-						viewModelForUpdates[key] = value;
+						setViewModelAnswer(viewModelForUpdates, key, value);
 					}
 				}
 
 				// IMPORTANT: organisations are excluded here because organisation/contact updates are handled
 				// separately via the deterministic write plan (see buildCaseUpdateWritePlan/executeCaseUpdateWritePlan).
-				let updateInput = editsToDatabaseUpdates(toSave, viewModelForUpdates, { includeOrganisations: false });
+				const updateInput = editsToDatabaseUpdates(toSave, viewModelForUpdates, { includeOrganisations: false });
 				updateInput.updatedDate = new Date();
 
 				const caseIds = [id];
@@ -109,20 +152,12 @@ export function buildUpdateCase(service, clearAnswer = false) {
 					caseIds.push(...crownDevelopment.ChildrenCrownDevelopment.map((child) => child.id));
 				}
 
-				let crownDevelopmentsForPlanning = [crownDevelopment];
+				let crownDevelopmentsForPlanning: CrownDevelopmentPlanningPayload[] = [crownDevelopment];
 				const shouldDeleteAgentData = toSave.hasAgent === false && dbViewModel.hasAgent === BOOLEAN_OPTIONS.YES;
 				if ((hasOrganisationWriteEdits(toSave) || shouldDeleteAgentData) && caseIds.length > 1) {
 					crownDevelopmentsForPlanning = await tx.crownDevelopment.findMany({
 						where: { id: { in: caseIds } },
-						include: {
-							Organisations: {
-								include: {
-									Organisation: {
-										include: { Address: true, OrganisationToContact: { include: { Contact: true } } }
-									}
-								}
-							}
-						}
+						include: CROWN_DEVELOPMENT_PLANNING_INCLUDE
 					});
 				}
 
@@ -175,11 +210,8 @@ export function buildUpdateCase(service, clearAnswer = false) {
 
 /**
  * Add a case updated flag to the session
- *
- * @param {{session?: Object<string, any>}} req
- * @param {string} id
  */
-function addCaseUpdatedSession(req, id) {
+function addCaseUpdatedSession(req: Request, id: string) {
 	if (!req.session) {
 		throw new Error('request session required');
 	}
@@ -190,22 +222,19 @@ function addCaseUpdatedSession(req, id) {
 
 /**
  * Handle edit case updates with custom behaviour
- * @param {import('#service').ManageService} service
- * @param {string} id
- * @param {import('./view-model').CrownDevelopmentSaveModel} toSave
- * @param {import('./view-model').CrownDevelopmentViewModel} fullViewModel
  */
-export async function customUpdateCaseActions(service, id, toSave, fullViewModel) {
-	if (toSave.applicationFee !== undefined) {
-		handleApplicationFee(toSave);
-	}
-
+export async function customUpdateCaseActions(
+	service: ManageService,
+	id: string,
+	toSave: CrownDevelopmentSaveModel,
+	fullViewModel: CrownDevelopmentViewModel
+) {
 	if (
 		toSave.lpaQuestionnaireReceivedDate &&
 		fullViewModel.lpaQuestionnaireReceivedEmailSent !== BOOLEAN_OPTIONS.YES &&
 		fullViewModel.typeId !== APPLICATION_TYPE_ID.PLANNING_AND_LISTED_BUILDING_CONSENT
 	) {
-		await handleLpaQuestionnaireReceivedDateUpdate(service, id, toSave);
+		await handleLpaQuestionnaireReceivedDateUpdate(service, id, toSave, toSave.lpaQuestionnaireReceivedDate);
 	}
 
 	if (toSave.lpaQuestionnaireSentDate && fullViewModel.lpaQuestionnaireSpecialEmailSent !== BOOLEAN_OPTIONS.YES) {
@@ -213,7 +242,7 @@ export async function customUpdateCaseActions(service, id, toSave, fullViewModel
 	}
 
 	if (toSave.applicationReceivedDate) {
-		await handleApplicationReceivedDateUpdate(service, id, toSave, fullViewModel);
+		await handleApplicationReceivedDateUpdate(service, id, toSave, fullViewModel, toSave.applicationReceivedDate);
 	}
 
 	if (
@@ -225,39 +254,41 @@ export async function customUpdateCaseActions(service, id, toSave, fullViewModel
 	}
 }
 
-function handleApplicationFee(toSave) {
-	if (typeof toSave.applicationFee === 'string') {
-		toSave.applicationFee = Number(toSave.applicationFee.replace(/,/g, ''));
-	}
-}
-
 /**
- * @param {import('#service').ManageService} service
- * @param {string} id
- * @param {import('./view-model').CrownDevelopmentSaveModel} toSave
+ * Send notifications and update flags for LPA questionnaire received date updates
  */
-async function handleLpaQuestionnaireReceivedDateUpdate(service, id, toSave) {
-	await sendLpaAcknowledgeReceiptOfQuestionnaireNotification(service, id, toSave.lpaQuestionnaireReceivedDate);
+async function handleLpaQuestionnaireReceivedDateUpdate(
+	service: ManageService,
+	id: string,
+	toSave: CrownDevelopmentSaveModel,
+	receivedDate: Date
+) {
+	await sendLpaAcknowledgeReceiptOfQuestionnaireNotification(service, id, receivedDate);
 	toSave['lpaQuestionnaireReceivedEmailSent'] = true;
 }
 
 /**
- * @param {import('#service').ManageService} service
- * @param {string} id
- * @param {import('./view-model').CrownDevelopmentSaveModel} toSave
+ * Send notifications and update flags for LPA questionnaire sent date updates
  */
-async function handleLpaQuestionnaireSentDateUpdate(service, id, toSave) {
+async function handleLpaQuestionnaireSentDateUpdate(
+	service: ManageService,
+	id: string,
+	toSave: CrownDevelopmentSaveModel
+) {
 	await sendLpaQuestionnaireSentNotification(service, id);
 	toSave['lpaQuestionnaireSpecialEmailSent'] = true;
 }
 
 /**
- * @param {import('#service').ManageService} service
- * @param {string} id
- * @param {import('./view-model').CrownDevelopmentSaveModel} toSave
- * @param {import('./view-model').CrownDevelopmentViewModel} fullViewModel
+ * Handle application received date updates, including validation and notification logic
  */
-async function handleApplicationReceivedDateUpdate(service, id, toSave, fullViewModel) {
+async function handleApplicationReceivedDateUpdate(
+	service: ManageService,
+	id: string,
+	toSave: CrownDevelopmentSaveModel,
+	fullViewModel: CrownDevelopmentViewModel,
+	receivedDate: Date
+) {
 	const validations = [
 		{
 			condition: !fullViewModel.siteAddressId && !fullViewModel.siteNorthing && !fullViewModel.siteEasting,
@@ -276,7 +307,7 @@ async function handleApplicationReceivedDateUpdate(service, id, toSave, fullView
 		}
 	];
 
-	const errors = [];
+	const errors: ErrorSummaryItem[] = [];
 	validations.forEach(({ condition, message, href }) => {
 		if (condition) {
 			errors.push({ text: message, href });
@@ -284,36 +315,31 @@ async function handleApplicationReceivedDateUpdate(service, id, toSave, fullView
 	});
 
 	if (errors.length > 0) {
-		const error = new Error('Data required to set Application received date is missing');
-		error.errorSummary = errors;
-		throw error;
+		throw buildSummaryError('Data required to set Application received date is missing', errors);
 	}
 
 	if (
 		fullViewModel.applicationReceivedDateEmailSent !== BOOLEAN_OPTIONS.YES &&
 		fullViewModel.typeId !== APPLICATION_TYPE_ID.PLANNING_AND_LISTED_BUILDING_CONSENT
 	) {
-		await sendApplicationReceivedNotification(service, id, toSave.applicationReceivedDate);
+		await sendApplicationReceivedNotification(service, id, receivedDate);
 		toSave['applicationReceivedDateEmailSent'] = true;
 	}
 }
 
 /**
- * @param {import('#service').ManageService} service
- * @param {string} id
- * @param {import('./view-model').CrownDevelopmentSaveModel} toSave
+ * Handle turned away date updates, including notification logic
  */
-async function handleTurnedAwayDateUpdate(service, id, toSave) {
+async function handleTurnedAwayDateUpdate(service: ManageService, id: string, toSave: CrownDevelopmentSaveModel) {
 	await sendApplicationNotOfNationalImportanceNotification(service, id);
 	toSave['notNationallyImportantEmailSent'] = true;
 }
 
 /**
+ * Does the update input contain any fields that are not linked across linked cases?
  * Note that any scalar foreign keys also need their relation fields specifying (e.g. both statusId & Status)
- * @param {object} updateInput
- * @returns {boolean}
  */
-function updateContainsDeLinkedField(updateInput) {
+function updateContainsDeLinkedField(updateInput: Prisma.CrownDevelopmentUpdateInput): boolean {
 	const deLinkedFields = [
 		'id',
 		'expectedDateOfSubmission',

--- a/apps/manage/src/app/views/cases/view/view-model.test.js
+++ b/apps/manage/src/app/views/cases/view/view-model.test.js
@@ -619,10 +619,9 @@ describe('view-model', () => {
 	describe('editsToDatabaseUpdates', () => {
 		it('should map crown development fields', () => {
 			const toSave = {
-				siteArea: '8.79',
+				siteArea: 8.79,
 				environmentalStatementReceivedDate: new Date('2025-01-17T00:00Z'),
-				description: 'A big project to build something important',
-				inquiryDurationSitting: 'Sitting: 0 days'
+				description: 'A big project to build something important'
 			};
 			const updates = editsToDatabaseUpdates(toSave, {});
 			assert.ok(updates);
@@ -632,7 +631,6 @@ describe('view-model', () => {
 		});
 		it('should not map uneditable fields', () => {
 			const toSave = {
-				siteArea: '8.79',
 				environmentalStatementReceivedDate: new Date('2025-01-17T00:00Z'),
 				description: 'A big project to build something important',
 				reference: 'CASE/1',
@@ -642,14 +640,6 @@ describe('view-model', () => {
 			assert.ok(updates);
 			assert.strictEqual(updates.reference, undefined);
 			assert.strictEqual(updates.updatedDate, undefined);
-		});
-
-		it(`should map siteArea to a number`, () => {
-			const toSave = {
-				siteArea: '0.125'
-			};
-			const result = editsToDatabaseUpdates(toSave, {});
-			assert.strictEqual(result.siteArea, 0.125);
 		});
 		it(`should map siteNorthing and siteEasting to an int`, () => {
 			const toSave = {
@@ -663,7 +653,7 @@ describe('view-model', () => {
 
 		it('should not include boolean fields if not in edits', () => {
 			const toSave = {
-				siteArea: '8.79'
+				siteArea: 8.79
 			};
 			const result = editsToDatabaseUpdates(toSave, {});
 			assert.strictEqual(result.environmentalImpactAssessment, undefined);
@@ -1141,6 +1131,37 @@ describe('view-model', () => {
 			assert.strictEqual(updates.hasSecondaryLpa, false);
 			assert.deepStrictEqual(updates.SecondaryLpa, { disconnect: true });
 			assert.strictEqual(updates.secondaryLpaId, undefined); // should be removed
+		});
+		describe('decimal field normalization', () => {
+			it('should coerce empty string decimal edits to null for Prisma update input', () => {
+				const updates = editsToDatabaseUpdates(
+					{
+						siteArea: '',
+						applicationFee: '',
+						applicationFeeRefundAmount: '',
+						cilAmount: ''
+					},
+					{}
+				);
+
+				assert.strictEqual(updates.siteArea, null);
+				assert.strictEqual(updates.applicationFee, null);
+				assert.strictEqual(updates.applicationFeeRefundAmount, null);
+				assert.strictEqual(updates.cilAmount, null);
+			});
+
+			it('should keep non-empty decimal values unchanged', () => {
+				const updates = editsToDatabaseUpdates(
+					{
+						siteArea: 12.34,
+						applicationFee: 99.99
+					},
+					{}
+				);
+
+				assert.strictEqual(updates.siteArea, 12.34);
+				assert.strictEqual(updates.applicationFee, 99.99);
+			});
 		});
 	});
 });

--- a/apps/manage/src/app/views/cases/view/view-model.ts
+++ b/apps/manage/src/app/views/cases/view/view-model.ts
@@ -3,7 +3,7 @@ import {
 	APPLICATION_STAGE_ID,
 	ORGANISATION_ROLES_ID
 } from '@pins/crowndev-database/src/seed/data-static.ts';
-import { toFloat, toInt, parseNumberStringToNumber } from '@pins/crowndev-lib/util/numbers.ts';
+import { toInt, parseNumberStringToNumber } from '@pins/crowndev-lib/util/numbers.ts';
 import { booleanToYesNoValue } from '@planning-inspectorate/dynamic-forms';
 import { optionalWhere } from '@pins/crowndev-lib/util/database.js';
 import { addressToViewModel, viewModelToAddressUpdateInput } from '@pins/crowndev-lib/util/address.ts';
@@ -171,19 +171,70 @@ export interface CrownDevelopmentViewModel {
 	siteVisitDate?: Date;
 }
 
+export type CrownDevelopmentViewModelFields = keyof CrownDevelopmentViewModel;
+
+type BooleanMappedViewModelFields = {
+	[K in CrownDevelopmentViewModelFields]: NonNullable<CrownDevelopmentViewModel[K]> extends YesNo ? K : never;
+}[CrownDevelopmentViewModelFields];
+
+type DirectMappedViewModelFields = Exclude<CrownDevelopmentViewModelFields, BooleanMappedViewModelFields>;
+
+/**
+ * Fields that are included in the view model but should not be updatable when
+ * mapping edits back to the database, because they are system-generated.
+ */
+const NON_UPDATABLE_FIELDS = Object.freeze(['reference', 'updatedDate', 'SubType'] as const);
+
+/**
+ * Fields that are not optional in the database and must be included in the view model.
+ */
+const REQUIRED_FIELDS = Object.freeze([
+	'reference',
+	'description',
+	'containsDistressingContent',
+	'hasSecondaryLpa',
+	'expectedDateOfSubmission',
+	'updatedDate',
+	'hasAgent'
+] as const satisfies Readonly<CrownDevelopmentViewModelFields[]>);
+
+type SaveModelStringNumberField = (typeof INTEGER_STRING_FIELDS)[number] | DurationFieldKeys[number];
+
 /**
  * Map the view model to the answer model.
  * In the answer model:
  * - boolean fields must be true booleans (as set in dynamic-forms)
- * - number fields must be strings (as they come from the form inputs)
+ * - only multi-field question numbers are stored as strings
  * - all fields are optional and can be included in the edits object when they are edited, but do not need to be included if they are not edited
  */
-export type CrownDevelopmentSaveModel = Partial<{
+type CrownDevelopmentSaveValueMap = {
 	[K in keyof CrownDevelopmentViewModel]: NonNullable<CrownDevelopmentViewModel[K]> extends YesNo
 		? boolean | (undefined extends CrownDevelopmentViewModel[K] ? undefined : never)
-		: NonNullable<CrownDevelopmentViewModel[K]> extends number
+		: K extends SaveModelStringNumberField
 			? string | (undefined extends CrownDevelopmentViewModel[K] ? undefined : never)
 			: CrownDevelopmentViewModel[K];
+};
+
+type PrismaNullableUpdateKey = {
+	[K in keyof Prisma.CrownDevelopmentUpdateInput]-?: null extends Prisma.CrownDevelopmentUpdateInput[K] ? K : never;
+}[keyof Prisma.CrownDevelopmentUpdateInput];
+
+type NonUpdatableField = (typeof NON_UPDATABLE_FIELDS)[number];
+type RequiredField = (typeof REQUIRED_FIELDS)[number];
+
+type NullableScalarClearableKey = Exclude<
+	Extract<keyof CrownDevelopmentSaveValueMap, PrismaNullableUpdateKey>,
+	NonUpdatableField | RequiredField
+>;
+
+type RelationIdClearableKey = Extract<keyof CrownDevelopmentSaveValueMap, (typeof RELATION_ID_FIELDS)[number]>;
+
+export type CrownDevelopmentClearableKey = NullableScalarClearableKey | RelationIdClearableKey;
+
+export type CrownDevelopmentSaveModel = Partial<{
+	[K in keyof CrownDevelopmentSaveValueMap]: K extends CrownDevelopmentClearableKey
+		? CrownDevelopmentSaveValueMap[K] | null
+		: CrownDevelopmentSaveValueMap[K];
 }>;
 
 export interface ManageApplicantDetails {
@@ -215,36 +266,9 @@ export interface QuestionOverrides {
 	isQuestionView: boolean;
 }
 
-export type CrownDevelopmentViewModelFields = keyof CrownDevelopmentViewModel;
-
-type BooleanMappedViewModelFields = {
-	[K in CrownDevelopmentViewModelFields]: NonNullable<CrownDevelopmentViewModel[K]> extends YesNo ? K : never;
-}[CrownDevelopmentViewModelFields];
-
-type DirectMappedViewModelFields = Exclude<CrownDevelopmentViewModelFields, BooleanMappedViewModelFields>;
-
 type DecimalMappedViewModelFields = (typeof DECIMAL_FIELDS)[number];
 
 type NullableDirectMappedViewModelFields = Exclude<DirectMappedViewModelFields, DecimalMappedViewModelFields>;
-
-/**
- * Fields that are included in the view model but should not be updatable when
- * mapping edits back to the database, because they are system-generated.
- */
-const NON_UPDATABLE_FIELDS = Object.freeze(['reference', 'updatedDate', 'SubType'] as const);
-
-/**
- * Fields that are not optional in the database and must be included in the view model.
- */
-const REQUIRED_FIELDS = Object.freeze([
-	'reference',
-	'description',
-	'containsDistressingContent',
-	'hasSecondaryLpa',
-	'expectedDateOfSubmission',
-	'updatedDate',
-	'hasAgent'
-] as const satisfies Readonly<CrownDevelopmentViewModelFields[]>);
 
 type BooleanPayloadField = BooleanMappedViewModelFields & keyof CrownDevelopmentPayload;
 
@@ -286,11 +310,30 @@ const DECIMAL_FIELDS = Object.freeze([
 ] as const);
 
 /**
+ * Numerical duration fields that are custom mapped in viewModelToEventUpdateInput.
+ * These float fields are in the SaveModel as strings because they are in a multi-field input.
+ */
+type DurationFieldKeys = Readonly<
+	[
+		'hearingDurationPrep',
+		'hearingDurationSitting',
+		'hearingDurationReporting',
+		'inquiryDurationPrep',
+		'inquiryDurationSitting',
+		'inquiryDurationReporting'
+	]
+>;
+
+/**
+ * These integer fields are in the SaveModel as strings because they are in a multi-field input.
+ * TODO update multi-field input to allow number fields CROWN-1620
+ */
+const INTEGER_STRING_FIELDS = Object.freeze(['siteNorthing', 'siteEasting'] as const);
+
+/**
  * Fields that do not need mapping to (or from) the view model
  */
 const DIRECT_UNMAPPED_FIELDS = Object.freeze([
-	'siteNorthing',
-	'siteEasting',
 	'lpaReference',
 	'nationallyImportantConfirmationDate',
 	'healthAndSafetyIssue',
@@ -344,7 +387,18 @@ const RELATION_ID_FIELDS = Object.freeze([
 	'eventId'
 ] as const satisfies Readonly<NullableDirectMappedViewModelFields[]>);
 
-type DirectUnmappedField = (typeof DIRECT_UNMAPPED_FIELDS)[number] | (typeof RELATION_ID_FIELDS)[number];
+export const CLEARABLE_SAVE_KEYS = Object.freeze([
+	...BOOLEAN_FIELDS,
+	...DECIMAL_FIELDS,
+	...INTEGER_STRING_FIELDS,
+	...DIRECT_UNMAPPED_FIELDS,
+	...RELATION_ID_FIELDS
+] as const satisfies ReadonlyArray<CrownDevelopmentClearableKey>);
+
+type DirectUnmappedField =
+	| (typeof DIRECT_UNMAPPED_FIELDS)[number]
+	| (typeof RELATION_ID_FIELDS)[number]
+	| (typeof INTEGER_STRING_FIELDS)[number];
 
 /**
  * Field prefixes used for the contact fields in the view model
@@ -391,7 +445,7 @@ export function crownDevelopmentToViewModel(crownDevelopment: CrownDevelopmentPa
 	}
 
 	// Directly assign fields that have the same type in the database and view model
-	for (const field of [...RELATION_ID_FIELDS, ...DIRECT_UNMAPPED_FIELDS]) {
+	for (const field of [...RELATION_ID_FIELDS, ...DIRECT_UNMAPPED_FIELDS, ...INTEGER_STRING_FIELDS]) {
 		assignNullableDirectField(viewModel, crownDevelopment, field);
 	}
 
@@ -505,27 +559,34 @@ export function crownDevelopmentToViewModel(crownDevelopment: CrownDevelopmentPa
 }
 
 /**
- * Convert Decimal database fields to floats in view model.
+ * Number fields that are not stored as numbers in CrownDevelopmentSaveModel
  */
-function assignDecimalUpdates(edits: CrownDevelopmentSaveModel, updates: Prisma.CrownDevelopmentUpdateInput) {
-	for (const field of DECIMAL_FIELDS) {
-		if (Object.hasOwn(edits, field) && edits[field] !== undefined) {
-			updates[field] = toFloat(edits[field]);
-		}
-	}
-}
+type NumericCoercedField = (typeof INTEGER_STRING_FIELDS)[number] | DurationFieldKeys[number];
 
-type DirectUpdateField = keyof CrownDevelopmentSaveModel & keyof Prisma.CrownDevelopmentUpdateInput;
+type DirectUpdateField = Exclude<
+	keyof CrownDevelopmentSaveModel & keyof Prisma.CrownDevelopmentUpdateInput,
+	NumericCoercedField | NonUpdatableField
+>;
+
+type DirectUpdateFields = (typeof DIRECT_UPDATE_FIELDS)[number];
+
+type DirectUpdateEdits = Pick<CrownDevelopmentSaveModel, DirectUpdateFields>;
+
+type DirectUpdateUpdates = Pick<Prisma.CrownDevelopmentUpdateInput, DirectUpdateFields>;
 
 const DIRECT_UPDATE_FIELDS: ReadonlyArray<DirectUpdateField> = Object.freeze([
-	...REQUIRED_FIELDS,
+	...REQUIRED_FIELDS.filter(
+		(field): field is Exclude<RequiredField, NonUpdatableField> =>
+			!NON_UPDATABLE_FIELDS.includes(field as NonUpdatableField)
+	),
 	...BOOLEAN_FIELDS,
-	...DIRECT_UNMAPPED_FIELDS
+	...DIRECT_UNMAPPED_FIELDS,
+	...DECIMAL_FIELDS
 ]);
 
 function assignDirectUpdate<K extends DirectUpdateField>(
-	updates: Prisma.CrownDevelopmentUpdateInput,
-	edits: CrownDevelopmentSaveModel,
+	updates: DirectUpdateUpdates,
+	edits: DirectUpdateEdits,
 	field: K
 ) {
 	if (Object.hasOwn(edits, field)) {
@@ -561,13 +622,18 @@ export function editsToDatabaseUpdates(
 		delete crownDevelopmentUpdateInput[field];
 	});
 
-	// set number fields
+	// Coerce empty strings to null for decimal fields – Prisma cannot parse "" as Decimal
+	for (const field of DECIMAL_FIELDS) {
+		if (field in crownDevelopmentUpdateInput && crownDevelopmentUpdateInput[field] === '') {
+			crownDevelopmentUpdateInput[field] = null;
+		}
+	}
+
+	// set number-as-string fields
 	if ('siteNorthing' in edits || 'siteEasting' in edits) {
 		crownDevelopmentUpdateInput.siteNorthing = edits.siteNorthing ? toInt(edits.siteNorthing) : null;
 		crownDevelopmentUpdateInput.siteEasting = edits.siteEasting ? toInt(edits.siteEasting) : null;
 	}
-
-	assignDecimalUpdates(edits, crownDevelopmentUpdateInput);
 
 	if (edits.representationsPeriod) {
 		crownDevelopmentUpdateInput.representationsPeriodStartDate = edits.representationsPeriod.start;


### PR DESCRIPTION
## Describe your changes
Convert `update-case` to typescript.

I've made some updates in how numbers are handled in `CrownDevelopmentSaveModel`. Essentially if a `number` question is used, these are `number` in both schemas. But some of our number fields use `multi-field-input` (e.g. site coordinates), which retains them as `string` in the save model. Therefore I've:
- separated out these fields so only they are `number` in the view model and `string` in the save model
- removed redundant number conversion for application fee field that is already a number
- added [a ticket to the backlog](https://pins-ds.atlassian.net/browse/CROWN-1620) for improving the multi-field input so these can be treated as the number fields they are.

Clearing data now also has an extra check to make sure that required fields are not clearable (a double-check, since these should also be required questions).

## Issue ticket number and link
N/A
