### PR TITLE
Fix/crown 1622 add tag manager to img src csp

### DIFF
--- a/apps/portal/src/app/app.js
+++ b/apps/portal/src/app/app.js
@@ -7,7 +7,7 @@ import { buildLogRequestsMiddleware } from '@pins/crowndev-lib/middleware/log-re
 import { buildDefaultErrorHandlerMiddleware, notFoundHandler } from '@pins/crowndev-lib/middleware/errors.ts';
 import { initSessionMiddleware } from '@pins/crowndev-lib/util/session.ts';
 import { addLocalsConfiguration } from '#util/config-middleware.js';
-import { initContentSecurityPolicyMiddlewares } from '#util/csp-middleware.js';
+import { initContentSecurityPolicyMiddlewares } from '#util/csp-middleware.ts';
 import { buildAnalyticsCookiesMiddleware } from '#util/cookies.js';
 import { cleanEmptyQueryParams, trimEmptyQuery } from '@pins/crowndev-lib/middleware/query-middleware.js';
 import lusca from 'lusca';

--- a/apps/portal/src/util/csp-middleware.ts
+++ b/apps/portal/src/util/csp-middleware.ts
@@ -23,7 +23,8 @@ export function initContentSecurityPolicyMiddlewares(): Handler[] {
 			"'sha256-7zbeFC0WLiMB91PUOjhl4gr+nVFhMvuL8499Uj28yhk='",
 			"'sha256-UN0YC/M1Zsw697Rinjvc9+EQSGi5Rp94tCe93kO195E='"
 		],
-		connectSrc: ['https://*.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com']
+		connectSrc: ['https://*.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com'],
+		imgSrc: ['https://www.googletagmanager.com']
 	};
 
 	const directives: HelmetCspDirectives = {
@@ -37,7 +38,7 @@ export function initContentSecurityPolicyMiddlewares(): Handler[] {
 		defaultSrc: ["'self'"],
 		connectSrc: ["'self'", ...googleAnalytics.connectSrc],
 		fontSrc: ["'self'"],
-		imgSrc: ["'self'"],
+		imgSrc: ["'self'", ...googleAnalytics.imgSrc],
 		styleSrc: ["'self'"]
 	};
 

--- a/apps/portal/src/util/csp-middleware.ts
+++ b/apps/portal/src/util/csp-middleware.ts
@@ -1,21 +1,13 @@
-import helmet from 'helmet';
-import crypto from 'node:crypto';
+import {
+	type HelmetCspDirectives,
+	initContentSecurityPolicyMiddlewares as initSharedContentSecurityPolicyMiddlewares
+} from '@pins/crowndev-lib/middleware/csp-middleware.ts';
+import type { Handler } from 'express';
 
 /**
- * @returns {import('express').Handler[]}
+ * Initialises the Content Security Policy (CSP) middlewares for the application.
  */
-export function initContentSecurityPolicyMiddlewares() {
-	/** @type {import('express').Handler[]} */
-	const middlewares = [];
-
-	// Generate the nonce for each request
-	middlewares.push((req, res, next) => {
-		res.locals.cspNonce = crypto.randomBytes(32).toString('hex');
-		next();
-	});
-
-	middlewares.push(helmet());
-
+export function initContentSecurityPolicyMiddlewares(): Handler[] {
 	const googleAnalytics = {
 		scriptSrc: [
 			'https://*.googletagmanager.com',
@@ -34,9 +26,14 @@ export function initContentSecurityPolicyMiddlewares() {
 		connectSrc: ['https://*.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com']
 	};
 
-	/** @type {import('helmet').ContentSecurityPolicyOptions['directives']} */
-	const directives = {
-		scriptSrc: ["'self'", ...googleAnalytics.scriptSrc, (req, res) => `'nonce-${res.locals.cspNonce}'`],
+	const directives: HelmetCspDirectives = {
+		scriptSrc: [
+			"'self'",
+			...googleAnalytics.scriptSrc,
+			(req, res) => {
+				return `'nonce-${res.locals?.cspNonce}'`;
+			}
+		],
 		defaultSrc: ["'self'"],
 		connectSrc: ["'self'", ...googleAnalytics.connectSrc],
 		fontSrc: ["'self'"],
@@ -44,11 +41,5 @@ export function initContentSecurityPolicyMiddlewares() {
 		styleSrc: ["'self'"]
 	};
 
-	middlewares.push(
-		helmet.contentSecurityPolicy({
-			directives
-		})
-	);
-
-	return middlewares;
+	return initSharedContentSecurityPolicyMiddlewares(directives);
 }

--- a/packages/lib/middleware/csp-middleware.test.ts
+++ b/packages/lib/middleware/csp-middleware.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
+import express from 'express';
+import supertest from 'supertest';
 import { initContentSecurityPolicyMiddlewares } from './csp-middleware.ts';
 import type { Request, Response, NextFunction } from 'express';
 
@@ -54,5 +56,29 @@ describe('csp-middleware', () => {
 				scriptSrc: ["'self'", "'unsafe-inline'"]
 			});
 		});
+	});
+
+	it('should include a non-empty nonce in the CSP header from middleware-generated res.locals.cspNonce', async () => {
+		const app = express();
+		app.use(
+			...initContentSecurityPolicyMiddlewares({
+				defaultSrc: ["'self'"],
+				scriptSrc: ["'self'", (_req, res) => `'nonce-${res.locals.cspNonce}'`]
+			})
+		);
+
+		app.get('/csp-check', (_req, res) => {
+			res.json({ cspNonce: res.locals.cspNonce });
+		});
+
+		const response = await supertest(app).get('/csp-check');
+		const cspHeader = response.headers['content-security-policy'];
+
+		assert.ok(response.body.cspNonce);
+		assert.equal(typeof response.body.cspNonce, 'string');
+		assert.match(response.body.cspNonce, /\S+/);
+		assert.ok(cspHeader);
+		assert.match(cspHeader, new RegExp(`'nonce-${response.body.cspNonce}'`));
+		assert.doesNotMatch(cspHeader, /'nonce-undefined'/);
 	});
 });


### PR DESCRIPTION
## Describe your changes

- Update `apps/portal/src/util/csp-middleware.js` to TypeScript
- Refactor `initContentSecurityPolicyMiddlewares` to use shared util now in use by S62A
- Add test to ensure that `cspNonce` is correctly set
- Add Google Tag Manager to `img-src` CSP directives for portal

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1622
<img width="614" height="355" alt="image" src="https://github.com/user-attachments/assets/734a9ba0-f7f8-4b7c-89c1-e30c3ab229f2" />
