### PR TITLE
refactor(macros): abstract nunjuck case list table macros to shared lib

### DIFF
--- a/apps/manage/src/app/views/cases/list/controller.js
+++ b/apps/manage/src/app/views/cases/list/controller.js
@@ -1,4 +1,5 @@
 import { createWhereClause, splitStringQueries } from '@pins/crowndev-lib/util/search-queries.js';
+import { insertWbr, formatStatusTag } from '@pins/crowndev-lib/util/string.ts';
 
 /**
  * @param {import('#service').ManageService} service
@@ -51,9 +52,15 @@ export function crownDevelopmentToViewModel(crownDevelopment) {
 		id: crownDevelopment.id,
 		reference: crownDevelopment.reference,
 		lpaName: crownDevelopment.Lpa?.name,
-		status: crownDevelopment.Status?.displayName,
+		status: formatStatusTag(crownDevelopment.Status?.displayName),
 		type: crownDevelopment.Type?.displayName,
-		location: ''
+		location: '',
+		referenceLink:
+			'<a class="govuk-link" href="/cases/' +
+			crownDevelopment.id +
+			'">' +
+			insertWbr(crownDevelopment.reference) +
+			'</a>'
 	};
 	if (crownDevelopment.SiteAddress) {
 		fields.location = addressToViewModel(crownDevelopment.SiteAddress);

--- a/apps/manage/src/app/views/cases/list/controller.test.js
+++ b/apps/manage/src/app/views/cases/list/controller.test.js
@@ -17,7 +17,7 @@ describe('case list', () => {
 			};
 			const result = crownDevelopmentToViewModel(input);
 			assert.strictEqual(result.lpaName, 'LPA 1');
-			assert.strictEqual(result.status, 'New');
+			assert.strictEqual(result.status, '<span class="govuk-tag">New</span>');
 			assert.strictEqual(result.type, 'Planning permission');
 		});
 		it(`should ignore relations that don't exist`, () => {
@@ -113,7 +113,10 @@ describe('case list', () => {
 			};
 			const mockDb = {
 				crownDevelopment: {
-					findMany: mock.fn(() => [{ id: 'id-1' }, { id: 'id-2' }])
+					findMany: mock.fn(() => [
+						{ id: 'id-1', reference: 'case/ref-1' },
+						{ id: 'id-2', reference: 'case/ref-2' }
+					])
 				}
 			};
 			const listCases = buildListCases({ db: mockDb, logger: mockLogger() });
@@ -133,7 +136,10 @@ describe('case list', () => {
 			};
 			const mockDb = {
 				crownDevelopment: {
-					findMany: mock.fn(() => [{ id: 'id-1' }, { id: 'id-2' }])
+					findMany: mock.fn(() => [
+						{ id: 'id-1', reference: 'case/ref-1' },
+						{ id: 'id-2', reference: 'case/ref-2' }
+					])
 				}
 			};
 			const listCases = buildListCases({ db: mockDb, logger: mockLogger() });

--- a/apps/manage/src/app/views/cases/list/view.njk
+++ b/apps/manage/src/app/views/cases/list/view.njk
@@ -1,9 +1,9 @@
 {% extends "views/layouts/main.njk" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "search-bar/search-bar.njk" import searchBar %}
+{% from "tables/tables.njk" import baseCaseListTable, baseManageHeaders, baseManageColumns %}
 
 {% block pageTitle %}
     Case list - All Cases - Manage a Crown Development Application
@@ -50,75 +50,8 @@
         <p class="govuk-body">No results were found.</p>
         <p class="govuk-body"><a href="/cases" class="govuk-link govuk-link--no-visited-state">Clear search</a> to view all cases.</p>
     {% else %}
-        {{ casesTable(crownDevelopments) }}
+        {{ baseCaseListTable(crownDevelopments,baseManageHeaders,baseManageColumns,true) }}
     {% endif %}
 {% endblock %}
 
-{% macro casesTable(developments) %}
-    {% set developments = [] %}
 
-    {% for development in crownDevelopments %}
-        {% set developments = (developments.push([
-            {
-                html: "<a class='govuk-link' href='/cases/" +  development.id +"'>" + development.reference + "</a>",
-                attributes: {
-                    "data-sort-value": development.reference
-                }
-            },
-            {
-                text: development.location,
-                classes: 'pins-white-space-pre-wrap'
-            },
-            {
-                text: development.lpaName
-            },
-            {
-                text: development.type
-            },
-            {
-                html: govukTag({text: development.status})
-            }
-        ]), developments) %}
-    {% endfor %}
-
-    {% set headers = [
-        {
-            text: 'Reference',
-            attributes: {
-            "aria-sort": "descending"
-            }
-        },
-        {
-            text: 'Site location',
-            attributes: {
-            "aria-sort": "none"
-            }
-        },
-        {
-            text: 'Local planning authority (LPA)',
-            attributes: {
-            "aria-sort": "none"
-            }
-        },
-        {
-          text: 'Application type',
-            attributes: {
-            "aria-sort": "none"
-            }
-        },
-        {
-            text: 'Status',
-            attributes: {
-            "aria-sort": "none"
-            }
-        }
-    ] %}
-
-    {{ govukTable({
-        attributes: {
-            "data-module": "moj-sortable-table"
-        },
-        head: headers,
-        rows: developments
-    }) }}
-{% endmacro %}

--- a/apps/manage/src/app/views/s62a/cases/list/controller.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.test.ts
@@ -215,7 +215,10 @@ describe('case list', () => {
 			} as unknown as Request;
 			const mockDb = {
 				s62aCase: {
-					findMany: mock.fn(() => [{ id: 'id-1' }, { id: 'id-2' }]),
+					findMany: mock.fn(() => [
+						{ id: 'id-1', reference: 'S62A/1' },
+						{ id: 'id-2', reference: 'S62A/2' }
+					]),
 					count: mock.fn(() => 2)
 				}
 			} as unknown;

--- a/apps/manage/src/app/views/s62a/cases/list/view-model.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/view-model.test.ts
@@ -8,7 +8,7 @@ describe('Case list view model', () => {
 	describe('genericDevelopmentToViewModel', () => {
 		const input = {
 			id: 'id-1',
-			reference: 'reference-id-1',
+			reference: 'REF/2025/001',
 			Type: {
 				displayName: 'Planning permission'
 			},
@@ -81,7 +81,8 @@ describe('Case list view model', () => {
 			const result = s62aToViewModel(input as unknown as S62ACasePayload) as S62ACaseView;
 			assert.deepStrictEqual(result, {
 				id: 'id-1',
-				reference: 'reference-id-1',
+				reference: 'REF/2025/001',
+				referenceLink: '<a class="govuk-link" href="/cases/id-1">REF/<wbr>2025/<wbr>001</a>',
 				lpaName: 'Test LPA',
 				status: undefined,
 				type: 'Planning permission',

--- a/apps/manage/src/app/views/s62a/cases/list/view-model.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/view-model.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { addressToViewModel } from '@pins/crowndev-lib/util/address.ts';
 import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
+import { insertWbr, formatStatusTag } from '@pins/crowndev-lib/util/string.ts';
 
 export interface S62ACaseView {
 	id: string;
@@ -38,14 +39,15 @@ export function s62aToViewModel(s62aCases: S62ACasePayload) {
 		id: s62aCases.id,
 		reference: s62aCases.reference,
 		lpaName: s62aCases.Lpa?.name,
-		status: s62aCases.S62aStatus?.displayName ?? undefined,
+		status: formatStatusTag(s62aCases.S62aStatus?.displayName),
 		type: s62aCases.Type?.displayName ?? undefined,
 		applicantOrganisations:
 			s62aCases.S62aToApplicants?.filter(
 				(relation) =>
 					relation.roleId === ORGANISATION_ROLES_ID.APPLICANT && typeof relation.Organisation?.name === 'string'
 			).map((item) => item.Organisation!.name) ?? [],
-		location: ''
+		location: '',
+		referenceLink: '<a class="govuk-link" href="/cases/' + s62aCases.id + '">' + insertWbr(s62aCases.reference) + '</a>'
 	};
 	if (s62aCases.SiteAddress) {
 		const address = addressToViewModel(s62aCases.SiteAddress);

--- a/apps/manage/src/app/views/s62a/cases/list/view.njk
+++ b/apps/manage/src/app/views/s62a/cases/list/view.njk
@@ -1,11 +1,10 @@
 {% extends "views/layouts/main.njk" %}
 
-{% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% import "pagination/pagination.njk" as pagination %}
 {% import "pagination/pagination-options.njk" as paginationOptions %}
 {% from "views/layouts/components/header.njk" import header %}
 {% from "search-bar/search-bar.njk" import searchBar %}
+{% from "tables/tables.njk" import baseCaseListTable, baseManageHeaders, baseManageColumns %}
 
 {% block pageTitle %}
     Case list - All Cases - Manage a Section 62A Development Application
@@ -51,7 +50,7 @@
                 </p>
                 {{ paginationOptions.renderPagination(paginationParams.selectedItemsPerPage, paginationParams.totalItems, baseUrl, queryParams) }}
                 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-                {{ casesTable(s62aCasesViewModels) }}
+                {{ baseCaseListTable(s62aCasesViewModels,baseManageHeaders,baseManageColumns,true) }}
             {% endif %}
         </div>
     </div>
@@ -60,72 +59,3 @@
     {{ pagination.renderPagination(paginationParams.pageNumber, paginationParams.totalPages, baseUrl, queryParams) }}
 
 {% endblock %}
-
-{% macro casesTable(s62aCases) %}
-    {% set cases = [] %}
-
-    {% for case in s62aCases %}
-        {% set cases = (cases.push([
-            {
-                html: "<a class='govuk-link' href='/s62a/cases/" +  case.id +"'>" + case.reference + "</a>",
-                attributes: {
-                    "data-sort-value": case.reference
-                }
-            },
-            {
-                text: case.location,
-                classes: 'pins-white-space-pre-wrap'
-            },
-            {
-                text: case.lpaName
-            },
-            {
-                text: case.type
-            },
-            {
-                html: govukTag({text: case.status})
-            }
-        ]), cases) %}
-    {% endfor %}
-
-    {% set headers = [
-        {
-            text: 'Reference',
-            attributes: {
-                "aria-sort": "descending"
-            }
-        },
-        {
-            text: 'Site location',
-            attributes: {
-                "aria-sort": "none"
-            }
-        },
-        {
-            text: 'Local planning authority (LPA)',
-            attributes: {
-                "aria-sort": "none"
-            }
-        },
-        {
-          text: 'Application type',
-            attributes: {
-                "aria-sort": "none"
-            }
-        },
-        {
-            text: 'Status',
-            attributes: {
-                "aria-sort": "none"
-            }
-        }
-    ] %}
-
-    {{ govukTable({
-        attributes: {
-            "data-module": "moj-sortable-table"
-        },
-        head: headers,
-        rows: cases
-    }) }}
-{% endmacro %}

--- a/apps/portal/src/app/views/applications/list/view.njk
+++ b/apps/portal/src/app/views/applications/list/view.njk
@@ -1,8 +1,8 @@
 {% extends "views/layouts/main.njk" %}
 
-{% from "govuk/components/table/macro.njk" import govukTable %}
 {% import "pagination/pagination.njk" as pagination %}
 {% import "pagination/pagination-options.njk" as paginationOptions %}
+{% from "tables/tables.njk" import baseCaseListTable, basePortalHeaders, basePortalColumns %}
 
 {% block pageHeading %}{% endblock %}
 
@@ -12,11 +12,6 @@
     </div>
     {{ super() }}
 {% endblock %}
-
-{% macro insertWbr(inputString) %}
-    {{ inputString | replace("/", "/<wbr>") | safe }}
-{% endmacro %}
-
 
 {% block pageContent %}
     <div class="govuk-grid-row">
@@ -33,7 +28,7 @@
                 {{ paginationOptions.renderPagination(paginationParams.selectedItemsPerPage, paginationParams.totalItems, baseUrl, queryParams) }}
                 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-                {{ crownDevelopmentsTable(crownDevelopmentsViewModels) }}
+                {{ baseCaseListTable(crownDevelopmentsViewModels,basePortalHeaders,basePortalColumns)}} 
             </div>
 
             {# if pageNumber and totalPages values are both 1 then pagination options not shown #}
@@ -41,38 +36,3 @@
         </div>
     </div>
 {% endblock %}
-
-{% macro crownDevelopmentsTable(crownDevelopments) %}
-    {% set crownDevelopmentRows = [] %}
-    {% for crownDevelopment in crownDevelopmentsViewModels %}
-        {% set applicantName = crownDevelopment.applicantOrganisations | join(", ") %}
-        {% set crownDevelopmentRows = (crownDevelopmentRows.push([
-            {
-                html: "<a class='govuk-link' href='/applications/" +  crownDevelopment.id + "/application-information'>" + insertWbr(crownDevelopment.reference) + "</a>"
-            },
-            {
-                text: applicantName
-            },
-            {
-                text: crownDevelopment.lpaName
-            }
-        ]), crownDevelopmentRows) %}
-    {% endfor %}
-
-    {{ govukTable({
-        captionClasses: "govuk-table__caption--m",
-        firstCellIsHeader: true,
-        head: [
-            {
-                text: "Application reference"
-            },
-            {
-                text: "Applicant name"
-            },
-            {
-                text: "Local planning authority"
-            }
-        ],
-        rows: crownDevelopmentRows
-    }) }}
-{% endmacro %}

--- a/apps/portal/src/app/views/applications/view/view-model.test.js
+++ b/apps/portal/src/app/views/applications/view/view-model.test.js
@@ -553,7 +553,7 @@ describe('view-model', () => {
 				withdrawnDate: null
 			};
 			const result = applicationListViewFormattingFunction(input);
-			assert.deepStrictEqual(result.applicantOrganisations, []);
+			assert.deepStrictEqual(result.applicantOrganisations, '');
 		});
 
 		it('should return empty applicantOrganisations array when Organisations is empty array', () => {
@@ -564,7 +564,7 @@ describe('view-model', () => {
 				withdrawnDate: null
 			};
 			const result = applicationListViewFormattingFunction(input);
-			assert.deepStrictEqual(result.applicantOrganisations, []);
+			assert.deepStrictEqual(result.applicantOrganisations, '');
 		});
 
 		it('should filter and map only applicant organisations', () => {
@@ -588,10 +588,8 @@ describe('view-model', () => {
 				withdrawnDate: null
 			};
 			const result = applicationListViewFormattingFunction(input);
-			assert.ok(Array.isArray(result.applicantOrganisations));
-			assert.strictEqual(result.applicantOrganisations.length, 2);
-			assert.strictEqual(result.applicantOrganisations[0], 'Applicant Organisation 1');
-			assert.strictEqual(result.applicantOrganisations[1], 'Applicant Organisation 2');
+			assert.ok(result.applicantOrganisations);
+			assert.strictEqual(result.applicantOrganisations, 'Applicant Organisation 1, Applicant Organisation 2');
 		});
 
 		it('should exclude non-applicant organisations', () => {
@@ -607,7 +605,7 @@ describe('view-model', () => {
 				withdrawnDate: null
 			};
 			const result = applicationListViewFormattingFunction(input);
-			assert.deepStrictEqual(result.applicantOrganisations, []);
+			assert.deepStrictEqual(result.applicantOrganisations, '');
 		});
 
 		it('should return undefined for withdrawnDate when not present', () => {
@@ -644,7 +642,8 @@ describe('view-model', () => {
 			};
 			const result = applicationListViewFormattingFunction(input);
 			assert.deepStrictEqual(result, {
-				applicantOrganisations: ['Test Applicant'],
+				applicantOrganisations: 'Test Applicant',
+				referenceLink: '<a class="govuk-link" href="/applications/id-1/application-information">reference-id-1</a>',
 				withdrawnDate: '20 March 2025'
 			});
 		});

--- a/apps/portal/src/app/views/applications/view/view-model.ts
+++ b/apps/portal/src/app/views/applications/view/view-model.ts
@@ -17,6 +17,8 @@ import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import type { BaseDevelopmentView } from '@pins/crowndev-lib/util/shared-view-model.ts';
 import { baseDevelopmentSelect, isInquiry, isHearing } from '@pins/crowndev-lib/util/shared-view-model.ts';
 
+import { insertWbr } from '@pins/crowndev-lib/util/string.ts';
+
 export const formatDate = (date: Date | null | undefined, options?: { format?: string }): string =>
 	formatDateForDisplay(date as Date | undefined, options);
 
@@ -158,7 +160,8 @@ export function crownDevelopmentToViewModel(
 }
 
 export interface CrownDevelopmentCaseListView extends BaseDevelopmentView {
-	applicantOrganisations: string[];
+	applicantOrganisations: string;
+	referenceLink: string;
 	withdrawnDate: string | undefined;
 }
 
@@ -178,14 +181,22 @@ export type CrownDevelopmentCaseListPayload = Prisma.CrownDevelopmentGetPayload<
  */
 export function applicationListViewFormattingFunction(crownDevelopment: CrownDevelopmentCaseListPayload) {
 	const extendedFields: Omit<CrownDevelopmentCaseListView, keyof BaseDevelopmentView | 'developmentContactEmail'> = {
-		applicantOrganisations: [],
+		applicantOrganisations: '',
+		referenceLink:
+			'<a class="govuk-link" href="/applications/' +
+			crownDevelopment.id +
+			'/application-information">' +
+			insertWbr(crownDevelopment.reference) +
+			'</a>',
 		withdrawnDate: undefined
 	};
 
 	if (crownDevelopment.Organisations && crownDevelopment.Organisations.length > 0) {
 		extendedFields.applicantOrganisations = crownDevelopment.Organisations.filter(
 			(organisation) => organisation.role === ORGANISATION_ROLES_ID.APPLICANT
-		).map((item) => item.Organisation.name);
+		)
+			.map((item) => item.Organisation.name)
+			.join(', ');
 	}
 
 	const withdrawnDateFormatted = formatDate(crownDevelopment.withdrawnDate, { format: 'd MMMM yyyy' });

--- a/apps/s62a-portal/src/app/views/list/view-model.test.ts
+++ b/apps/s62a-portal/src/app/views/list/view-model.test.ts
@@ -8,7 +8,7 @@ describe('view-model', () => {
 	describe('genericDevelopmentToViewModel', () => {
 		const input = {
 			id: 'id-1',
-			reference: 'reference-id-1',
+			reference: 'REF/2025/001',
 			Type: {
 				displayName: 'Planning permission'
 			},
@@ -79,9 +79,11 @@ describe('view-model', () => {
 			);
 			assert.deepStrictEqual(result, {
 				id: 'id-1',
-				reference: 'reference-id-1',
+				reference: 'REF/2025/001',
+				referenceLink:
+					'<a class="govuk-link" href="/applications/id-1/application-information">REF/<wbr>2025/<wbr>001</a>',
 				developmentContactEmail: 's62a.dev@planninginspectorate.gov.uk',
-				applicantOrganisations: ['Applicant organisation 1', 'Applicant organisation 2'],
+				applicantOrganisations: 'Applicant organisation 1, Applicant organisation 2',
 				description: 'A significant project',
 				stage: 'Inquiry',
 				lpaName: 'Test LPA',
@@ -127,10 +129,7 @@ describe('view-model', () => {
 				s62aViewFormattingFunction
 			) as S62ADevelopmentView;
 			assert.ok(result.applicantOrganisations);
-			assert.ok(Array.isArray(result.applicantOrganisations));
-			assert.ok(result.applicantOrganisations.length === 2);
-			assert.strictEqual(result.applicantOrganisations[0], 'Applicant organisation 1');
-			assert.strictEqual(result.applicantOrganisations[1], 'Applicant organisation 2');
+			assert.strictEqual(result.applicantOrganisations, 'Applicant organisation 1, Applicant organisation 2');
 		});
 	});
 });

--- a/apps/s62a-portal/src/app/views/list/view-model.ts
+++ b/apps/s62a-portal/src/app/views/list/view-model.ts
@@ -2,10 +2,12 @@ import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-sta
 import type { BaseDevelopmentView } from '@pins/crowndev-lib/util/shared-view-model.ts';
 import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { baseDevelopmentSelect } from '@pins/crowndev-lib/util/shared-view-model.ts';
+import { insertWbr } from '@pins/crowndev-lib/util/string.ts';
 
 export interface S62ADevelopmentView extends BaseDevelopmentView {
-	applicantOrganisations: string[];
+	applicantOrganisations: string;
 	withdrawnDate: Date | null;
+	referenceLink: string;
 }
 
 export const s62aDevelopmentSelect = {
@@ -24,14 +26,22 @@ export type S62ADevelopmentPayload = Prisma.CrownDevelopmentGetPayload<{
  */
 export function s62aViewFormattingFunction(s62aDevelopment: S62ADevelopmentPayload) {
 	const extendedFields: Omit<S62ADevelopmentView, keyof BaseDevelopmentView | 'developmentContactEmail'> = {
-		applicantOrganisations: [],
-		withdrawnDate: s62aDevelopment.withdrawnDate
+		applicantOrganisations: '',
+		withdrawnDate: s62aDevelopment.withdrawnDate,
+		referenceLink:
+			'<a class="govuk-link" href="/applications/' +
+			s62aDevelopment.id +
+			'/application-information">' +
+			insertWbr(s62aDevelopment.reference) +
+			'</a>'
 	};
 
 	if (s62aDevelopment.Organisations && s62aDevelopment.Organisations.length > 0) {
 		extendedFields.applicantOrganisations = s62aDevelopment.Organisations.filter(
 			(organisation) => organisation.role === ORGANISATION_ROLES_ID.APPLICANT
-		).map((item) => item.Organisation.name);
+		)
+			.map((item) => item.Organisation.name)
+			.join(', ');
 	}
 
 	return extendedFields;

--- a/apps/s62a-portal/src/app/views/list/view.njk
+++ b/apps/s62a-portal/src/app/views/list/view.njk
@@ -1,9 +1,6 @@
 {% extends "views/layouts/main.njk" %}
 
-{% from "govuk/components/table/macro.njk" import govukTable %}
-
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "tables/tables.njk" import baseCaseListTable, basePortalHeaders, basePortalColumns %}
 
 {% import "pagination/pagination.njk" as pagination %}
 {% import "pagination/pagination-options.njk" as paginationOptions %}
@@ -25,7 +22,7 @@
                         {{ paginationOptions.renderPagination(paginationParams.selectedItemsPerPage, paginationParams.totalItems, baseUrl, queryParams) }}
                         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     
-                        {{ s62aDevelopmentsTable(s62aDevelopmentsViewModels) }}
+                        {{ baseCaseListTable(s62aDevelopmentsViewModels,basePortalHeaders,basePortalColumns) }}
                     </div>
     
                 {# if pageNumber and totalPages values are both 1 then pagination options not shown #}
@@ -33,44 +30,3 @@
         </div>            
     </div>
 {% endblock %}
-
-{% macro insertWbr(inputString) %}
-    {{ inputString | replace("/", "/<wbr>") | safe }}
-{% endmacro %}
-
-{% macro s62aDevelopmentsTable(s62aDevelopments) %}
-    {% set s62aDevelopmentRows = [] %}
-    {% for s62aDevelopment in s62aDevelopments %}
-        {% if s62aDevelopment.applicantOrganisations and s62aDevelopment.applicantOrganisations.length > 0 %}
-            {% set applicantName = s62aDevelopment.applicantOrganisations | join(", ") %}
-        {% endif %}
-        {% set s62aDevelopmentRows = (s62aDevelopmentRows.push([
-            {
-                html: "<a class='govuk-link' href='/applications/" +  s62aDevelopment.id + "/application-information'>" + insertWbr(s62aDevelopment.reference) + "</a>"
-            },
-            {
-                text: applicantName
-            },
-            {
-                text: s62aDevelopment.lpaName
-            }
-        ]), s62aDevelopmentRows) %}
-    {% endfor %}
-
-    {{ govukTable({
-        captionClasses: "govuk-table__caption--m",
-        firstCellIsHeader: true,
-        head: [
-            {
-                text: "Application reference"
-            },
-            {
-                text: "Applicant name"
-            },
-            {
-                text: "Local planning authority"
-            }
-        ],
-        rows: s62aDevelopmentRows
-    }) }}
-{% endmacro %}

--- a/packages/lib/util/string.test.ts
+++ b/packages/lib/util/string.test.ts
@@ -7,7 +7,9 @@ import {
 	isString,
 	getFilenameStem,
 	isSafeRelativeUrl,
-	escapeHtml
+	escapeHtml,
+	insertWbr,
+	formatStatusTag
 } from './string.ts';
 
 describe('string util', () => {
@@ -252,6 +254,31 @@ describe('string util', () => {
 
 		it('should preserve numbers and punctuation other than special HTML characters', () => {
 			assert.strictEqual(escapeHtml('Hello, world! 123 ... @#$%'), 'Hello, world! 123 ... @#$%');
+		});
+	});
+	describe('insertWbr', () => {
+		it('should replace all forward slashes with /<wbr>', () => {
+			assert.strictEqual(insertWbr('a/b'), 'a/<wbr>b');
+			assert.strictEqual(insertWbr('a///b'), 'a/<wbr>/<wbr>/<wbr>b');
+			assert.strictEqual(insertWbr('2026/0000003'), '2026/<wbr>0000003');
+		});
+		it('should handle empty strings', () => {
+			assert.strictEqual(insertWbr(''), '');
+		});
+	});
+	describe('formatStatusTag', () => {
+		it('should wrap input string in correct gov-uk tag span formatting', () => {
+			assert.strictEqual(formatStatusTag('Test'), '<span class="govuk-tag">Test</span>');
+			assert.strictEqual(formatStatusTag('New'), '<span class="govuk-tag">New</span>');
+		});
+		it('should handle null input', () => {
+			assert.strictEqual(formatStatusTag(null), undefined);
+		});
+		it('should handle undefined input', () => {
+			assert.strictEqual(formatStatusTag(undefined), undefined);
+		});
+		it('should handle empty strings', () => {
+			assert.strictEqual(formatStatusTag(''), undefined);
 		});
 	});
 });

--- a/packages/lib/util/string.ts
+++ b/packages/lib/util/string.ts
@@ -82,3 +82,18 @@ const HTML_ESCAPES: Record<string, string> = {
 export function escapeHtml(value: string): string {
 	return value.replace(/[&<>"']/g, (c) => HTML_ESCAPES[c]);
 }
+
+/**
+ * Adds word break opportunities for pathing
+ */
+export function insertWbr(str?: string): string {
+	return typeof str === 'string' ? str.replace(/\//g, '/<wbr>') : '';
+}
+
+/**
+ * Formats case table status tags
+ */
+export function formatStatusTag(displayName?: string | null): string | undefined {
+	if (!displayName) return undefined;
+	return '<span class="govuk-tag">' + escapeHtml(displayName) + '</span>';
+}

--- a/packages/lib/views/tables/tables.njk
+++ b/packages/lib/views/tables/tables.njk
@@ -1,0 +1,98 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% macro baseCaseListTable(developments, headers, columns, isSortable) %}
+    {% set rows = [] %}
+    
+    {% for development in developments %}
+        {% set rowData = [] %}
+        
+        {% for column in columns %}
+            {% set rowData = (rowData.push({
+                html: development[column.field],
+                classes: column.classes
+            }), rowData) %}
+        {% endfor %}
+
+        {% set rows = (rows.push(rowData), rows) %}
+    {% endfor %}
+
+    {% if isSortable %}
+        {% set attributes = { "data-module": "moj-sortable-table" } %}
+    {% else %}
+        {% set attributes = {} %}
+    {% endif %}
+    
+    {{ govukTable({
+        attributes:  attributes,
+        firstCellIsHeader: true,
+        head: headers,
+        rows: rows
+    }) }}
+{% endmacro %}
+
+
+{% set basePortalHeaders = [
+    {text: "Application reference" },
+    {text: "Applicant name"},
+    {text: "Local planning authority"}
+] %}
+
+{% set basePortalColumns = [
+    {
+        field: "referenceLink"
+    },
+    {
+        field: "applicantOrganisations"
+    },
+    {
+        field: "lpaName"
+    }
+] %}
+
+{% set baseManageHeaders = [
+    {text: "Reference", 
+        attributes: {
+            "aria-sort": "descending"
+        }
+    },
+    {text: "Site location",
+        attributes: {
+            "aria-sort": "none"
+        }
+    },
+    {text: "Local planning authority (LPA)",
+        attributes: {
+                "aria-sort": "none"
+            }
+    },
+    {text: "Application type",
+        attributes: {
+            "aria-sort": "none"
+        }
+    },
+    {text: "Status",
+        attributes: {
+            "aria-sort": "none"
+        }
+    }
+] %}
+
+{% set baseManageColumns = [
+    {
+        field: "referenceLink"
+    },
+    {
+        field: "location",
+        classes: "pins-white-space-pre-wrap"
+    },
+    {
+        field: "lpaName"
+    },
+    {
+        field: "type"
+    },
+    {
+        field: "status"
+    }
+] %}


### PR DESCRIPTION
## Describe your changes
Refactored case list table formatting macros (Portal/S62A Portal: _crownDevelopmentsTable_, Manage: _casesTable_), and associated functional macro (_insertWbr_).

New macro (_genericCaseListTable_) in _/packages/lib/views/tables/tables.njk_ :

- Takes inputs (_developments, headers, columns, isSortable_)
- Displays as formatted _govukTable_

~Additional edits to BaseConfig variable names to standardise from cacheControl to staticCacheControl or dynamicCacheControl~

~BLOCKED - Awaiting merge of shared view model on ticket PEAS-9~

## Issue ticket number and link
PEAS-13 Abstracted Logic Ticket
[https://pins-ds.atlassian.net/browse/PEAS-13](https://pins-ds.atlassian.net/browse/PEAS-13)