### PR TITLE
fix(portal): make link text clearer with context

### DIFF
--- a/apps/portal/src/app/views/applications/view/application-info/have-your-say-information.njk
+++ b/apps/portal/src/app/views/applications/view/application-info/have-your-say-information.njk
@@ -23,8 +23,8 @@
         <p class="govuk-body">We’ll ask for your name, email address and written representation. Your name and written representation will be published on our website.</p>
         <p class="govuk-body">The representations period will be published on this website as soon as dates are confirmed.</p>
     {% elif haveYourSayStatus === 'closedRepsPublished' %}
-        <p class="govuk-body">The representations period for this application has now ended.</p>
-        <p class="govuk-body">You can view the written representations <a class="govuk-link" href="/applications/{{ crownDevelopmentFields.id }}/written-representations">here</a>.</p>
+        <p class="govuk-body">The written representations period has ended.</p>
+        <p class="govuk-body">You can <a class="govuk-link" href="/applications/{{ crownDevelopmentFields.id }}/written-representations">view the written representations</a> for this application.</p>
     {% elif haveYourSayStatus === 'closedPublishedDateInFuture' %}{# Scenario 5 #}
         <p class="govuk-body">The representations period for this application has now ended.</p>
         <p class="govuk-body">You can view the written representations from: {{ crownDevelopmentFields.representationsPublishDate }}</p>


### PR DESCRIPTION
## Describe your changes
Content change to add context to link text.

## Issue ticket number and link
[CROWN-1541](https://pins-ds.atlassian.net/browse/CROWN-1541)
<img width="836" height="254" alt="Screenshot 2026-06-04 175318" src="https://github.com/user-attachments/assets/52dc31d9-673c-45da-bd50-cee1eaad3210" />



[CROWN-1541]: https://pins-ds.atlassian.net/browse/CROWN-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ