### PR TITLE
feat(portal): add service link to header

### DIFF
--- a/apps/portal/src/util/config-middleware.js
+++ b/apps/portal/src/util/config-middleware.js
@@ -29,6 +29,7 @@ export function addLocalsConfiguration({
 			appName,
 			cspNonce: res.locals.cspNonce,
 			headerTitle: 'Find a Crown development application',
+			headerUrl: '/',
 			footerLinks: [
 				{
 					text: 'Terms and conditions',

--- a/packages/lib/views/header/pins-header.njk
+++ b/packages/lib/views/header/pins-header.njk
@@ -16,6 +16,7 @@
         {{ govukServiceNavigation({
             classes: 'pins-navigation',
             serviceName: config.headerTitle,
+            serviceUrl: config.headerUrl,
             navigation: config.primaryNavigationLinks
         }) }}
 


### PR DESCRIPTION
## Describe your changes
This pull request updates the header navigation across the application to ensure the service name in the header links to the correct URL. The main changes involve passing a new `headerUrl` configuration value from the backend to the frontend template and using it in the header component.

Header navigation improvements:

* Added a `headerUrl` property to the locals configuration in `config-middleware.js`, setting it to `/applications` so the header title links to the applications page.
* Updated the `pins-header.njk` template to use the new `headerUrl` property for the service name link in the header navigation.
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1651
<img width="1247" height="332" alt="image" src="https://github.com/user-attachments/assets/641d8091-55ca-4a7a-8c85-b951d2fe8731" />

