### PR TITLE
feat(manage): delete agent org and contacts when hasAgent changes to no

### DIFF
--- a/apps/manage/src/app/views/cases/view/linked-case-updates.test.ts
+++ b/apps/manage/src/app/views/cases/view/linked-case-updates.test.ts
@@ -1123,9 +1123,29 @@ describe('organisation/contact updates', () => {
 					role: ORGANISATION_ROLES_ID.AGENT
 				}
 			});
-			assert.deepStrictEqual(calls.contactDeleteMany, [{ where: { id: { in: ['contact-1'] } } }]);
-			assert.deepStrictEqual(calls.organisationDeleteMany, [{ where: { id: { in: ['agent-org-1'] } } }]);
-			assert.deepStrictEqual(calls.addressDeleteMany, [{ where: { id: { in: ['agent-address-1'] } } }]);
+			assert.deepStrictEqual(calls.contactDeleteMany, [
+				{ where: { OrganisationToContact: { none: {} }, id: { in: ['contact-1'] } } }
+			]);
+			assert.deepStrictEqual(calls.organisationDeleteMany, [
+				{
+					where: {
+						CrownDevelopmentToOrganisation: { none: {} },
+						OrganisationToContact: { none: {} },
+						id: { in: ['agent-org-1'] }
+					}
+				}
+			]);
+			assert.deepStrictEqual(calls.addressDeleteMany, [
+				{
+					where: {
+						Contact: { none: {} },
+						CrownDevelopment: { none: {} },
+						Lpa: { none: {} },
+						Organisation: { none: {} },
+						id: { in: ['agent-address-1'] }
+					}
+				}
+			]);
 		});
 
 		it('should resolve created organisation placeholder ids for links and organisation contacts', async () => {

--- a/apps/manage/src/app/views/cases/view/linked-case-updates.test.ts
+++ b/apps/manage/src/app/views/cases/view/linked-case-updates.test.ts
@@ -645,6 +645,46 @@ describe('organisation/contact updates', () => {
 	});
 
 	describe('buildCaseUpdateWritePlan (happy paths)', () => {
+		it('should queue nested agent organisation contact deletes and link deletes when hasAgent changes from yes to no', () => {
+			const plan = buildCaseUpdateWritePlan({
+				toSave: { hasAgent: false },
+				dbViewModel: { hasAgent: 'yes' },
+				caseIds: ['case-1', 'case-2'],
+				scalarUpdateInput: { hasAgent: false },
+				crownDevelopments: [
+					{
+						id: 'case-1',
+						Organisations: [
+							{
+								id: 'rel-agent-1',
+								role: ORGANISATION_ROLES_ID.AGENT,
+								organisationId: 'agent-org-1',
+								Organisation: {
+									id: 'agent-org-1',
+									OrganisationToContact: [
+										{ id: 'join-1', contactId: 'contact-1' },
+										{ id: 'join-2', contactId: 'contact-2' }
+									]
+								}
+							}
+						]
+					}
+				]
+			});
+
+			assert.strictEqual(plan.organisationGraph.organisationUpdates.length, 0);
+			assert.deepStrictEqual(plan.organisationGraph.organisationToContactDeletes, [{ id: 'join-1' }, { id: 'join-2' }]);
+			assert.deepStrictEqual(plan.organisationGraph.agentLinkDeleteMany, [
+				{ caseIds: ['case-1', 'case-2'], roleId: ORGANISATION_ROLES_ID.AGENT, organisationId: 'agent-org-1' }
+			]);
+			assert.deepStrictEqual(plan.organisationGraph.agentContactDeleteMany, [
+				{ contactIds: ['contact-1', 'contact-2'] }
+			]);
+			assert.deepStrictEqual(plan.organisationGraph.agentOrganisationDeleteMany, [
+				{ organisationIds: ['agent-org-1'] }
+			]);
+		});
+
 		it('should include address create when creating a new agent organisation', () => {
 			const plan = buildCaseUpdateWritePlan({
 				toSave: {
@@ -1003,6 +1043,83 @@ describe('organisation/contact updates', () => {
 	});
 
 	describe('executeCaseUpdateWritePlan', () => {
+		it('should delete agent org contact joins, then case-to-org links, contacts, and organisations', async () => {
+			const plan = {
+				scalarCaseUpdates: { caseIds: ['case-1'], updateInput: { hasAgent: false } },
+				organisationGraph: {
+					organisationCreates: [],
+					organisationUpdates: [],
+					linkCreates: [],
+					contactUpdates: [],
+					newOrganisationContacts: [],
+					organisationToContactDeletes: [{ id: 'join-1' }],
+					organisationToContactCreates: [],
+					agentLinkDeleteMany: [
+						{ caseIds: ['case-1'], roleId: ORGANISATION_ROLES_ID.AGENT, organisationId: 'agent-org-1' }
+					],
+					agentContactDeleteMany: [{ contactIds: ['contact-1'] }],
+					agentOrganisationDeleteMany: [{ organisationIds: ['agent-org-1'] }]
+				}
+			};
+
+			const calls = {
+				orgToContactDelete: [],
+				linkDeleteMany: [],
+				contactDeleteMany: [],
+				organisationDeleteMany: []
+			};
+
+			const tx = {
+				organisation: {
+					create: async () => {
+						throw new Error('not expected');
+					},
+					update: async () => {
+						throw new Error('not expected');
+					},
+					deleteMany: async (args) => calls.organisationDeleteMany.push(args)
+				},
+				crownDevelopmentToOrganisation: {
+					create: async () => {
+						throw new Error('not expected');
+					},
+					deleteMany: async (args) => calls.linkDeleteMany.push(args)
+				},
+				contact: {
+					update: async () => {
+						throw new Error('not expected');
+					},
+					create: async () => {
+						throw new Error('not expected');
+					},
+					deleteMany: async (args) => calls.contactDeleteMany.push(args)
+				},
+				organisationToContact: {
+					delete: async (args) => calls.orgToContactDelete.push(args),
+					create: async () => {
+						throw new Error('not expected');
+					}
+				},
+				crownDevelopment: {
+					update: async () => ({})
+				}
+			};
+
+			await executeCaseUpdateWritePlan(plan, tx);
+
+			assert.deepStrictEqual(calls.orgToContactDelete, [{ where: { id: 'join-1' } }]);
+			assert.strictEqual(calls.linkDeleteMany.length, 1);
+			assert.deepStrictEqual(calls.linkDeleteMany[0], {
+				where: {
+					crownDevelopmentId: { in: ['case-1'] },
+					organisationId: 'agent-org-1',
+					role: ORGANISATION_ROLES_ID.AGENT
+				}
+			});
+			assert.deepStrictEqual(calls.contactDeleteMany, [{ where: { id: { in: ['contact-1'] } } }]);
+			assert.deepStrictEqual(calls.organisationDeleteMany, [{ where: { id: { in: ['agent-org-1'] } } }]);
+		});
+
 		it('should resolve created organisation placeholder ids for links and organisation contacts', async () => {
 			const plan = {
 				scalarCaseUpdates: { caseIds: ['case-1', 'case-2'], updateInput: { description: 'updated' } },

--- a/apps/manage/src/app/views/cases/view/linked-case-updates.test.ts
+++ b/apps/manage/src/app/views/cases/view/linked-case-updates.test.ts
@@ -661,6 +661,7 @@ describe('organisation/contact updates', () => {
 								organisationId: 'agent-org-1',
 								Organisation: {
 									id: 'agent-org-1',
+									addressId: 'agent-address-1',
 									OrganisationToContact: [
 										{ id: 'join-1', contactId: 'contact-1' },
 										{ id: 'join-2', contactId: 'contact-2' }
@@ -683,6 +684,7 @@ describe('organisation/contact updates', () => {
 			assert.deepStrictEqual(plan.organisationGraph.agentOrganisationDeleteMany, [
 				{ organisationIds: ['agent-org-1'] }
 			]);
+			assert.deepStrictEqual(plan.organisationGraph.agentAddressDeleteMany, [{ addressIds: ['agent-address-1'] }]);
 		});
 
 		it('should include address create when creating a new agent organisation', () => {
@@ -1043,7 +1045,7 @@ describe('organisation/contact updates', () => {
 	});
 
 	describe('executeCaseUpdateWritePlan', () => {
-		it('should delete agent org contact joins, then case-to-org links, contacts, and organisations', async () => {
+		it('should delete agent org contact joins, then case-to-org links, contacts, organisations, and addresses', async () => {
 			const plan = {
 				scalarCaseUpdates: { caseIds: ['case-1'], updateInput: { hasAgent: false } },
 				organisationGraph: {
@@ -1058,7 +1060,8 @@ describe('organisation/contact updates', () => {
 						{ caseIds: ['case-1'], roleId: ORGANISATION_ROLES_ID.AGENT, organisationId: 'agent-org-1' }
 					],
 					agentContactDeleteMany: [{ contactIds: ['contact-1'] }],
-					agentOrganisationDeleteMany: [{ organisationIds: ['agent-org-1'] }]
+					agentOrganisationDeleteMany: [{ organisationIds: ['agent-org-1'] }],
+					agentAddressDeleteMany: [{ addressIds: ['agent-address-1'] }]
 				}
 			};
 
@@ -1066,10 +1069,14 @@ describe('organisation/contact updates', () => {
 				orgToContactDelete: [],
 				linkDeleteMany: [],
 				contactDeleteMany: [],
-				organisationDeleteMany: []
+				organisationDeleteMany: [],
+				addressDeleteMany: []
 			};
 
 			const tx = {
+				address: {
+					deleteMany: async (args) => calls.addressDeleteMany.push(args)
+				},
 				organisation: {
 					create: async () => {
 						throw new Error('not expected');
@@ -1118,6 +1125,7 @@ describe('organisation/contact updates', () => {
 			});
 			assert.deepStrictEqual(calls.contactDeleteMany, [{ where: { id: { in: ['contact-1'] } } }]);
 			assert.deepStrictEqual(calls.organisationDeleteMany, [{ where: { id: { in: ['agent-org-1'] } } }]);
+			assert.deepStrictEqual(calls.addressDeleteMany, [{ where: { id: { in: ['agent-address-1'] } } }]);
 		});
 
 		it('should resolve created organisation placeholder ids for links and organisation contacts', async () => {

--- a/apps/manage/src/app/views/cases/view/linked-case-updates.ts
+++ b/apps/manage/src/app/views/cases/view/linked-case-updates.ts
@@ -27,6 +27,9 @@ type CaseUpdateWritePlan = {
 		newOrganisationContacts: Array<{ organisationId: string; data: Prisma.ContactCreateInput }>;
 		organisationToContactDeletes: Array<{ id: string }>;
 		organisationToContactCreates: Array<{ organisationId: string; contactId: string }>;
+		agentLinkDeleteMany?: Array<{ caseIds: string[]; roleId: string; organisationId: string }>;
+		agentContactDeleteMany?: Array<{ contactIds: string[] }>;
+		agentOrganisationDeleteMany?: Array<{ organisationIds: string[] }>;
 	};
 };
 
@@ -413,6 +416,46 @@ export function buildCaseUpdateWritePlan({
 		}
 	}
 
+	// When hasAgent is set from yes to no, remove all agent joins, case links, contacts, and organisations.
+	if (toSave.hasAgent === false && dbViewModel.hasAgent === 'yes') {
+		const allRelationships = crownDevelopments.flatMap((crownDevelopment) => crownDevelopment?.Organisations || []);
+		const agentRelationships = allRelationships.filter(
+			(relationship) => relationship.role === ORGANISATION_ROLES_ID.AGENT && relationship.organisationId
+		);
+
+		const agentOrganisationIds = new Set<string>();
+		const agentContactIds = new Set<string>();
+		const agentJoinIdsAdded = new Set<string>();
+
+		for (const relationship of agentRelationships) {
+			agentOrganisationIds.add(relationship.organisationId);
+
+			for (const join of relationship?.Organisation?.OrganisationToContact || []) {
+				if (join.id && !agentJoinIdsAdded.has(join.id)) {
+					agentJoinIdsAdded.add(join.id);
+					plan.organisationGraph.organisationToContactDeletes.push({ id: join.id });
+				}
+				if (join.contactId) {
+					agentContactIds.add(join.contactId);
+				}
+			}
+		}
+
+		// Queue deletion of CrownDevelopmentToOrganisation links for all cases
+		plan.organisationGraph.agentLinkDeleteMany = Array.from(agentOrganisationIds).map((organisationId) => ({
+			caseIds,
+			roleId: ORGANISATION_ROLES_ID.AGENT,
+			organisationId
+		}));
+
+		if (agentContactIds.size > 0) {
+			plan.organisationGraph.agentContactDeleteMany = [{ contactIds: Array.from(agentContactIds) }];
+		}
+		if (agentOrganisationIds.size > 0) {
+			plan.organisationGraph.agentOrganisationDeleteMany = [{ organisationIds: Array.from(agentOrganisationIds) }];
+		}
+	}
+
 	return plan;
 }
 
@@ -464,6 +507,25 @@ export async function executeCaseUpdateWritePlan(plan: CaseUpdateWritePlan, tx: 
 
 	for (const del of plan.organisationGraph.organisationToContactDeletes) {
 		await tx.organisationToContact.delete({ where: { id: del.id } });
+	}
+	for (const deleteManyLinks of plan.organisationGraph.agentLinkDeleteMany || []) {
+		await tx.crownDevelopmentToOrganisation.deleteMany({
+			where: {
+				crownDevelopmentId: { in: deleteManyLinks.caseIds },
+				organisationId: resolveOrgId(deleteManyLinks.organisationId),
+				role: deleteManyLinks.roleId
+			}
+		});
+	}
+	for (const deleteManyContacts of plan.organisationGraph.agentContactDeleteMany || []) {
+		await tx.contact.deleteMany({
+			where: { id: { in: deleteManyContacts.contactIds } }
+		});
+	}
+	for (const deleteManyOrgs of plan.organisationGraph.agentOrganisationDeleteMany || []) {
+		await tx.organisation.deleteMany({
+			where: { id: { in: deleteManyOrgs.organisationIds.map(resolveOrgId) } }
+		});
 	}
 	for (const create of plan.organisationGraph.organisationToContactCreates) {
 		await tx.organisationToContact.create({

--- a/apps/manage/src/app/views/cases/view/linked-case-updates.ts
+++ b/apps/manage/src/app/views/cases/view/linked-case-updates.ts
@@ -30,6 +30,7 @@ type CaseUpdateWritePlan = {
 		agentLinkDeleteMany?: Array<{ caseIds: string[]; roleId: string; organisationId: string }>;
 		agentContactDeleteMany?: Array<{ contactIds: string[] }>;
 		agentOrganisationDeleteMany?: Array<{ organisationIds: string[] }>;
+		agentAddressDeleteMany?: Array<{ addressIds: string[] }>;
 	};
 };
 
@@ -425,18 +426,24 @@ export function buildCaseUpdateWritePlan({
 
 		const agentOrganisationIds = new Set<string>();
 		const agentContactIds = new Set<string>();
+		const agentAddressIds = new Set<string>();
 		const agentJoinIdsAdded = new Set<string>();
 
 		for (const relationship of agentRelationships) {
 			agentOrganisationIds.add(relationship.organisationId);
+			const addressId = relationship?.Organisation?.addressId ?? relationship?.Organisation?.Address?.id;
+			if (addressId) {
+				agentAddressIds.add(addressId);
+			}
 
 			for (const join of relationship?.Organisation?.OrganisationToContact || []) {
 				if (join.id && !agentJoinIdsAdded.has(join.id)) {
 					agentJoinIdsAdded.add(join.id);
 					plan.organisationGraph.organisationToContactDeletes.push({ id: join.id });
 				}
-				if (join.contactId) {
-					agentContactIds.add(join.contactId);
+				const contactId = join.contactId ?? join?.Contact?.id;
+				if (contactId) {
+					agentContactIds.add(contactId);
 				}
 			}
 		}
@@ -453,6 +460,9 @@ export function buildCaseUpdateWritePlan({
 		}
 		if (agentOrganisationIds.size > 0) {
 			plan.organisationGraph.agentOrganisationDeleteMany = [{ organisationIds: Array.from(agentOrganisationIds) }];
+		}
+		if (agentAddressIds.size > 0) {
+			plan.organisationGraph.agentAddressDeleteMany = [{ addressIds: Array.from(agentAddressIds) }];
 		}
 	}
 
@@ -525,6 +535,11 @@ export async function executeCaseUpdateWritePlan(plan: CaseUpdateWritePlan, tx: 
 	for (const deleteManyOrgs of plan.organisationGraph.agentOrganisationDeleteMany || []) {
 		await tx.organisation.deleteMany({
 			where: { id: { in: deleteManyOrgs.organisationIds.map(resolveOrgId) } }
+		});
+	}
+	for (const deleteManyAddresses of plan.organisationGraph.agentAddressDeleteMany || []) {
+		await tx.address.deleteMany({
+			where: { id: { in: deleteManyAddresses.addressIds } }
 		});
 	}
 	for (const create of plan.organisationGraph.organisationToContactCreates) {

--- a/apps/manage/src/app/views/cases/view/linked-case-updates.ts
+++ b/apps/manage/src/app/views/cases/view/linked-case-updates.ts
@@ -3,6 +3,7 @@ import { optionalWhere } from '@pins/crowndev-lib/util/database.js';
 import { viewModelToAddressUpdateInput, isAddress, isSameAddress } from '@pins/crowndev-lib/util/address.ts';
 import { extractApplicantContactFields, extractAgentContactFields } from '../util/contact.js';
 import { isDefined } from '@pins/crowndev-lib/util/boolean.js';
+import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms';
 import type {
 	CrownDevelopmentViewModel,
 	CrownDevelopmentSaveModel,
@@ -418,7 +419,7 @@ export function buildCaseUpdateWritePlan({
 	}
 
 	// When hasAgent is set from yes to no, remove all agent joins, case links, contacts, and organisations.
-	if (toSave.hasAgent === false && dbViewModel.hasAgent === 'yes') {
+	if (toSave.hasAgent === false && dbViewModel.hasAgent === BOOLEAN_OPTIONS.YES) {
 		const allRelationships = crownDevelopments.flatMap((crownDevelopment) => crownDevelopment?.Organisations || []);
 		const agentRelationships = allRelationships.filter(
 			(relationship) => relationship.role === ORGANISATION_ROLES_ID.AGENT && relationship.organisationId
@@ -529,17 +530,27 @@ export async function executeCaseUpdateWritePlan(plan: CaseUpdateWritePlan, tx: 
 	}
 	for (const deleteManyContacts of plan.organisationGraph.agentContactDeleteMany || []) {
 		await tx.contact.deleteMany({
-			where: { id: { in: deleteManyContacts.contactIds } }
+			where: { id: { in: deleteManyContacts.contactIds }, OrganisationToContact: { none: {} } }
 		});
 	}
 	for (const deleteManyOrgs of plan.organisationGraph.agentOrganisationDeleteMany || []) {
 		await tx.organisation.deleteMany({
-			where: { id: { in: deleteManyOrgs.organisationIds.map(resolveOrgId) } }
+			where: {
+				id: { in: deleteManyOrgs.organisationIds.map(resolveOrgId) },
+				CrownDevelopmentToOrganisation: { none: {} },
+				OrganisationToContact: { none: {} }
+			}
 		});
 	}
 	for (const deleteManyAddresses of plan.organisationGraph.agentAddressDeleteMany || []) {
 		await tx.address.deleteMany({
-			where: { id: { in: deleteManyAddresses.addressIds } }
+			where: {
+				id: { in: deleteManyAddresses.addressIds },
+				Organisation: { none: {} },
+				Contact: { none: {} },
+				CrownDevelopment: { none: {} },
+				Lpa: { none: {} }
+			}
 		});
 	}
 	for (const create of plan.organisationGraph.organisationToContactCreates) {

--- a/apps/manage/src/app/views/cases/view/update-case.js
+++ b/apps/manage/src/app/views/cases/view/update-case.js
@@ -94,7 +94,8 @@ export function buildUpdateCase(service, clearAnswer = false) {
 				}
 
 				let crownDevelopmentsForPlanning = [crownDevelopment];
-				if (hasOrganisationWriteEdits(toSave) && caseIds.length > 1) {
+				const shouldDeleteAgentData = toSave.hasAgent === false && dbViewModel.hasAgent === BOOLEAN_OPTIONS.YES;
+				if ((hasOrganisationWriteEdits(toSave) || shouldDeleteAgentData) && caseIds.length > 1) {
 					crownDevelopmentsForPlanning = await tx.crownDevelopment.findMany({
 						where: { id: { in: caseIds } },
 						include: {

--- a/apps/manage/src/app/views/cases/view/update-case.test.js
+++ b/apps/manage/src/app/views/cases/view/update-case.test.js
@@ -1590,13 +1590,18 @@ describe('case details', () => {
 			const logger = mockLogger();
 			const mockDb = {
 				$transaction: mock.fn(() => Promise.resolve()),
+				address: {
+					deleteMany: mock.fn(() => ({ count: 1 }))
+				},
 				organisation: {
 					create: mock.fn(() => ({ id: 'org-created' })),
-					update: mock.fn(() => ({ kind: 'organisation.update' }))
+					update: mock.fn(() => ({ kind: 'organisation.update' })),
+					deleteMany: mock.fn(() => ({ count: 1 }))
 				},
 				contact: {
 					update: mock.fn(() => ({ kind: 'contact.update' })),
-					create: mock.fn(() => ({ id: 'created-contact-id' }))
+					create: mock.fn(() => ({ id: 'created-contact-id' })),
+					deleteMany: mock.fn(() => ({ count: 1 }))
 				},
 				organisationToContact: {
 					create: mock.fn(() => ({ id: 'created-join-id' })),
@@ -1619,6 +1624,7 @@ describe('case details', () => {
 								organisationId: 'agent-org-1',
 								Organisation: {
 									id: 'agent-org-1',
+									addressId: 'agent-address-1',
 									OrganisationToContact: [{ id: 'join-1', Contact: { id: 'contact-1' } }]
 								}
 							}
@@ -1634,6 +1640,7 @@ describe('case details', () => {
 									organisationId: 'agent-org-1',
 									Organisation: {
 										id: 'agent-org-1',
+										addressId: 'agent-address-1',
 										OrganisationToContact: [{ id: 'join-1', Contact: { id: 'contact-1' } }]
 									}
 								}
@@ -1667,8 +1674,10 @@ describe('case details', () => {
 			});
 
 			assert.strictEqual(mockDb.crownDevelopment.findMany.mock.callCount(), 1);
-			assert.strictEqual(mockDb.organisation.update.mock.callCount(), 1);
 			assert.strictEqual(mockDb.crownDevelopmentToOrganisation.deleteMany.mock.callCount(), 1);
+			assert.strictEqual(mockDb.contact.deleteMany.mock.callCount(), 1);
+			assert.strictEqual(mockDb.organisation.deleteMany.mock.callCount(), 1);
+			assert.strictEqual(mockDb.address.deleteMany.mock.callCount(), 1);
 		});
 	});
 

--- a/apps/manage/src/app/views/cases/view/update-case.test.js
+++ b/apps/manage/src/app/views/cases/view/update-case.test.js
@@ -1585,6 +1585,91 @@ describe('case details', () => {
 				assert.strictEqual(d.role, ORGANISATION_ROLES_ID.AGENT);
 			});
 		});
+
+		it('should delete agent contacts and organisation when hasAgent is changed from yes to no', async () => {
+			const logger = mockLogger();
+			const mockDb = {
+				$transaction: mock.fn(() => Promise.resolve()),
+				organisation: {
+					create: mock.fn(() => ({ id: 'org-created' })),
+					update: mock.fn(() => ({ kind: 'organisation.update' }))
+				},
+				contact: {
+					update: mock.fn(() => ({ kind: 'contact.update' })),
+					create: mock.fn(() => ({ id: 'created-contact-id' }))
+				},
+				organisationToContact: {
+					create: mock.fn(() => ({ id: 'created-join-id' })),
+					delete: mock.fn(() => ({ id: 'deleted-join-id' }))
+				},
+				crownDevelopmentToOrganisation: {
+					create: mock.fn((args) => args),
+					deleteMany: mock.fn(() => ({ count: 2 }))
+				},
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: 'case-1',
+						hasAgent: true,
+						linkedParentId: 'parent-case-1',
+						ChildrenCrownDevelopment: [],
+						Organisations: [
+							{
+								id: 'rel-agent-1',
+								role: ORGANISATION_ROLES_ID.AGENT,
+								organisationId: 'agent-org-1',
+								Organisation: {
+									id: 'agent-org-1',
+									OrganisationToContact: [{ id: 'join-1', Contact: { id: 'contact-1' } }]
+								}
+							}
+						]
+					})),
+					findMany: mock.fn(() => [
+						{
+							id: 'case-1',
+							Organisations: [
+								{
+									id: 'rel-agent-1',
+									role: ORGANISATION_ROLES_ID.AGENT,
+									organisationId: 'agent-org-1',
+									Organisation: {
+										id: 'agent-org-1',
+										OrganisationToContact: [{ id: 'join-1', Contact: { id: 'contact-1' } }]
+									}
+								}
+							]
+						},
+						{
+							id: 'parent-case-1',
+							Organisations: [
+								{
+									id: 'rel-agent-2',
+									role: ORGANISATION_ROLES_ID.AGENT,
+									organisationId: 'agent-org-1',
+									Organisation: {
+										id: 'agent-org-1',
+										OrganisationToContact: [{ id: 'join-1', Contact: { id: 'contact-1' } }]
+									}
+								}
+							]
+						}
+					]),
+					update: mock.fn(() => ({ kind: 'crownDevelopment.update' }))
+				}
+			};
+			makeTransactionInteractive(mockDb);
+
+			const updateCase = buildUpdateCase({ db: mockDb, logger, notifyClient: {} });
+			await updateCase({
+				req: { params: { id: 'case-1' }, session: {} },
+				res: { locals: {} },
+				data: { answers: { hasAgent: false } }
+			});
+
+			assert.strictEqual(mockDb.crownDevelopment.findMany.mock.callCount(), 1);
+			assert.strictEqual(mockDb.organisation.update.mock.callCount(), 1);
+			assert.strictEqual(mockDb.crownDevelopmentToOrganisation.deleteMany.mock.callCount(), 1);
+		});
 	});
 
 	describe('multi applicant contact updates', () => {


### PR DESCRIPTION
## Describe your changes
Handle deletion of organisations, contacts and addresses when `hasAgent` is changed from yes to no:

* Update `buildCaseUpdateWritePlan` in `linked-case-updates.ts` to detect when `hasAgent` changes from "yes" to "no" and queue deletions for all related agent organisations, contacts, addresses, and links across all relevant cases.
* Extend the `CaseUpdateWritePlan` type to include new fields for bulk deletion of agent links, contacts, organisations, and addresses.
* Extend `executeCaseUpdateWritePlan` to process and execute the new bulk deletion instructions for agent data.
* Add tests for the above

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1564
Before deletion: agent details containing "1325" exist in DB tables:
<img width="967" height="265" alt="Screenshot 2026-06-02 132610" src="https://github.com/user-attachments/assets/d3bd3ca9-2f9a-4194-803c-ecbad1f1c4c0" />
<img width="1108" height="279" alt="Screenshot 2026-06-02 132650" src="https://github.com/user-attachments/assets/27a71520-943a-4320-ab3a-a5a876179c71" />
<img width="1120" height="249" alt="Screenshot 2026-06-02 132658" src="https://github.com/user-attachments/assets/b6d45efb-4016-4fe6-9d86-7b6cef939457" />
<img width="1122" height="248" alt="Screenshot 2026-06-02 132705" src="https://github.com/user-attachments/assets/88d99b25-21b6-4c51-bd3a-6b30def7d063" />
After deletion: these DB entries have all been removed:
<img width="1105" height="230" alt="Screenshot 2026-06-02 132727" src="https://github.com/user-attachments/assets/47052f77-acb4-4148-817c-3b20fc617007" />
<img width="1115" height="239" alt="Screenshot 2026-06-02 132732" src="https://github.com/user-attachments/assets/9375c816-0ad3-4875-b5c3-93c99e37fda8" />
<img width="1103" height="243" alt="Screenshot 2026-06-02 132738" src="https://github.com/user-attachments/assets/868be9e8-0d1d-4990-92d9-04cc0e30adfe" />
And when setting `hasAgent` back to yes, the old data does not persist:
<img width="977" height="143" alt="Screenshot 2026-06-02 132758" src="https://github.com/user-attachments/assets/1f6711cd-33d4-4609-9d4b-97ec0592a3bd" />
