### PR TITLE
fix(portal): correct mapping written representation category in sharepoint

### DIFF
--- a/packages/lib/documents/categories.test.ts
+++ b/packages/lib/documents/categories.test.ts
@@ -34,7 +34,7 @@ describe('Document Categories', () => {
 			assert.deepStrictEqual(getCategorySharePointNames(), [
 				'Application',
 				'LPA Questionnaire',
-				'Written Representations',
+				'Written Representation',
 				'Inquiry',
 				'Hearing',
 				'Decision'
@@ -66,7 +66,7 @@ describe('Document Categories', () => {
 		const mappings = [
 			{ sharepoint: 'Application', value: 'application' },
 			{ sharepoint: 'LPA Questionnaire', value: 'lpaQuestionnaire' },
-			{ sharepoint: 'Written Representations', value: 'writtenRepresentations' },
+			{ sharepoint: 'Written Representation', value: 'writtenRepresentations' },
 			{ sharepoint: 'Inquiry', value: 'inquiry' },
 			{ sharepoint: 'Hearing', value: 'hearing' },
 			{ sharepoint: 'Decision', value: 'decision' }
@@ -91,7 +91,7 @@ describe('Document Categories', () => {
 		const mappings = [
 			{ value: 'application', sharepoint: 'Application' },
 			{ value: 'lpaQuestionnaire', sharepoint: 'LPA Questionnaire' },
-			{ value: 'writtenRepresentations', sharepoint: 'Written Representations' },
+			{ value: 'writtenRepresentations', sharepoint: 'Written Representation' },
 			{ value: 'inquiry', sharepoint: 'Inquiry' },
 			{ value: 'hearing', sharepoint: 'Hearing' },
 			{ value: 'decision', sharepoint: 'Decision' }

--- a/packages/lib/documents/categories.ts
+++ b/packages/lib/documents/categories.ts
@@ -24,7 +24,7 @@ export const DOCUMENT_CATEGORIES: ReadonlyArray<Readonly<CategoryDefinition>> = 
 		alwaysShow: true
 	}),
 	Object.freeze({
-		sharepointName: 'Written Representations',
+		sharepointName: 'Written Representation',
 		displayName: 'Written Representations',
 		value: 'writtenRepresentations',
 		alwaysShow: false

--- a/packages/lib/documents/view-model.test.js
+++ b/packages/lib/documents/view-model.test.js
@@ -122,10 +122,10 @@ describe('view-model', () => {
 			assert.deepStrictEqual(mapDriveItemToViewModel(driveItem), expected);
 		});
 
-		it('should map Written Representations category correctly', () => {
+		it('should map Written Representation category correctly', () => {
 			const driveItem = createBaseDriveItem({
 				createdDateTime: '2025-02-13T16:56:00Z',
-				listItem: { fields: { Category: 'Written Representations' } }
+				listItem: { fields: { Category: 'Written Representation' } }
 			});
 			const expected = createExpectedViewModel({
 				createdDate: '13 Feb 2025',


### PR DESCRIPTION
## Describe your changes
This pull request updates the naming of the "Written Representations" document category to "Written Representation" throughout the codebase and associated tests to ensure consistency with the correct SharePoint category name.

**Document Category Naming Consistency:**

* Updated the `sharepointName` property in `DOCUMENT_CATEGORIES` in `categories.ts` from 'Written Representations' to 'Written Representation' to match the correct SharePoint name.
* Modified all relevant test cases in `categories.test.ts` to use 'Written Representation' instead of 'Written Representations' for both category lists and mapping tests. [[1]](diffhunk://#diff-bd9a62963223856a787c49ba042f0ac21f72a1687eda5d8396b2a4f912548243L37-R37) [[2]](diffhunk://#diff-bd9a62963223856a787c49ba042f0ac21f72a1687eda5d8396b2a4f912548243L69-R69) [[3]](diffhunk://#diff-bd9a62963223856a787c49ba042f0ac21f72a1687eda5d8396b2a4f912548243L94-R94)
* Updated the test description and test data in `view-model.test.js` to refer to 'Written Representation' and ensure the mapping logic reflects the new category name.
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1639
<img width="1691" height="1015" alt="Screenshot 2026-06-10 134537" src="https://github.com/user-attachments/assets/bd4acddc-052b-409b-9f15-f426084a50ce" />

