### PR TITLE
feat(manage): add anchor link to audit section

### DIFF
--- a/apps/manage/src/app/views/cases/view/view.njk
+++ b/apps/manage/src/app/views/cases/view/view.njk
@@ -44,6 +44,9 @@
                         </li>
                     {% endif %}
                 {% endfor %}
+                <li>
+                    <a href="#case-audit-log" class="govuk-link govuk-link--no-visited-state">Case audit log</a>
+                </li>
             </ul>
         </div>
 


### PR DESCRIPTION
## Describe your changes
Adds an anchor link to the top of the case details page to navigate to the audit section. Have hardcoded this in rather than adding at the controller level for two reasons:

1) The section is currently hardcoded and changing it to be loaded from the controller would be a bigger change and more fiddly.
2) We want the audit section to always appear last.

<img width="949" height="368" alt="Screenshot 2026-06-03 at 13 42 57" src="https://github.com/user-attachments/assets/8445eeb3-c236-40bd-a5e3-d82f53981dc5" />
<img width="1009" height="474" alt="Screenshot 2026-06-03 at 13 43 10" src="https://github.com/user-attachments/assets/86ebdd7c-4df7-4c1b-886d-0b1029c7c9c9" />
number and link

## Issue ticket 
https://pins-ds.atlassian.net/browse/CROWN-1625