### PR TITLE
feat(portal): use full date format for written reps card

### DIFF
--- a/apps/portal/src/app/views/applications/view/view-model.test.js
+++ b/apps/portal/src/app/views/applications/view/view-model.test.js
@@ -420,7 +420,7 @@ describe('view-model', () => {
 				representationComment: 'This is a comment',
 				representationCommentIsRedacted: false,
 				representationCategory: 'Category 1',
-				dateRepresentationSubmitted: '1 Jan 2025',
+				dateRepresentationSubmitted: '1 January 2025',
 				hasAcceptedAttachments: true,
 				distressingContent: false
 			});
@@ -444,7 +444,7 @@ describe('view-model', () => {
 				representationComment: 'This is a comment',
 				representationCommentIsRedacted: false,
 				representationCategory: 'Category 1',
-				dateRepresentationSubmitted: '1 Jan 2025',
+				dateRepresentationSubmitted: '1 January 2025',
 				hasAcceptedAttachments: false,
 				distressingContent: false
 			});
@@ -468,7 +468,7 @@ describe('view-model', () => {
 				representationComment: 'This is a comment',
 				representationCommentIsRedacted: false,
 				representationCategory: 'Category 1',
-				dateRepresentationSubmitted: '1 Jan 2025',
+				dateRepresentationSubmitted: '1 January 2025',
 				hasAcceptedAttachments: false,
 				distressingContent: false
 			});
@@ -493,7 +493,7 @@ describe('view-model', () => {
 				representationComment: 'This is a comment',
 				representationCommentIsRedacted: false,
 				representationCategory: 'Category 1',
-				dateRepresentationSubmitted: '1 Jan 2025',
+				dateRepresentationSubmitted: '1 January 2025',
 				hasAcceptedAttachments: false,
 				distressingContent: true
 			});
@@ -518,7 +518,7 @@ describe('view-model', () => {
 				representationComment: 'This is a comment',
 				representationCommentIsRedacted: false,
 				representationCategory: 'Category 1',
-				dateRepresentationSubmitted: '1 Jan 2025',
+				dateRepresentationSubmitted: '1 January 2025',
 				hasAcceptedAttachments: false,
 				distressingContent: false
 			});

--- a/apps/portal/src/app/views/applications/view/view-model.ts
+++ b/apps/portal/src/app/views/applications/view/view-model.ts
@@ -260,7 +260,7 @@ export function representationToViewModel(
 			: representationComment,
 		representationCommentIsRedacted: Boolean(representation.commentRedacted),
 		representationCategory: representation.Category?.displayName,
-		dateRepresentationSubmitted: formatDateForDisplay(representation.submittedDate),
+		dateRepresentationSubmitted: formatDateForDisplay(representation.submittedDate, { format: 'd MMMM yyyy' }),
 		hasAcceptedAttachments:
 			representation.Attachments?.some((doc) => doc.statusId === REPRESENTATION_STATUS_ID.ACCEPTED) &&
 			representation.containsAttachments,

--- a/apps/portal/src/app/views/applications/view/written-representations/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/controller.test.js
@@ -73,7 +73,7 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.pageTitle, 'Written representations');
 			assert.strictEqual(viewData.representations.length, 1);
 			assert.deepStrictEqual(viewData.representations[0], {
-				dateRepresentationSubmitted: '15 Jan 2025',
+				dateRepresentationSubmitted: '15 January 2025',
 				representationCategory: 'General Representation',
 				representationComment: 'This is a test representation.',
 				representationCommentIsRedacted: true,
@@ -371,7 +371,7 @@ describe('written representations', () => {
 			assert.strictEqual(viewData.pageTitle, 'Written representations');
 			assert.strictEqual(viewData.representations.length, 1);
 			assert.deepStrictEqual(viewData.representations[0], {
-				dateRepresentationSubmitted: '15 Jan 2025',
+				dateRepresentationSubmitted: '15 January 2025',
 				representationCategory: 'General Representation',
 				representationComment:
 					'It began with an ordinary morning. The air smelled faintly of dew, the street empty but for leaves drifting lazily. ████████ ██████ adjusted his collar, noting his watch was three minutes late—a stubborn old thing, loyal only to its own time. Across the street, a bakery opened, the scent of bread spilling into the cool air. A woman in a green scarf carried loaves in quiet balance. The square stirred slowly; ████████ wrote in his notebook, letting the day delay his errands, wholly unhurried and s... ',

--- a/apps/portal/src/app/views/applications/view/written-representations/read-more/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/read-more/controller.test.js
@@ -157,7 +157,7 @@ describe('written representations read more', () => {
 		const viewData = mockRes.render.mock.calls[0].arguments[1];
 		assert.strictEqual(viewData.pageCaption, 'CROWN/2025/0000001');
 		assert.deepStrictEqual(viewData.representationViewModel, {
-			dateRepresentationSubmitted: '15 Jan 2025',
+			dateRepresentationSubmitted: '15 January 2025',
 			representationCategory: 'General Representation',
 			representationComment: 'This is a test representation.',
 			representationCommentIsRedacted: true,
@@ -279,7 +279,7 @@ describe('written representations read more', () => {
 		const viewData = mockRes.render.mock.calls[0].arguments[1];
 		assert.strictEqual(viewData.pageCaption, 'CROWN/2025/0000001');
 		assert.deepStrictEqual(viewData.representationViewModel, {
-			dateRepresentationSubmitted: '15 Jan 2025',
+			dateRepresentationSubmitted: '15 January 2025',
 			representationCategory: 'General Representation',
 			representationComment: 'This is a test representation.',
 			representationCommentIsRedacted: true,
@@ -362,7 +362,7 @@ describe('written representations read more', () => {
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
 			assert.strictEqual(viewData.pageCaption, 'CROWN/2025/0000001');
 			assert.deepStrictEqual(viewData.representationViewModel, {
-				dateRepresentationSubmitted: '15 Jan 2025',
+				dateRepresentationSubmitted: '15 January 2025',
 				representationCategory: 'General Representation',
 				representationComment: 'This is a test representation.',
 				representationCommentIsRedacted: true,
@@ -439,7 +439,7 @@ describe('written representations read more', () => {
 			const viewData = mockRes.render.mock.calls[0].arguments[1];
 			assert.strictEqual(viewData.pageCaption, 'CROWN/2025/0000001');
 			assert.deepStrictEqual(viewData.representationViewModel, {
-				dateRepresentationSubmitted: '15 Jan 2025',
+				dateRepresentationSubmitted: '15 January 2025',
 				representationCategory: 'General Representation',
 				representationComment: 'This is a test representation.',
 				representationCommentIsRedacted: true,


### PR DESCRIPTION
## Describe your changes
Change date format to use full month on representations, and update tests. 

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1545
<img width="645" height="192" alt="Screenshot 2026-06-03 163554" src="https://github.com/user-attachments/assets/cc29ffcf-7a87-41e7-9ea8-d59f484d6a5c" />
