### PR TITLE
test(lib): add assertIncludesObject for partial object testing

### DIFF
--- a/packages/lib/testing/custom-assert.test.js
+++ b/packages/lib/testing/custom-assert.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { assertRenders404Page } from '@pins/crowndev-lib/testing/custom-asserts.js';
+import { assertIncludesObject, assertRenders404Page } from '@pins/crowndev-lib/testing/custom-asserts.js';
 import { notFoundHandler } from '../middleware/errors.ts';
 
 describe('custom-assert', () => {
@@ -29,6 +29,62 @@ describe('custom-assert', () => {
 			await assert.doesNotReject(() => assertRenders404Page(functionToTest, mockReq, false), {
 				message: 'Got unwanted rejection.\nActual message: "error"'
 			});
+		});
+	});
+	describe('assertIncludesObject', () => {
+		it('should pass if the object subset is in included in the actual object', async () => {
+			const someObject = {
+				keyOne: 'something',
+				keyTwo: 2,
+				keyThree: ['array', 'of', 3, 'mixed', ['arrays', 'to', { key: 'test' }]]
+			};
+			const anotherObject = { ...someObject, ignoredKey: 'ignoreThis' };
+			assert.doesNotThrow(() => assertIncludesObject(anotherObject, someObject));
+		});
+		it('should not pass if the object subset is not included in the actual object', () => {
+			const someObject = {
+				keyOne: 'something',
+				keyTwo: 2
+			};
+			const mismatchedSubset = {
+				keyOne: 'different value'
+			};
+			assert.throws(() => assertIncludesObject(someObject, mismatchedSubset));
+		});
+		it('should not pass if the object is missing keys from the subset', () => {
+			const someObject = { keyOne: 'something' };
+			const subsetWithExtraKey = { keyOne: 'something', keyTwo: 'missing from actual' };
+			assert.throws(() => assertIncludesObject(someObject, subsetWithExtraKey));
+		});
+		it('should pass if a nested object subset matches', () => {
+			const actual = { nested: { a: 1, b: 2 }, other: 'x' };
+			const subset = { nested: { a: 1, b: 2 } };
+			assert.doesNotThrow(() => assertIncludesObject(actual, subset));
+		});
+		it('should not pass if a nested object only partially matches', () => {
+			const actual = { nested: { a: 1, b: 2, c: 3 } };
+			const subset = { nested: { a: 1, b: 2 } };
+			assert.throws(() => assertIncludesObject(actual, subset));
+		});
+		it('should pass if the expected subset is empty', () => {
+			const actual = { keyOne: 'something' };
+			assert.doesNotThrow(() => assertIncludesObject(actual, {}));
+		});
+		it('should not pass if values have different types', () => {
+			const actual = { count: '2' };
+			const subset = { count: 2 };
+			assert.throws(() => assertIncludesObject(actual, subset));
+		});
+		it('should pass if both actual and subset have null for a key', () => {
+			const actual = { key: null, other: 'x' };
+			const subset = { key: null };
+			assert.doesNotThrow(() => assertIncludesObject(actual, subset));
+		});
+
+		it('should not pass if subset expects null but actual has undefined', () => {
+			const actual = { key: undefined };
+			const subset = { key: null };
+			assert.throws(() => assertIncludesObject(actual, subset));
 		});
 	});
 });

--- a/packages/lib/testing/custom-asserts.js
+++ b/packages/lib/testing/custom-asserts.js
@@ -26,3 +26,14 @@ export async function assertRenders404Page(functionToTest, mockReq, isMiddleWare
 	assert.strictEqual(mockRes.status.mock.calls[0].arguments[0], 404);
 	assert.strictEqual(mockRes.render.mock.callCount(), 1);
 }
+
+/**
+ * Assert that the actual object includes the expected subset of key-value pairs.
+ * @param {Record<string, unknown>} actual
+ * @param {Record<string, unknown>} expectedSubset
+ */
+export function assertIncludesObject(actual, expectedSubset) {
+	for (const [key, value] of Object.entries(expectedSubset)) {
+		assert.deepStrictEqual(actual[key], value);
+	}
+}


### PR DESCRIPTION
## Describe your changes
This pull request adds a new custom assertion utility and comprehensive tests for it. The main focus is on introducing and testing the `assertIncludesObject` function, which checks if an object includes a given subset of key-value pairs.

### New Assertion Utility

* Added the `assertIncludesObject` function to `custom-asserts.js`, which asserts that an actual object includes all key-value pairs from a provided subset using deep equality checks.

### Testing Enhancements

* Added a new test suite in `custom-assert.test.js` for `assertIncludesObject`, covering various scenarios such as matching subsets, missing keys, mismatched values, nested objects, empty subsets, and type differences.
* Updated imports in `custom-assert.test.js` to include the new `assertIncludesObject` function.
## Issue ticket number and link
