### PR TITLE
fix(manage): rename redacted comment field/url

### DIFF
--- a/apps/manage/src/app/views/cases/view/manage-reps/review/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/controller.js
@@ -22,13 +22,13 @@ import { fetchRedactionSuggestions, highlightRedactionSuggestions } from '#util/
  * @typedef {Object} ReviewControllers - controllers for review representation
  * @property {Handler} reviewRepresentationSubmission - handles POST for /review/task-list
  * @property {Handler} reviewRepresentation - handles POST for /review page and redirects users to /review/task-list page if there are no errors
- * @property {Handler} representationTaskList - handles GET for /review/task-list/comment
- * @property {Handler} reviewRepresentationComment - handles GET for /review/task-list/comment
- * @property {Handler} reviewRepresentationCommentDecision - handles POST for /review/task-list/comment
- * @property {Handler} redactRepresentation - handles GET for /review/task-list/comment/redact
- * @property {Handler} redactRepresentationPost - handles POST for /review/task-list/comment/redact
- * @property {Handler} redactConfirmation - handles GET for /review/task-list/comment/redact/confirmation
- * @property {Handler} acceptRedactedComment - handles POST for /review/task-list/comment/redact/confirmation
+ * @property {Handler} representationTaskList - handles GET for /review/task-list/representation
+ * @property {Handler} reviewRepresentationComment - handles GET for /review/task-list/representation
+ * @property {Handler} reviewRepresentationCommentDecision - handles POST for /review/task-list/representation
+ * @property {Handler} redactRepresentation - handles GET for /review/task-list/representation/redact
+ * @property {Handler} redactRepresentationPost - handles POST for /review/task-list/representation/redact
+ * @property {Handler} redactConfirmation - handles GET for /review/task-list/representation/redact/confirmation
+ * @property {Handler} acceptRedactedComment - handles POST for /review/task-list/representation/redact/confirmation
  * @property {Handler} reviewDistressingContent - handles GET for /review/task-list/distressing-content
  * @property {Handler} reviewDistressingContentDecision - handles POST for /review/task-list/distressing-content
  * @property {Handler} reviewRepresentationDocument - handles GET for /review/task-list/:itemId
@@ -226,7 +226,7 @@ export function buildReviewControllers(service, journeyId) {
 				reject: REPRESENTATION_STATUS_ID.REJECTED,
 				journeyTitle: 'Manage Reps',
 				layoutTemplate: 'views/layouts/forms-question.njk',
-				backLinkUrl: getTaskListURL(req.baseUrl, '/comment'),
+				backLinkUrl: getTaskListURL(req.baseUrl, '/representation'),
 				...viewData
 			});
 		},
@@ -263,7 +263,7 @@ export function buildReviewControllers(service, journeyId) {
 
 				updateRepReviewSession(req, representationRef, 'comment', { reviewDecision: reviewCommentDecision });
 				clearRepRedactedCommentSession(req, representationRef);
-				res.redirect(getTaskListURL(req.baseUrl, '/comment'));
+				res.redirect(getTaskListURL(req.baseUrl, '/representation'));
 			}
 		},
 		async redactRepresentation(req, res) {
@@ -346,7 +346,7 @@ export function buildReviewControllers(service, journeyId) {
 
 				await updateRepresentationItemsReviewStatus(req, db, logger);
 
-				res.redirect(getTaskListURL(req.baseUrl, '/comment'));
+				res.redirect(getTaskListURL(req.baseUrl, '/representation'));
 				return;
 			}
 			logger.info('saving redacted comment to session');
@@ -376,7 +376,7 @@ export function buildReviewControllers(service, journeyId) {
 			}
 
 			updateRepReviewSession(req, representationRef, 'comment', { reviewDecision: ACCEPT_AND_REDACT });
-			res.redirect(getTaskListURL(req.baseUrl, '/comment'));
+			res.redirect(getTaskListURL(req.baseUrl, '/representation'));
 		},
 
 		async reviewDistressingContent(req, res, viewData = {}) {
@@ -1096,6 +1096,15 @@ async function processUploadedFilesOnRejection(req, journeyId, representationRef
 	}
 }
 
-function getTaskListURL(baseUrl, urlSegment) {
-	return baseUrl.slice(0, baseUrl.indexOf(urlSegment));
+/**
+ * Get a parent URL by removing the last occurrence of `urlSegment` from `baseUrl`.
+ * Uses lastIndexOf to avoid substring collisions.
+ *
+ * @param {string} baseUrl
+ * @param {string} urlSegment
+ * @returns {string}
+ */
+export function getTaskListURL(baseUrl, urlSegment) {
+	const index = baseUrl.lastIndexOf(urlSegment);
+	return index === -1 ? baseUrl : baseUrl.slice(0, index);
 }

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/controller.test.js
@@ -5,6 +5,7 @@ import {
 	buildReviewControllers,
 	buildViewDocument,
 	clearRepReviewedSession,
+	getTaskListURL,
 	readRepReviewedSession,
 	viewRepresentationAwaitingReview,
 	viewReviewRedirect
@@ -463,7 +464,7 @@ describe('controller', () => {
 			const { reviewRepresentationComment } = buildReviewControllers({ db: mockDb, logger });
 
 			const mockReq = {
-				baseUrl: 'some-url-here/case-1/manage-representations/ref-1/review/comment',
+				baseUrl: 'some-url-here/case-1/manage-representations/ref-1/review/representation',
 				params: { id: 'case-1', representationRef: 'ref-1' },
 				body: {}
 			};
@@ -500,7 +501,7 @@ describe('controller', () => {
 			const { reviewRepresentationCommentDecision } = buildReviewControllers({ db: mockDb, logger });
 
 			const mockReq = {
-				baseUrl: 'some/url/ref-1/review/comment',
+				baseUrl: 'some/url/ref-1/review/representation',
 				params: { id: 'case-1', representationRef: 'ref-1' },
 				body: { reviewCommentDecision: 'approved' },
 				session: {}
@@ -524,7 +525,7 @@ describe('controller', () => {
 			const { reviewRepresentationCommentDecision } = buildReviewControllers({ db: mockDb, logger });
 
 			const mockReq = {
-				baseUrl: 'some/url/ref-1/review/task-list/comment',
+				baseUrl: 'some/url/ref-1/review/task-list/representation',
 				params: { id: 'case-1', representationRef: 'ref-1' },
 				body: { reviewCommentDecision: ACCEPT_AND_REDACT },
 				session: {}
@@ -535,7 +536,7 @@ describe('controller', () => {
 
 			assert.strictEqual(mockRes.redirect.mock.callCount(), 1);
 			const redirectUrl = mockRes.redirect.mock.calls[0].arguments[0];
-			assert.match(redirectUrl, /some\/url\/ref-1\/review\/task-list\/comment\/redact$/);
+			assert.match(redirectUrl, /some\/url\/ref-1\/review\/task-list\/representation\/redact$/);
 		});
 		it('should update document status if moving from rejected into non-rejected status', async () => {
 			const { reviewRepresentationCommentDecision } = buildReviewControllers({});
@@ -812,7 +813,7 @@ describe('controller', () => {
 			const { reviewRepresentationCommentDecision } = buildReviewControllers({ db: mockDb, logger });
 
 			const mockReq = {
-				baseUrl: 'some-url-here/case-1/manage-representations/ref-1/review/task-list/comment',
+				baseUrl: 'some-url-here/case-1/manage-representations/ref-1/review/task-list/representation',
 				params: { id: 'case-1', representationRef: 'ref-1' },
 				body: {},
 				session: {}
@@ -1156,7 +1157,7 @@ describe('controller', () => {
 			const { acceptRedactedComment } = buildReviewControllers({ db: mockDb, logger });
 
 			const mockReq = {
-				baseUrl: 'some-url-here/case-1/manage-representations/ref-1/review/task-list/comment',
+				baseUrl: 'some-url-here/case-1/manage-representations/ref-1/review/task-list/representation',
 				params: { id: 'case-1', representationRef: 'ref-1' },
 				session: {
 					reviewDecisions: {
@@ -1185,7 +1186,8 @@ describe('controller', () => {
 			const { acceptRedactedComment } = buildReviewControllers({});
 
 			const mockReq = {
-				baseUrl: 'some-url-here/case-1/manage-representations/ref-1/review/task-list/comment/redact/confirmation',
+				baseUrl:
+					'some-url-here/case-1/manage-representations/ref-1/review/task-list/representation/redact/confirmation',
 				params: { id: 'case-1', representationRef: 'ref-1' },
 				session: {
 					reviewDecisions: {
@@ -2509,6 +2511,51 @@ describe('controller', () => {
 				clearRepReviewedSession(mockReq, 'case-1');
 				assert.strictEqual(mockReq.session.cases['case-1'].representationReviewed, undefined);
 			});
+		});
+	});
+
+	describe('getTaskListURL', () => {
+		it('should remove urlSegment from the end of baseUrl', () => {
+			const baseUrl = 'some/url/ref-1/review/task-list/representation';
+			const result = getTaskListURL(baseUrl, '/representation');
+			assert.strictEqual(result, 'some/url/ref-1/review/task-list');
+		});
+
+		it('should handle /manage-representations in baseUrl without incorrect substring match', () => {
+			// This is the critical edge case - /representation should NOT match within /manage-representations
+			const baseUrl = 'some-url-here/case-1/manage-representations/ref-1/review/task-list/representation';
+			const result = getTaskListURL(baseUrl, '/representation');
+			assert.strictEqual(result, 'some-url-here/case-1/manage-representations/ref-1/review/task-list');
+		});
+
+		it('should handle /manage-representations without trailing /representation', () => {
+			const baseUrl = 'some-url-here/case-1/manage-representations/ref-1/review';
+			const result = getTaskListURL(baseUrl, '/review');
+			assert.strictEqual(result, 'some-url-here/case-1/manage-representations/ref-1');
+		});
+
+		it('should remove itemId from the end of baseUrl', () => {
+			const baseUrl = 'some-url-here/case-1/manage-representations/ref-1/review/task-list/DOC1234';
+			const result = getTaskListURL(baseUrl, '/DOC1234');
+			assert.strictEqual(result, 'some-url-here/case-1/manage-representations/ref-1/review/task-list');
+		});
+
+		it('should remove distressing-content from the end of baseUrl', () => {
+			const baseUrl = 'some/url/ref-1/review/task-list/distressing-content';
+			const result = getTaskListURL(baseUrl, '/distressing-content');
+			assert.strictEqual(result, 'some/url/ref-1/review/task-list');
+		});
+
+		it('should handle deeply nested URLs correctly', () => {
+			const baseUrl = '/cases/case-1/manage-representations/ref-1/review/task-list/representation/redact/confirmation';
+			const result = getTaskListURL(baseUrl, '/representation/redact/confirmation');
+			assert.strictEqual(result, '/cases/case-1/manage-representations/ref-1/review/task-list');
+		});
+
+		it('should return baseUrl unchanged when urlSegment is not found', () => {
+			const baseUrl = 'some-url-here/case-1/manage-representations/ref-1/review/task-list';
+			const result = getTaskListURL(baseUrl, '/missing-segment');
+			assert.strictEqual(result, baseUrl);
 		});
 	});
 });

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/review-comment.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/review-comment.njk
@@ -15,7 +15,7 @@
         <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-l">
                 <span class="govuk-caption-xl">{{ reference }}</span>
-                Review comment
+                Review representation
             </h1>
         </div>
     </div>

--- a/apps/manage/src/app/views/cases/view/manage-reps/task-list/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/task-list/index.js
@@ -20,7 +20,7 @@ export function createRoutes(service, journeyId) {
 	router.get('/', asyncHandler(representationTaskList));
 	router.post('/', asyncHandler(reviewRepresentationSubmission));
 
-	router.use('/comment', commentRoutes);
+	router.use('/representation', commentRoutes);
 	router.use('/distressing-content', distressingContentRoutes);
 	router.use('/:itemId', attachmentRoutes);
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/task-list/task-list.njk
+++ b/apps/manage/src/app/views/cases/view/manage-reps/task-list/task-list.njk
@@ -23,14 +23,14 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h2 class="govuk-heading-m">Review comment</h2>
+            <h2 class="govuk-heading-m">Review representation</h2>
             {{ govukTaskList({
                 items: [
                     {
                         title: {
-                            text: "Comment"
+                            text: "Representation"
                         },
-                        href: "task-list/comment",
+                        href: "task-list/representation",
                         status: {
                             tag: commentStatusTag
                         }

--- a/packages/lib/forms/custom-components/representation-comment/question.test.js
+++ b/packages/lib/forms/custom-components/representation-comment/question.test.js
@@ -81,7 +81,7 @@ describe('./src/dynamic-forms/components/text-entry-details/question.js', () => 
 				return 'back';
 			},
 			getCurrentQuestionUrl: () => {
-				return '/redacted-comment';
+				return '/redacted-representation';
 			},
 			response: {
 				answers: {}
@@ -96,9 +96,9 @@ describe('./src/dynamic-forms/components/text-entry-details/question.js', () => 
 			{
 				key: 'title',
 				value:
-					'It began with an ordinary morning. The air smelled faintly of dew, the street empty but for leaves drifting lazily. Johnathan Le-Smithard adjusted his collar, noting his watch was three minutes late—a stubborn old thing, loyal only to its own time. Across the street, a bakery opened, the scent of bread spilling into the cool air. A woman in a green scarf carried loaves in quiet balance. The square stirred slowly; Johnathan Le-Smithard wrote in his notebook, letting the day delay his errands, who... <a class="govuk-link govuk-link--no-visited-state" href="/redacted-comment">Read more</a>',
+					'It began with an ordinary morning. The air smelled faintly of dew, the street empty but for leaves drifting lazily. Johnathan Le-Smithard adjusted his collar, noting his watch was three minutes late—a stubborn old thing, loyal only to its own time. Across the street, a bakery opened, the scent of bread spilling into the cool air. A woman in a green scarf carried loaves in quiet balance. The square stirred slowly; Johnathan Le-Smithard wrote in his notebook, letting the day delay his errands, who... <a class="govuk-link govuk-link--no-visited-state" href="/redacted-representation">Read more</a>',
 				action: {
-					href: '/redacted-comment',
+					href: '/redacted-representation',
 					text: 'Change',
 					visuallyHiddenText: 'Question?'
 				}
@@ -117,7 +117,7 @@ describe('./src/dynamic-forms/components/text-entry-details/question.js', () => 
 				return 'back';
 			},
 			getCurrentQuestionUrl: () => {
-				return '/redacted-comment';
+				return '/redacted-representation';
 			},
 			response: {
 				answers: {}
@@ -134,7 +134,7 @@ describe('./src/dynamic-forms/components/text-entry-details/question.js', () => 
 				value:
 					'It began, as many stories do, with an ordinary morning. The air carried the faint smell of dew, and the street was empty save for a few scattered leaves drifting lazily in the wind. Jonathan Price adjusted his collar and glanced at his watch, noting with mild irritation that they were three minutes late.',
 				action: {
-					href: '/redacted-comment',
+					href: '/redacted-representation',
 					text: 'Change',
 					visuallyHiddenText: 'Question?'
 				}

--- a/packages/lib/forms/representations/question-utils.js
+++ b/packages/lib/forms/representations/question-utils.js
@@ -193,10 +193,10 @@ export function representationsContactQuestions({
 
 	questions[`${prefix}CommentRedacted`] = {
 		type: COMPONENT_TYPES.TEXT_ENTRY_REDACT,
-		title: 'Redacted Comment',
-		question: 'Representation Comment',
+		title: 'Redacted representation',
+		question: 'Representation',
 		fieldName: 'comment',
-		url: 'redacted-comment',
+		url: 'redacted-representation',
 		validators: [],
 		editable: false,
 		onlyShowRedactedValueForSummary: true,


### PR DESCRIPTION
## Describe your changes

- Rename "Redacted Comment"/"Review comment" to "Redacted representation"/"Review representation"
- Updating the URL from `/comment` to `/representation` required a change to `getTaskListURL` to use `lastIndexOf`, in order to avoid finding matches in the middle of the string. 
- New tests added for the above

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-470
<img width="704" height="130" alt="Screenshot 2026-06-11 104849" src="https://github.com/user-attachments/assets/14e9a3ee-021d-4fc4-941a-b865baacdd58" />
<img width="1015" height="268" alt="Screenshot 2026-06-11 104856" src="https://github.com/user-attachments/assets/5d3d473c-1da2-46a5-bc51-8425f7eb7a0a" />
<img width="874" height="791" alt="Screenshot 2026-06-11 104908" src="https://github.com/user-attachments/assets/775f8269-ebd1-4e43-b360-910f577a3ad1" />
