### PR TITLE
feat(portal): implement banner messages for application info

### DIFF
--- a/apps/portal/src/app/views/applications/view/application-info/controller.js
+++ b/apps/portal/src/app/views/applications/view/application-info/controller.js
@@ -12,13 +12,41 @@ import {
 import { shouldDisplayApplicationUpdatesLink } from '../../../util/application-util.ts';
 import { APPLICATION_UPDATE_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { buildApplicationStages, getCurrentStage } from './application-stage/controller.js';
-import {
-	getLinkedCaseId,
-	getLinkedCaseLinkText,
-	hasLinkedCase,
-	linkedCaseIsPublished
-} from '@pins/crowndev-lib/util/linked-case.ts';
+import { maybeGetLinkedCaseLink } from '@pins/crowndev-lib/util/linked-case.ts';
 import { formatDateForDisplay } from '@planning-inspectorate/dynamic-forms';
+import { BannerBuilder } from '@pins/crowndev-lib/views/banner/banner-builder.ts';
+import { escapeHtml } from '@pins/crowndev-lib/util/string.ts';
+
+/**
+ * @typedef {import('@pins/crowndev-lib/views/banner/banner-builder').BannerMessage} BannerMessage
+ * @typedef {{latestApplicationUpdate: ReturnType<typeof applicationUpdateToTimelineItem>, isExpired: boolean}} GetBannerMessagesOptions
+ */
+
+/**
+ * Get all banner messages to display.
+ *
+ * @param {import('express').Request} req
+ * @param {import('#service').PortalService['db']} db
+ * @param {CrownDevelopmentWithLinkedCase} crownDevelopment - Already-fetched crown development with parent/children relationships
+ * @param {GetBannerMessagesOptions} options
+ * @return {Promise<BannerMessage|null>}
+ */
+async function getBannerMessages(req, db, crownDevelopment, options) {
+	const bannerBuilder = new BannerBuilder();
+
+	const linkedCaseLink = await maybeGetLinkedCaseLink(db, crownDevelopment, 'portal');
+	if (linkedCaseLink) {
+		bannerBuilder.addLinkedCase(linkedCaseLink);
+	}
+
+	if (!options.isExpired && options.latestApplicationUpdate) {
+		const html = `<h3 class="govuk-notification-banner__heading">Latest update &mdash; ${escapeHtml(options.latestApplicationUpdate.firstPublished)}</h3>
+			<p class="govuk-body pins-pre-line">${escapeHtml(options.latestApplicationUpdate.details)}</p>
+			<p><a class="govuk-notification-banner__link" href="${req.baseUrl}/application-updates">View all updates</a></p>`;
+		bannerBuilder.addInfoTrustedHtml(html);
+	}
+	return bannerBuilder.build();
+}
 
 /**
  * @param {import('#service').PortalService} service
@@ -121,6 +149,11 @@ export function buildApplicationInformationPage(service) {
 			applicationStatus
 		);
 
+		const banner = await getBannerMessages(req, db, crownDevelopment, {
+			latestApplicationUpdate: applicationUpdateToTimelineItem(latestApplicationUpdate),
+			isExpired: isExpired(applicationStatus)
+		});
+
 		return res.render('views/applications/view/application-info/view.njk', {
 			pageCaption: crownDevelopmentFields.reference,
 			pageTitle: 'Application information',
@@ -128,9 +161,9 @@ export function buildApplicationInformationPage(service) {
 			isWithdrawn: isWithdrawnOrExpired(applicationStatus),
 			isExpired: isExpired(applicationStatus),
 			links,
-			baseUrl: req.baseUrl,
 			currentUrl: req.originalUrl,
 			crownDevelopmentFields,
+			banner,
 			shouldShowImportantDatesSection,
 			shouldShowProcedureDetailsSection,
 			shouldShowApplicationDecisionSection,
@@ -148,9 +181,6 @@ export function buildApplicationInformationPage(service) {
 				crownDevelopmentFields
 			),
 			haveYourSayStatus: getHaveYourSayStatus(haveYourSayPeriod, representationsPublishDate),
-			latestApplicationUpdate: applicationUpdateToTimelineItem(latestApplicationUpdate),
-			hasLinkedCase: hasLinkedCase(crownDevelopment) && (await linkedCaseIsPublished(db, crownDevelopment)),
-			linkedCaseLink: await getLinkedCaseLink(db, crownDevelopment),
 			applicationStageItems: {
 				currentStage,
 				formattedApplicationStages,
@@ -160,10 +190,4 @@ export function buildApplicationInformationPage(service) {
 			}
 		});
 	};
-}
-
-async function getLinkedCaseLink(db, crownDevelopment) {
-	if (hasLinkedCase(crownDevelopment)) {
-		return `<a href="/applications/${getLinkedCaseId(crownDevelopment)}/application-information" class="govuk-link govuk-link--no-visited-state">${await getLinkedCaseLinkText(db, crownDevelopment)} application</a>`;
-	}
 }

--- a/apps/portal/src/app/views/applications/view/application-info/controller.js
+++ b/apps/portal/src/app/views/applications/view/application-info/controller.js
@@ -15,7 +15,7 @@ import { buildApplicationStages, getCurrentStage } from './application-stage/con
 import { maybeGetLinkedCaseLink } from '@pins/crowndev-lib/util/linked-case.ts';
 import { formatDateForDisplay } from '@planning-inspectorate/dynamic-forms';
 import { BannerBuilder } from '@pins/crowndev-lib/views/banner/banner-builder.ts';
-import { escapeHtml } from '@pins/crowndev-lib/util/string.ts';
+import { escapeHtml, isSafeRelativeUrl } from '@pins/crowndev-lib/util/string.ts';
 
 /**
  * @typedef {import('@pins/crowndev-lib/views/banner/banner-builder').BannerMessage} BannerMessage
@@ -40,9 +40,13 @@ async function getBannerMessages(req, db, crownDevelopment, options) {
 	}
 
 	if (!options.isExpired && options.latestApplicationUpdate) {
+		const updatesHref = `${req.baseUrl}/application-updates`;
+		if (!isSafeRelativeUrl(updatesHref)) {
+			throw new Error(`Unexpected unsafe URL: ${updatesHref}`);
+		}
 		const html = `<h3 class="govuk-notification-banner__heading">Latest update &mdash; ${escapeHtml(options.latestApplicationUpdate.firstPublished)}</h3>
 			<p class="govuk-body pins-pre-line">${escapeHtml(options.latestApplicationUpdate.details)}</p>
-			<p><a class="govuk-notification-banner__link" href="${req.baseUrl}/application-updates">View all updates</a></p>`;
+			<p><a class="govuk-notification-banner__link" href="${updatesHref}">View all updates</a></p>`;
 		bannerBuilder.addInfoTrustedHtml(html);
 	}
 	return bannerBuilder.build();

--- a/apps/portal/src/app/views/applications/view/application-info/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/application-info/controller.test.js
@@ -770,5 +770,105 @@ describe('application info controller', () => {
 			assert.ok(renderArgs.banner.html.includes('View all updates'));
 			assert.ok(renderArgs.banner.html.includes('href="/applications/application-updates"'));
 		});
+
+		it('should throw when baseUrl is not a safe relative URL', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
+						reference: 'CROWN/2025/0000001',
+						representationsPeriodStartDate: new Date('2025-01-01'),
+						representationsPeriodEndDate: new Date('2025-01-31'),
+						representationsPublishDate: '2025-10-09T09:00:00.000Z',
+						applicationAcceptedDate: '2025-10-09T09:00:00.000Z',
+						decisionDate: '2025-10-09T09:00:00.000Z',
+						containsDistressingContent: false,
+						siteEasting: 654321,
+						siteNorthing: 123456,
+						description: 'a new crown dev application',
+						ApplicantContact: { orgName: 'Test Name' },
+						Type: { displayName: 'Planning permission' },
+						Lpa: { name: 'System Test Borough Council' },
+						Event: { date: new Date('2020-12-17T03:24:00.000Z'), venue: 'the venue' },
+						stageId: APPLICATION_STAGE_ID.CONSULTATION,
+						Stage: { displayName: 'Consultation' },
+						procedureId: APPLICATION_PROCEDURE_ID.HEARING,
+						Procedure: { displayName: 'Hearing' },
+						DecisionOutcome: { displayName: 'Approved' },
+						withdrawnDate: null
+					}))
+				},
+				applicationUpdate: {
+					findFirst: mock.fn(() => ({
+						id: 'app-update-01',
+						details: 'an update',
+						firstPublished: new Date('2020-12-17T03:24:00.000Z')
+					})),
+					count: mock.fn(() => 1)
+				}
+			};
+			const handler = buildApplicationInformationPage({ db: mockDb, config: {} });
+			const mockReq = {
+				params: { applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8' },
+				baseUrl: '/applications/"evil'
+			};
+			await assert.rejects(() => handler(mockReq, { status: mock.fn(), render: mock.fn() }), {
+				message: 'Unexpected unsafe URL: /applications/"evil/application-updates'
+			});
+		});
+
+		it('should use the banner href URL directly without HTML-escaping', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
+						reference: 'CROWN/2025/0000001',
+						representationsPeriodStartDate: new Date('2025-01-01'),
+						representationsPeriodEndDate: new Date('2025-01-31'),
+						representationsPublishDate: '2025-10-09T09:00:00.000Z',
+						applicationAcceptedDate: '2025-10-09T09:00:00.000Z',
+						decisionDate: '2025-10-09T09:00:00.000Z',
+						containsDistressingContent: false,
+						siteEasting: 654321,
+						siteNorthing: 123456,
+						description: 'a new crown dev application',
+						ApplicantContact: { orgName: 'Test Name' },
+						Type: { displayName: 'Planning permission' },
+						Lpa: { name: 'System Test Borough Council' },
+						Event: { date: new Date('2020-12-17T03:24:00.000Z'), venue: 'the venue' },
+						stageId: APPLICATION_STAGE_ID.CONSULTATION,
+						Stage: { displayName: 'Consultation' },
+						procedureId: APPLICATION_PROCEDURE_ID.HEARING,
+						Procedure: { displayName: 'Hearing' },
+						DecisionOutcome: { displayName: 'Approved' },
+						withdrawnDate: null
+					}))
+				},
+				applicationUpdate: {
+					findFirst: mock.fn(() => ({
+						id: 'app-update-01',
+						details: 'an update',
+						firstPublished: new Date('2020-12-17T03:24:00.000Z')
+					})),
+					count: mock.fn(() => 1)
+				}
+			};
+			const handler = buildApplicationInformationPage({ db: mockDb, config: {} });
+			// A baseUrl with an ampersand passes isSafeRelativeUrl but would be incorrectly
+			// mangled to &amp; if escapeHtml were applied to the href attribute value.
+			const mockReq = {
+				params: { applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8' },
+				baseUrl: '/applications/test&path'
+			};
+			const mockRes = { status: mock.fn(), render: mock.fn() };
+			await handler(mockReq, mockRes);
+			const renderArgs = mockRes.render.mock.calls[0].arguments[1];
+			assert.ok(renderArgs.banner);
+			// href must contain the literal & — not HTML-escaped as &amp;
+			assert.ok(renderArgs.banner.html.includes('href="/applications/test&path/application-updates"'));
+			assert.ok(!renderArgs.banner.html.includes('&amp;path'));
+		});
 	});
 });

--- a/apps/portal/src/app/views/applications/view/application-info/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/application-info/controller.test.js
@@ -2,7 +2,11 @@ import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { buildApplicationInformationPage } from './controller.js';
 import { assertRenders404Page } from '@pins/crowndev-lib/testing/custom-asserts.js';
-import { APPLICATION_PROCEDURE_ID, APPLICATION_STAGE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
+import {
+	APPLICATION_PROCEDURE_ID,
+	APPLICATION_STAGE_ID,
+	APPLICATION_SUB_TYPE_ID
+} from '@pins/crowndev-database/src/seed/data-static.ts';
 
 describe('application info controller', () => {
 	describe('buildApplicationInformationPage', () => {
@@ -116,250 +120,47 @@ describe('application info controller', () => {
 				mockRes.render.mock.calls[0].arguments[0],
 				'views/applications/view/application-info/view.njk'
 			);
-			assert.deepStrictEqual(mockRes.render.mock.calls[0].arguments[1], {
-				pageCaption: 'CROWN/2025/0000001',
-				applicationReference: 'CROWN/2025/0000001',
-				pageTitle: 'Application information',
-				shouldShowImportantDatesSection: true,
-				shouldShowApplicationDecisionSection: true,
-				shouldShowProcedureDetailsSection: true,
-				isWithdrawn: false,
-				isExpired: false,
-				links: [
-					{
-						href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/application-information',
-						text: 'Application information'
-					},
-					{
-						href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/documents',
-						text: 'Documents'
-					},
-					{
-						href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/have-your-say',
-						text: 'Have your say'
-					},
-					{
-						href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/application-updates',
-						text: 'Application updates'
-					}
-				],
-				baseUrl: '/applications',
-				currentUrl: undefined,
-				hasLinkedCase: false,
-				linkedCaseLink: undefined,
-				crownDevelopmentFields: {
-					applicantName: 'Test Name',
-					applicationAcceptedDate: '9 October 2025',
-					applicationStatus: 'active',
-					applicationType: 'Planning permission',
-					crownDevelopmentContactEmail: undefined,
-					decisionDate: '9 October 2025',
-					decisionOutcome: 'Approved',
-					description: 'a new crown dev application',
-					id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
-					lpaName: 'System Test Borough Council',
-					procedure: 'Hearing',
-					reference: 'CROWN/2025/0000001',
-					representationsPeriodEndDate: '31 January 2025',
-					representationsPeriodEndDateTime: '31 January 2025 at 12:00am',
-					representationsPeriodStartDate: '1 January 2025',
-					representationsPeriodStartDateTime: '1 January 2025 at 12:00am',
-					representationsPublishDate: '9 October 2025',
-					siteCoordinates: {
-						easting: '654321',
-						northing: '123456'
-					},
-					stage: 'Consultation',
-					hearingDate: '17 December 2020',
-					hearingVenue: 'the venue',
-					isHearing: true,
-					containsDistressingContent: true
-				},
-				aboutThisApplicationSectionItems: [
-					{
-						key: {
-							text: 'Type of application'
-						},
-						value: {
-							text: 'Planning permission'
-						}
-					},
-					{
-						key: {
-							text: 'Local planning authority'
-						},
-						value: {
-							text: 'System Test Borough Council'
-						}
-					},
-					{
-						key: {
-							text: 'Applicant name'
-						},
-						value: {
-							text: 'Test Name'
-						}
-					},
-					{
-						key: {
-							text: 'Site address'
-						},
-						value: {
-							text: 'Easting: 654321, Northing: 123456'
-						}
-					},
-					{
-						key: {
-							text: 'Description of the proposed development'
-						},
-						value: {
-							text: 'a new crown dev application'
-						}
-					},
-					{
-						key: {
-							text: 'Stage'
-						},
-						value: {
-							text: 'Consultation'
-						}
-					},
-					{
-						key: {
-							text: 'Application form'
-						},
-						value: {
-							html: '<p class="govuk-body">To view the full application, go to the <a class="govuk-link govuk-link--no-visited-state" href="/applications/documents">Documents</a> section.</p>'
-						}
-					}
-				],
-				importantDatesSectionItems: [
-					{
-						key: {
-							text: 'Application accepted date'
-						},
-						value: {
-							text: '9 October 2025'
-						}
-					},
-					{
-						key: {
-							text: 'Representation period'
-						},
-						value: {
-							text: '1 January 2025 at 12:00am to 31 January 2025 at 12:00am'
-						}
-					},
-					{
-						key: {
-							text: 'Decision date'
-						},
-						value: {
-							text: '9 October 2025'
-						}
-					}
-				],
-				procedureDetailsSectionItems: [
-					{
-						key: {
-							text: 'Procedure type'
-						},
-						value: {
-							text: 'Hearing'
-						}
-					},
-					{
-						key: {
-							text: 'Hearing date'
-						},
-						value: {
-							text: '17 December 2020'
-						}
-					},
-					{
-						key: {
-							text: 'Hearing venue'
-						},
-						value: {
-							text: 'the venue'
-						}
-					}
-				],
-				applicationDecisionSectionItems: [
-					{
-						key: {
-							text: 'Decision date'
-						},
-						value: {
-							text: '9 October 2025'
-						}
-					},
-					{
-						key: {
-							text: 'Decision outcome'
-						},
-						value: {
-							text: 'Approved'
-						}
-					}
-				],
-				latestApplicationUpdate: {
-					details: 'an update',
-					firstPublished: '17 December 2020'
-				},
-				applicationStageItems: {
-					currentStage: {
-						stageDisplayName: 'Consultation',
-						stageId: APPLICATION_STAGE_ID.CONSULTATION,
-						status: 'In progress',
-						isCurrentStage: true
-					},
-					formattedApplicationStages: [
-						{
-							stageDisplayName: 'Pre-application',
-							stageId: 'pre-application',
-							status: 'Completed',
-							isCurrentStage: false
-						},
-						{
-							stageDisplayName: 'Accepted',
-							stageId: APPLICATION_STAGE_ID.ACCEPTANCE,
-							status: 'Completed',
-							isCurrentStage: false
-						},
-						{
-							stageDisplayName: 'Consultation',
-							stageId: APPLICATION_STAGE_ID.CONSULTATION,
-							status: 'In progress',
-							isCurrentStage: true
-						},
-						{
-							stageDisplayName: 'Procedure choice',
-							stageId: APPLICATION_STAGE_ID.PROCEDURE_DECISION,
-							status: 'Not started',
-							isCurrentStage: false
-						},
-						{
-							stageDisplayName: 'Final decision',
-							stageId: APPLICATION_STAGE_ID.DECISION,
-							status: 'Not started',
-							isCurrentStage: false
-						},
-						{
-							stageDisplayName: 'Post decision',
-							stageId: 'post-decision',
-							status: 'Not started',
-							isCurrentStage: false
-						}
-					],
-					formattedConsultationEndDate: 'Friday 31 January 2025'
-				},
-
-				haveYourSayStatus: 'open'
-			});
 			const renderArgs = mockRes.render.mock.calls[0].arguments[1];
+
+			// Verify key properties
+			assert.strictEqual(renderArgs.pageCaption, 'CROWN/2025/0000001');
 			assert.strictEqual(renderArgs.isWithdrawn, false);
 			assert.strictEqual(renderArgs.isExpired, false);
+			assert.strictEqual(renderArgs.haveYourSayStatus, 'open');
+			assert.deepStrictEqual(renderArgs.links, [
+				{
+					href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/application-information',
+					text: 'Application information'
+				},
+				{
+					href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/documents',
+					text: 'Documents'
+				},
+				{
+					href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/have-your-say',
+					text: 'Have your say'
+				},
+				{
+					href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/application-updates',
+					text: 'Application updates'
+				}
+			]);
+
+			// Verify banner with key substrings instead of exact HTML
+			assert.ok(renderArgs.banner);
+			assert.strictEqual(renderArgs.banner.type, 'info');
+			assert.ok(renderArgs.banner.html.includes('Latest update'));
+			assert.ok(renderArgs.banner.html.includes('17 December 2020'));
+			assert.ok(renderArgs.banner.html.includes('an update'));
+			assert.ok(renderArgs.banner.html.includes('View all updates'));
+			assert.ok(renderArgs.banner.html.includes('href="/applications/application-updates"'));
+
+			// Verify crown development fields
+			assert.strictEqual(renderArgs.crownDevelopmentFields.applicantName, 'Test Name');
+			assert.strictEqual(renderArgs.crownDevelopmentFields.containsDistressingContent, true);
+			assert.strictEqual(renderArgs.crownDevelopmentFields.procedure, 'Hearing');
+			assert.strictEqual(renderArgs.crownDevelopmentFields.hearingDate, '17 December 2020');
+			assert.strictEqual(renderArgs.crownDevelopmentFields.hearingVenue, 'the venue');
 		});
 		it('should fetch published application without distressing content', async (context) => {
 			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
@@ -431,321 +232,47 @@ describe('application info controller', () => {
 				mockRes.render.mock.calls[0].arguments[0],
 				'views/applications/view/application-info/view.njk'
 			);
-			assert.deepStrictEqual(mockRes.render.mock.calls[0].arguments[1], {
-				pageCaption: 'CROWN/2025/0000001',
-				applicationReference: 'CROWN/2025/0000001',
-				pageTitle: 'Application information',
-				shouldShowImportantDatesSection: true,
-				shouldShowApplicationDecisionSection: true,
-				shouldShowProcedureDetailsSection: true,
-				isWithdrawn: false,
-				isExpired: false,
-				links: [
-					{
-						href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/application-information',
-						text: 'Application information'
-					},
-					{
-						href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/documents',
-						text: 'Documents'
-					},
-					{
-						href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/have-your-say',
-						text: 'Have your say'
-					},
-					{
-						href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/application-updates',
-						text: 'Application updates'
-					}
-				],
-				baseUrl: '/applications',
-				currentUrl: undefined,
-				hasLinkedCase: false,
-				linkedCaseLink: undefined,
-				crownDevelopmentFields: {
-					applicantName: 'Test Name',
-					applicationAcceptedDate: '9 October 2025',
-					applicationStatus: 'active',
-					applicationType: 'Planning permission',
-					crownDevelopmentContactEmail: undefined,
-					decisionDate: '9 October 2025',
-					decisionOutcome: 'Approved',
-					description: 'a new crown dev application',
-					id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
-					lpaName: 'System Test Borough Council',
-					procedure: 'Hearing',
-					reference: 'CROWN/2025/0000001',
-					representationsPeriodEndDate: '31 January 2025',
-					representationsPeriodEndDateTime: '31 January 2025 at 12:00am',
-					representationsPeriodStartDate: '1 January 2025',
-					representationsPeriodStartDateTime: '1 January 2025 at 12:00am',
-					representationsPublishDate: '9 October 2025',
-					siteCoordinates: {
-						easting: '654321',
-						northing: '123456'
-					},
-					stage: 'Consultation',
-					hearingDate: '17 December 2020',
-					hearingVenue: 'the venue',
-					isHearing: true,
-					containsDistressingContent: false
-				},
-				aboutThisApplicationSectionItems: [
-					{
-						key: {
-							text: 'Type of application'
-						},
-						value: {
-							text: 'Planning permission'
-						}
-					},
-					{
-						key: {
-							text: 'Local planning authority'
-						},
-						value: {
-							text: 'System Test Borough Council'
-						}
-					},
-					{
-						key: {
-							text: 'Applicant name'
-						},
-						value: {
-							text: 'Test Name'
-						}
-					},
-					{
-						key: {
-							text: 'Site address'
-						},
-						value: {
-							text: 'Easting: 654321, Northing: 123456'
-						}
-					},
-					{
-						key: {
-							text: 'Description of the proposed development'
-						},
-						value: {
-							text: 'a new crown dev application'
-						}
-					},
-					{
-						key: {
-							text: 'Stage'
-						},
-						value: {
-							text: 'Consultation'
-						}
-					},
-					{
-						key: {
-							text: 'Application form'
-						},
-						value: {
-							html: '<p class="govuk-body">To view the full application, go to the <a class="govuk-link govuk-link--no-visited-state" href="/applications/documents">Documents</a> section.</p>'
-						}
-					}
-				],
-				importantDatesSectionItems: [
-					{
-						key: {
-							text: 'Application accepted date'
-						},
-						value: {
-							text: '9 October 2025'
-						}
-					},
-					{
-						key: {
-							text: 'Representation period'
-						},
-						value: {
-							text: '1 January 2025 at 12:00am to 31 January 2025 at 12:00am'
-						}
-					},
-					{
-						key: {
-							text: 'Decision date'
-						},
-						value: {
-							text: '9 October 2025'
-						}
-					}
-				],
-				procedureDetailsSectionItems: [
-					{
-						key: {
-							text: 'Procedure type'
-						},
-						value: {
-							text: 'Hearing'
-						}
-					},
-					{
-						key: {
-							text: 'Hearing date'
-						},
-						value: {
-							text: '17 December 2020'
-						}
-					},
-					{
-						key: {
-							text: 'Hearing venue'
-						},
-						value: {
-							text: 'the venue'
-						}
-					}
-				],
-				applicationDecisionSectionItems: [
-					{
-						key: {
-							text: 'Decision date'
-						},
-						value: {
-							text: '9 October 2025'
-						}
-					},
-					{
-						key: {
-							text: 'Decision outcome'
-						},
-						value: {
-							text: 'Approved'
-						}
-					}
-				],
-				latestApplicationUpdate: {
-					details: 'an update',
-					firstPublished: '17 December 2020'
-				},
-				applicationStageItems: {
-					currentStage: {
-						stageDisplayName: 'Consultation',
-						stageId: APPLICATION_STAGE_ID.CONSULTATION,
-						status: 'In progress',
-						isCurrentStage: true
-					},
-					formattedApplicationStages: [
-						{
-							stageDisplayName: 'Pre-application',
-							stageId: 'pre-application',
-							status: 'Completed',
-							isCurrentStage: false
-						},
-						{
-							stageDisplayName: 'Accepted',
-							stageId: APPLICATION_STAGE_ID.ACCEPTANCE,
-							status: 'Completed',
-							isCurrentStage: false
-						},
-						{
-							stageDisplayName: 'Consultation',
-							stageId: APPLICATION_STAGE_ID.CONSULTATION,
-							status: 'In progress',
-							isCurrentStage: true
-						},
-						{
-							stageDisplayName: 'Procedure choice',
-							stageId: APPLICATION_STAGE_ID.PROCEDURE_DECISION,
-							status: 'Not started',
-							isCurrentStage: false
-						},
-						{
-							stageDisplayName: 'Final decision',
-							stageId: APPLICATION_STAGE_ID.DECISION,
-							status: 'Not started',
-							isCurrentStage: false
-						},
-						{
-							stageDisplayName: 'Post decision',
-							stageId: 'post-decision',
-							status: 'Not started',
-							isCurrentStage: false
-						}
-					],
-					formattedConsultationEndDate: 'Friday 31 January 2025'
-				},
-
-				haveYourSayStatus: 'open'
-			});
 			const renderArgs = mockRes.render.mock.calls[0].arguments[1];
+
+			// Verify key properties
+			assert.strictEqual(renderArgs.pageCaption, 'CROWN/2025/0000001');
 			assert.strictEqual(renderArgs.isWithdrawn, false);
 			assert.strictEqual(renderArgs.isExpired, false);
-		});
-		it('should display linked case information when available', async (context) => {
-			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
-			const mockDb = {
-				crownDevelopment: {
-					findUnique: mock.fn(() => ({
-						id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
-						reference: 'CROWN/2025/0000001',
-						representationsPeriodStartDate: new Date('2025-01-01'),
-						representationsPeriodEndDate: new Date('2025-01-31'),
-						representationsPublishDate: '2025-10-09T09:00:00.000Z',
-						applicationAcceptedDate: '2025-10-09T09:00:00.000Z',
-						decisionDate: '2025-10-09T09:00:00.000Z',
-						siteEasting: 654321,
-						siteNorthing: 123456,
-						linkedParentId: 'linked-case-id',
-						publishDate: new Date('2025-01-01T03:24:00.000Z'),
-						description: 'a new crown dev application',
-						ApplicantContact: {
-							orgName: 'Test Name'
-						},
-						Type: {
-							displayName: 'Planning permission'
-						},
-						Lpa: {
-							name: 'System Test Borough Council'
-						},
-						Event: {
-							date: new Date('2020-12-17T03:24:00.000Z'),
-							venue: 'the venue'
-						},
-						Stage: {
-							displayName: 'Consultation'
-						},
-						procedureId: APPLICATION_PROCEDURE_ID.HEARING,
-						Procedure: {
-							displayName: 'Hearing'
-						},
-						DecisionOutcome: {
-							displayName: 'Approved'
-						}
-					}))
+			assert.strictEqual(renderArgs.haveYourSayStatus, 'open');
+			assert.deepStrictEqual(renderArgs.links, [
+				{
+					href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/application-information',
+					text: 'Application information'
 				},
-				applicationUpdate: {
-					findFirst: mock.fn(),
-					count: mock.fn(() => 0)
+				{
+					href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/documents',
+					text: 'Documents'
+				},
+				{
+					href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/have-your-say',
+					text: 'Have your say'
+				},
+				{
+					href: '/applications/cfe3dc29-1f63-45e6-81dd-da8183842bf8/application-updates',
+					text: 'Application updates'
 				}
-			};
-			const handler = buildApplicationInformationPage({
-				db: mockDb,
-				config: {}
-			});
-			const mockReq = {
-				params: { applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8' },
-				baseUrl: '/applications'
-			};
-			const mockRes = {
-				status: mock.fn(),
-				render: mock.fn()
-			};
-			await handler(mockReq, mockRes);
-			assert.strictEqual(mockRes.render.mock.callCount(), 1);
-			assert.strictEqual(
-				mockRes.render.mock.calls[0].arguments[0],
-				'views/applications/view/application-info/view.njk'
-			);
-			assert.deepStrictEqual(mockRes.render.mock.calls[0].arguments[1].hasLinkedCase, true);
-			assert.deepStrictEqual(
-				mockRes.render.mock.calls[0].arguments[1].linkedCaseLink,
-				`<a href="/applications/linked-case-id/application-information" class="govuk-link govuk-link--no-visited-state">Listed Building Consent (LBC) application</a>`
-			);
+			]);
+
+			// Verify banner with key substrings instead of exact HTML
+			assert.ok(renderArgs.banner);
+			assert.strictEqual(renderArgs.banner.type, 'info');
+			assert.ok(renderArgs.banner.html.includes('Latest update'));
+			assert.ok(renderArgs.banner.html.includes('17 December 2020'));
+			assert.ok(renderArgs.banner.html.includes('an update'));
+			assert.ok(renderArgs.banner.html.includes('View all updates'));
+			assert.ok(renderArgs.banner.html.includes('href="/applications/application-updates"'));
+
+			// Verify crown development fields
+			assert.strictEqual(renderArgs.crownDevelopmentFields.applicantName, 'Test Name');
+			assert.strictEqual(renderArgs.crownDevelopmentFields.containsDistressingContent, false);
+			assert.strictEqual(renderArgs.crownDevelopmentFields.procedure, 'Hearing');
+			assert.strictEqual(renderArgs.crownDevelopmentFields.hearingDate, '17 December 2020');
+			assert.strictEqual(renderArgs.crownDevelopmentFields.hearingVenue, 'the venue');
 		});
 		it('should set isWithdrawn and isExpired correctly when application is withdrawn but not expired', async (context) => {
 			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
@@ -972,6 +499,276 @@ describe('application info controller', () => {
 				mockRes.render.mock.calls[0].arguments[0],
 				'views/applications/view/application-info/view.njk'
 			);
+		});
+
+		it('should display linked case banner when case is published', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn((query) => {
+						// First call is for the main application
+						if (query.where.id === 'cfe3dc29-1f63-45e6-81dd-da8183842bf8') {
+							return {
+								id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
+								reference: 'CROWN/2025/0000001',
+								linkedParentId: 'linked-case-id',
+								ParentCrownDevelopment: null,
+								ChildrenCrownDevelopment: [],
+								representationsPeriodStartDate: new Date('2025-01-01'),
+								representationsPeriodEndDate: new Date('2025-01-31'),
+								representationsPublishDate: '2025-10-09T09:00:00.000Z',
+								applicationAcceptedDate: '2025-10-09T09:00:00.000Z',
+								decisionDate: '2025-10-09T09:00:00.000Z',
+								siteEasting: 654321,
+								siteNorthing: 123456,
+								description: 'a new crown dev application',
+								ApplicantContact: { orgName: 'Test Name' },
+								Type: { displayName: 'Planning permission' },
+								Lpa: { name: 'System Test Borough Council' },
+								Event: { date: new Date('2020-12-17T03:24:00.000Z'), venue: 'the venue' },
+								stageId: APPLICATION_STAGE_ID.CONSULTATION,
+								Stage: { displayName: 'Consultation' },
+								procedureId: APPLICATION_PROCEDURE_ID.HEARING,
+								Procedure: { displayName: 'Hearing' },
+								DecisionOutcome: { displayName: 'Approved' },
+								withdrawnDate: null
+							};
+						}
+						// Second call is for linked case check
+						if (query.where.id === 'linked-case-id') {
+							return {
+								subTypeId: APPLICATION_SUB_TYPE_ID.PLANNING_PERMISSION,
+								publishDate: new Date('2024-12-01T00:00:00.000Z')
+							};
+						}
+						return null;
+					})
+				},
+				applicationUpdate: {
+					findFirst: mock.fn(() => null),
+					count: mock.fn(() => 0)
+				}
+			};
+			const handler = buildApplicationInformationPage({
+				db: mockDb,
+				config: {}
+			});
+			const mockReq = {
+				params: { applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8' },
+				baseUrl: '/applications'
+			};
+			const mockRes = {
+				status: mock.fn(),
+				render: mock.fn()
+			};
+			await handler(mockReq, mockRes);
+			assert.strictEqual(mockRes.render.mock.callCount(), 1);
+			const renderArgs = mockRes.render.mock.calls[0].arguments[1];
+			assert.ok(renderArgs.banner);
+			assert.strictEqual(renderArgs.banner.type, 'info');
+			assert.ok(renderArgs.banner.html.includes('This application is connected to a'));
+			assert.ok(renderArgs.banner.html.includes('planning permission application'));
+			assert.ok(renderArgs.banner.html.includes('href="/applications/linked-case-id/application-information"'));
+		});
+
+		it('should not display linked case banner when case is not published', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn((query) => {
+						// First call is for the main application
+						if (query.where.id === 'cfe3dc29-1f63-45e6-81dd-da8183842bf8') {
+							return {
+								id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
+								reference: 'CROWN/2025/0000001',
+								linkedParentId: 'linked-case-id',
+								ParentCrownDevelopment: null,
+								ChildrenCrownDevelopment: [],
+								representationsPeriodStartDate: new Date('2025-01-01'),
+								representationsPeriodEndDate: new Date('2025-01-31'),
+								representationsPublishDate: '2025-10-09T09:00:00.000Z',
+								applicationAcceptedDate: '2025-10-09T09:00:00.000Z',
+								decisionDate: '2025-10-09T09:00:00.000Z',
+								siteEasting: 654321,
+								siteNorthing: 123456,
+								description: 'a new crown dev application',
+								ApplicantContact: { orgName: 'Test Name' },
+								Type: { displayName: 'Planning permission' },
+								Lpa: { name: 'System Test Borough Council' },
+								Event: { date: new Date('2020-12-17T03:24:00.000Z'), venue: 'the venue' },
+								stageId: APPLICATION_STAGE_ID.CONSULTATION,
+								Stage: { displayName: 'Consultation' },
+								procedureId: APPLICATION_PROCEDURE_ID.HEARING,
+								Procedure: { displayName: 'Hearing' },
+								DecisionOutcome: { displayName: 'Approved' },
+								withdrawnDate: null
+							};
+						}
+						// Second call is for linked case check - future publish date means not yet published
+						if (query.where.id === 'linked-case-id') {
+							return {
+								subTypeId: APPLICATION_SUB_TYPE_ID.PLANNING_PERMISSION,
+								publishDate: new Date('2025-12-01T00:00:00.000Z')
+							};
+						}
+						return null;
+					})
+				},
+				applicationUpdate: {
+					findFirst: mock.fn(() => null),
+					count: mock.fn(() => 0)
+				}
+			};
+			const handler = buildApplicationInformationPage({
+				db: mockDb,
+				config: {}
+			});
+			const mockReq = {
+				params: { applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8' },
+				baseUrl: '/applications'
+			};
+			const mockRes = {
+				status: mock.fn(),
+				render: mock.fn()
+			};
+			await handler(mockReq, mockRes);
+			assert.strictEqual(mockRes.render.mock.callCount(), 1);
+			const renderArgs = mockRes.render.mock.calls[0].arguments[1];
+			assert.strictEqual(renderArgs.banner, null, 'banner should be null when linked case is not published');
+		});
+
+		it('should not display linked case banner when there is no linked case', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
+						reference: 'CROWN/2025/0000001',
+						linkedParentId: null,
+						ParentCrownDevelopment: null,
+						ChildrenCrownDevelopment: [],
+						representationsPeriodStartDate: new Date('2025-01-01'),
+						representationsPeriodEndDate: new Date('2025-01-31'),
+						representationsPublishDate: '2025-10-09T09:00:00.000Z',
+						applicationAcceptedDate: '2025-10-09T09:00:00.000Z',
+						decisionDate: '2025-10-09T09:00:00.000Z',
+						siteEasting: 654321,
+						siteNorthing: 123456,
+						description: 'a new crown dev application',
+						ApplicantContact: { orgName: 'Test Name' },
+						Type: { displayName: 'Planning permission' },
+						Lpa: { name: 'System Test Borough Council' },
+						Event: { date: new Date('2020-12-17T03:24:00.000Z'), venue: 'the venue' },
+						stageId: APPLICATION_STAGE_ID.CONSULTATION,
+						Stage: { displayName: 'Consultation' },
+						procedureId: APPLICATION_PROCEDURE_ID.HEARING,
+						Procedure: { displayName: 'Hearing' },
+						DecisionOutcome: { displayName: 'Approved' },
+						withdrawnDate: null
+					}))
+				},
+				applicationUpdate: {
+					findFirst: mock.fn(() => null),
+					count: mock.fn(() => 0)
+				}
+			};
+			const handler = buildApplicationInformationPage({
+				db: mockDb,
+				config: {}
+			});
+			const mockReq = {
+				params: { applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8' },
+				baseUrl: '/applications'
+			};
+			const mockRes = {
+				status: mock.fn(),
+				render: mock.fn()
+			};
+			await handler(mockReq, mockRes);
+			assert.strictEqual(mockRes.render.mock.callCount(), 1);
+			const renderArgs = mockRes.render.mock.calls[0].arguments[1];
+			assert.strictEqual(renderArgs.banner, null, 'banner should be null when there is no linked case');
+		});
+
+		it('should display a single merged banner when linked case and latest update are both present', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00') });
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn((query) => {
+						// First call is for the main application
+						if (query.where.id === 'cfe3dc29-1f63-45e6-81dd-da8183842bf8') {
+							return {
+								id: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8',
+								reference: 'CROWN/2025/0000001',
+								linkedParentId: 'linked-case-id',
+								ParentCrownDevelopment: null,
+								ChildrenCrownDevelopment: [],
+								representationsPeriodStartDate: new Date('2025-01-01'),
+								representationsPeriodEndDate: new Date('2025-01-31'),
+								representationsPublishDate: '2025-10-09T09:00:00.000Z',
+								applicationAcceptedDate: '2025-10-09T09:00:00.000Z',
+								decisionDate: '2025-10-09T09:00:00.000Z',
+								siteEasting: 654321,
+								siteNorthing: 123456,
+								description: 'a new crown dev application',
+								ApplicantContact: { orgName: 'Test Name' },
+								Type: { displayName: 'Planning permission' },
+								Lpa: { name: 'System Test Borough Council' },
+								Event: { date: new Date('2020-12-17T03:24:00.000Z'), venue: 'the venue' },
+								stageId: APPLICATION_STAGE_ID.CONSULTATION,
+								Stage: { displayName: 'Consultation' },
+								procedureId: APPLICATION_PROCEDURE_ID.HEARING,
+								Procedure: { displayName: 'Hearing' },
+								DecisionOutcome: { displayName: 'Approved' },
+								withdrawnDate: null
+							};
+						}
+						// Second call is for linked case check
+						if (query.where.id === 'linked-case-id') {
+							return {
+								subTypeId: APPLICATION_SUB_TYPE_ID.PLANNING_PERMISSION,
+								publishDate: new Date('2024-12-01T00:00:00.000Z')
+							};
+						}
+						return null;
+					})
+				},
+				applicationUpdate: {
+					findFirst: mock.fn(() => ({
+						id: 'app-update-01',
+						details: 'an update',
+						firstPublished: new Date('2020-12-17T03:24:00.000Z')
+					})),
+					count: mock.fn(() => 3)
+				}
+			};
+			const handler = buildApplicationInformationPage({
+				db: mockDb,
+				config: {}
+			});
+			const mockReq = {
+				params: { applicationId: 'cfe3dc29-1f63-45e6-81dd-da8183842bf8' },
+				baseUrl: '/applications'
+			};
+			const mockRes = {
+				status: mock.fn(),
+				render: mock.fn()
+			};
+			await handler(mockReq, mockRes);
+			assert.strictEqual(mockRes.render.mock.callCount(), 1);
+			const renderArgs = mockRes.render.mock.calls[0].arguments[1];
+
+			assert.ok(renderArgs.banner);
+			assert.strictEqual(renderArgs.banner.type, 'info');
+			assert.ok(renderArgs.banner.html.includes('<ul class="govuk-list govuk-list--bullet">'));
+			assert.ok(renderArgs.banner.html.includes('This application is connected to a'));
+			assert.ok(renderArgs.banner.html.includes('planning permission application'));
+			assert.ok(renderArgs.banner.html.includes('href="/applications/linked-case-id/application-information"'));
+			assert.ok(renderArgs.banner.html.includes('Latest update'));
+			assert.ok(renderArgs.banner.html.includes('17 December 2020'));
+			assert.ok(renderArgs.banner.html.includes('an update'));
+			assert.ok(renderArgs.banner.html.includes('View all updates'));
+			assert.ok(renderArgs.banner.html.includes('href="/applications/application-updates"'));
 		});
 	});
 });

--- a/apps/portal/src/app/views/applications/view/application-info/view.njk
+++ b/apps/portal/src/app/views/applications/view/application-info/view.njk
@@ -33,25 +33,14 @@
         <div class="govuk-grid-column-two-thirds">
 
             {{ distressingContentBanner(crownDevelopmentFields.containsDistressingContent) }}
-            {% if hasLinkedCase %}
-                {{ govukNotificationBanner({
-                    html: '<p class="govuk-notification-banner__heading">This application is connected to a ' + linkedCaseLink + '.</p>'
-                }) }}
-            {% endif %}
-            {% if not isExpired %}
-            {% if latestApplicationUpdate %}
+
+            {% if banner %}
                 <div class="govuk-grid-row">
-                    {% set html %}
-                        <h3 class="govuk-notification-banner__heading">Latest update - {{ latestApplicationUpdate.firstPublished }}</h3>
-                        <p class="govuk-body pins-pre-line">{{ latestApplicationUpdate.details }}</p>
-                        <p><a class="govuk-notification-banner__link" href="{{ baseUrl }}/application-updates">View all updates</a></p>
-                    {% endset %}
-                    {{ govukNotificationBanner({
-                        html: html
-                    }) }}
+                    <div class="govuk-grid-column-full">
+                        {{ govukNotificationBanner(banner) }}
+                    </div>
                 </div>
             {% endif %}
-                {% endif %}
 
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">

--- a/packages/lib/views/distressing-content/distressing-content-banner.njk
+++ b/packages/lib/views/distressing-content/distressing-content-banner.njk
@@ -10,10 +10,12 @@
     {% endset %}
     {% if containsDistressingContent %}
         <div class="govuk-grid-row">
-            {{ govukNotificationBanner({
-                titleText: "Important",
-                html: html
-            }) }}
+            <div class="govuk-grid-column-full">
+                {{ govukNotificationBanner({
+                    titleText: "Important",
+                    html: html
+                }) }}
+            </div>
         </div>
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Describe your changes

- Combine banners on application info page: application updates and linked cases
- Add `govuk-grid-column-full` to distressing content banner to standardise column spacing

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1558
<img width="694" height="559" alt="image" src="https://github.com/user-attachments/assets/90d6c139-30c7-4ef5-86da-50d2752fb133" />
