### PR TITLE
feat: adds s62a create a case skeleton and q1

### DIFF
--- a/apps/manage/src/app/router.js
+++ b/apps/manage/src/app/router.js
@@ -5,6 +5,7 @@ import { createRoutes as createCasesRoutes } from './views/cases/index.js';
 import { createErrorRoutes } from './views/static/error/index.js';
 import { cacheNoCacheMiddleware } from '@pins/crowndev-lib/middleware/cache.ts';
 import { createNotifyRoutes } from './notify/router.js';
+import { createRoutes as createS62aRoutes } from './views/s62a/index.ts';
 
 /**
  * @param {import('#service').ManageService} service
@@ -16,6 +17,7 @@ export function buildRouter(service) {
 	const { router: authRoutes, guards: authGuards } = createAuthRoutesAndGuards(service);
 	const casesRoutes = createCasesRoutes(service);
 	const notifyRoutes = createNotifyRoutes(service);
+	const s62aRoutes = createS62aRoutes();
 
 	router.use('/', monitoringRoutes);
 	if (!service.notifyCallBackDisabled) {
@@ -43,6 +45,13 @@ export function buildRouter(service) {
 
 	router.get('/', (req, res) => res.redirect('/cases'));
 	router.use('/cases', casesRoutes);
+
+	if (service.isS62ALive) {
+		router.use('/s62a', s62aRoutes);
+	} else {
+		service.logger.warn('S62A not enabled; routes skipped');
+	}
+
 	router.use('/error', createErrorRoutes(service));
 
 	return router;

--- a/apps/manage/src/app/views/s62a/cases/create-a-case/index.ts
+++ b/apps/manage/src/app/views/s62a/cases/create-a-case/index.ts
@@ -1,0 +1,49 @@
+import { Router as createRouter, type Request } from 'express';
+import {
+	question,
+	buildSave,
+	redirectToUnansweredQuestion,
+	validate,
+	validationErrorHandler,
+	saveDataToSession,
+	buildGetJourneyResponseFromSession,
+	buildGetJourney,
+	type JourneyResponse,
+	type Journey,
+	list
+} from '@planning-inspectorate/dynamic-forms';
+import { JOURNEY_ID, createJourney } from './journey.ts';
+import { getQuestions } from './questions.ts';
+
+export function createRoutes() {
+	const router = createRouter({ mergeParams: true });
+
+	function makeGetJourneyCallback() {
+		return (req: Request, journeyResponse: JourneyResponse): Journey => {
+			const questions = getQuestions();
+			return createJourney(questions, journeyResponse, req);
+		};
+	}
+
+	const getQuestionJourney = buildGetJourney(makeGetJourneyCallback());
+	const getCheckJourney = buildGetJourney(makeGetJourneyCallback());
+
+	const getJourneyResponse = buildGetJourneyResponseFromSession(JOURNEY_ID);
+
+	router.get('/', getJourneyResponse, getQuestionJourney, redirectToUnansweredQuestion());
+
+	router.get('/:section/:question', getJourneyResponse, getQuestionJourney, question);
+
+	router.post(
+		'/:section/:question',
+		getJourneyResponse,
+		getQuestionJourney,
+		validate,
+		validationErrorHandler,
+		buildSave(saveDataToSession)
+	);
+
+	router.get('/check-your-answers', getJourneyResponse, getCheckJourney, (req, res) => list(req, res, '', {}));
+
+	return router;
+}

--- a/apps/manage/src/app/views/s62a/cases/create-a-case/journey.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/create-a-case/journey.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createJourney, JOURNEY_ID } from './journey.ts';
+import type { Question, JourneyResponse } from '@planning-inspectorate/dynamic-forms';
+import type { Request } from 'express';
+
+describe('s62a create a case journey', () => {
+	it('should error if used with the wrong router structure', () => {
+		const mockQuestions = {} as Record<string, Question>;
+		const mockRes = {} as unknown as JourneyResponse;
+		const mockReq = { baseUrl: '/s62a/cases/wrong-path' } as unknown as Request;
+
+		assert.throws(() => createJourney(mockQuestions, mockRes, mockReq), {
+			message: `not a valid request for the ${JOURNEY_ID} journey`
+		});
+	});
+
+	it('should create a journey with the correct configuration', () => {
+		const mockRes = {} as unknown as JourneyResponse;
+		const mockReq = { baseUrl: '/s62a/cases/create-a-case' } as unknown as Request;
+
+		const mockQuestions = new Proxy(
+			{},
+			{
+				get: (_target, prop) => ({ fieldName: prop })
+			}
+		) as unknown as Record<string, Question>;
+
+		const journey = createJourney(mockQuestions, mockRes, mockReq);
+
+		assert.strictEqual(journey.journeyId, JOURNEY_ID);
+		assert.strictEqual(journey.journeyTitle, 'S62A - Create a case');
+		assert.strictEqual(journey.returnToListing, false);
+		assert.strictEqual(journey.journeyTemplate, 'views/layouts/forms-question.njk');
+		assert.strictEqual(journey.taskListTemplate, 'views/layouts/forms-check-your-answers.njk');
+		assert.strictEqual(journey.taskListUrl, '/s62a/cases/create-a-case/check-your-answers');
+		assert.strictEqual(journey.initialBackLink, '/s62a/cases');
+
+		assert.strictEqual(journey.makeBaseUrl(mockRes), '/s62a/cases/create-a-case');
+	});
+
+	it('should create static sections with the correct order and questions', () => {
+		const mockRes = {} as unknown as JourneyResponse;
+		const mockReq = { baseUrl: '/s62a/cases/create-a-case' } as unknown as Request;
+
+		const mockQuestions = new Proxy(
+			{},
+			{
+				get: (_target, prop) => ({ fieldName: prop })
+			}
+		) as unknown as Record<string, Question>;
+
+		const journey = createJourney(mockQuestions, mockRes, mockReq);
+
+		const expectedSections = [
+			{
+				title: 'Create',
+				segment: 'questions',
+				questions: ['preApplicationOrApplication']
+			}
+		];
+
+		assert.strictEqual(
+			journey.sections.length,
+			expectedSections.length,
+			`Journey should have exactly ${expectedSections.length} section(s)`
+		);
+
+		expectedSections.forEach((expected, index) => {
+			const actualSection = journey.sections[index];
+
+			assert.ok(actualSection, `Section '${expected.title}' should exist`);
+			assert.strictEqual(actualSection.name, expected.title, `Section title mismatch at index ${index}`);
+			assert.strictEqual(actualSection.segment, expected.segment, `Section '${expected.title}' segment mismatch`);
+
+			assert.strictEqual(
+				actualSection.questions.length,
+				expected.questions.length,
+				`Section '${expected.title}' has incorrect number of questions`
+			);
+
+			expected.questions.forEach((qKey, qIndex) => {
+				const actualQuestion = actualSection.questions[qIndex];
+				assert.strictEqual(
+					actualQuestion.fieldName,
+					qKey,
+					`Section '${expected.title}' question at index ${qIndex} should be '${qKey}'`
+				);
+			});
+		});
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/create-a-case/journey.ts
+++ b/apps/manage/src/app/views/s62a/cases/create-a-case/journey.ts
@@ -1,0 +1,24 @@
+import { type Question, Section, Journey, type JourneyResponse } from '@planning-inspectorate/dynamic-forms';
+
+import type { Request } from 'express';
+
+export const JOURNEY_ID = 's62a-create-a-case';
+
+export function createJourney(questions: Record<string, Question>, response: JourneyResponse, req: Request) {
+	if (!req.baseUrl.endsWith('/create-a-case')) {
+		throw new Error(`not a valid request for the ${JOURNEY_ID} journey`);
+	}
+
+	return new Journey({
+		journeyId: JOURNEY_ID,
+		sections: [new Section('Create', 'questions').addQuestion(questions.preApplicationOrApplication)],
+		taskListUrl: 'check-your-answers',
+		journeyTemplate: 'views/layouts/forms-question.njk',
+		taskListTemplate: 'views/layouts/forms-check-your-answers.njk',
+		journeyTitle: 'S62A - Create a case',
+		returnToListing: false,
+		makeBaseUrl: () => req.baseUrl,
+		initialBackLink: '/s62a/cases',
+		response
+	});
+}

--- a/apps/manage/src/app/views/s62a/cases/create-a-case/questions.ts
+++ b/apps/manage/src/app/views/s62a/cases/create-a-case/questions.ts
@@ -1,0 +1,23 @@
+import {
+	createQuestions,
+	questionClasses,
+	COMPONENT_TYPES,
+	RequiredValidator
+} from '@planning-inspectorate/dynamic-forms';
+import { PRE_APPLICATION_OR_APPLICATIONS } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
+
+export function getQuestions() {
+	const questions = {
+		preApplicationOrApplication: {
+			type: COMPONENT_TYPES.RADIO,
+			title: 'Pre-application or application?',
+			question: 'Is this a pre-application or an application?',
+			fieldName: 'preApplicationOrApplication',
+			url: 'pre-application-or-application',
+			validators: [new RequiredValidator('Select whether this is a pre-application or an application')],
+			options: PRE_APPLICATION_OR_APPLICATIONS.map((t) => ({ text: t.displayName, value: t.id }))
+		}
+	};
+
+	return createQuestions(questions, questionClasses, {});
+}

--- a/apps/manage/src/app/views/s62a/cases/index.ts
+++ b/apps/manage/src/app/views/s62a/cases/index.ts
@@ -1,0 +1,11 @@
+import { Router as createRouter } from 'express';
+import { createRoutes as createCreateACaseRoutes } from './create-a-case/index.ts';
+
+export function createRoutes() {
+	const router = createRouter({ mergeParams: true });
+	const createACaseRoutes = createCreateACaseRoutes();
+
+	router.use('/create-a-case', createACaseRoutes);
+
+	return router;
+}

--- a/apps/manage/src/app/views/s62a/index.ts
+++ b/apps/manage/src/app/views/s62a/index.ts
@@ -1,0 +1,11 @@
+import { Router as createRouter } from 'express';
+import { createRoutes as createS62aCasesRoutes } from './cases/index.ts';
+
+export function createRoutes() {
+	const router = createRouter({ mergeParams: true });
+	const s62aCasesRoutes = createS62aCasesRoutes();
+
+	router.use('/cases', s62aCasesRoutes);
+
+	return router;
+}

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -31,7 +31,7 @@ apps_config = {
     application_updates_not_live = false
     multiple_applicants_not_live = true
     s62a_portal_not_live         = true
-    s62a_manage_not_live         = true
+    s62a_manage_not_live         = false
   }
 
   dynamic_cache_control = {

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -31,7 +31,7 @@ apps_config = {
     application_updates_not_live = false
     multiple_applicants_not_live = false
     s62a_portal_not_live         = true
-    s62a_manage_not_live         = true
+    s62a_manage_not_live         = false
   }
 
   dynamic_cache_control = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@azure/storage-blob": "^12.32.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@ministryofjustice/frontend": "^9.0.0",
-        "@planning-inspectorate/dynamic-forms": "^3.10.4",
+        "@planning-inspectorate/dynamic-forms": "^3.10.8",
         "@prisma/adapter-mssql": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "accessible-autocomplete": "^3.0.1",
@@ -1611,9 +1611,9 @@
       "link": true
     },
     "node_modules/@planning-inspectorate/dynamic-forms": {
-      "version": "3.10.4",
-      "resolved": "https://registry.npmjs.org/@planning-inspectorate/dynamic-forms/-/dynamic-forms-3.10.4.tgz",
-      "integrity": "sha512-BIfi8v+eWqmqfR85pZGfzRb+fbAmPWnR47Sdi4RAWtFz7Seine1nDnmnYon515rcO4BFy2fAP/iyxrjuYvq3vQ==",
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@planning-inspectorate/dynamic-forms/-/dynamic-forms-3.10.8.tgz",
+      "integrity": "sha512-eQr32llRix/DMtxuA6uhzZpRJ3+qVfOqmOXCcuUn2UkG21+FcDdWyhGMC7npiZEb9eb1D4X1p/KYcTv3HhkfzA==",
       "dependencies": {
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@azure/storage-blob": "^12.32.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@ministryofjustice/frontend": "^9.0.0",
-    "@planning-inspectorate/dynamic-forms": "^3.10.4",
+    "@planning-inspectorate/dynamic-forms": "^3.10.8",
     "@prisma/adapter-mssql": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "accessible-autocomplete": "^3.0.1",

--- a/packages/database/src/seed/s62a/data-static.ts
+++ b/packages/database/src/seed/s62a/data-static.ts
@@ -1,0 +1,15 @@
+export const PRE_APPLICATION_OR_APPLICATION_ID = Object.freeze({
+	PRE_APPLICATION: 'pre-application',
+	APPLICATION: 'application'
+} as const);
+
+export const PRE_APPLICATION_OR_APPLICATIONS = [
+	{
+		id: PRE_APPLICATION_OR_APPLICATION_ID.PRE_APPLICATION,
+		displayName: 'Pre-application'
+	},
+	{
+		id: PRE_APPLICATION_OR_APPLICATION_ID.APPLICATION,
+		displayName: 'Application'
+	}
+];


### PR DESCRIPTION
## Describe your changes
- Adds the skeleton for create a case + Q1
- Updates `dynamic-forms` to have fixed TS types
- Creates the basic routing structure for S62A

## Issue ticket number and link
[PEAS-54](https://pins-ds.atlassian.net/browse/PEAS-54)

## Implementation
<img width="600" height="61" alt="Screenshot 2026-06-18 at 16 29 42" src="https://github.com/user-attachments/assets/1ff7dfc9-f79f-42b8-a8ba-e9fd158a1a0d" />
<img width="786" height="547" alt="Screenshot 2026-06-18 at 16 29 48" src="https://github.com/user-attachments/assets/66a6d4ba-f405-49ce-97c3-7f850c73ce56" />
<img width="840" height="763" alt="Screenshot 2026-06-18 at 16 29 54" src="https://github.com/user-attachments/assets/96b789fc-b8b5-4a6d-ba38-9784e13fcf83" />
<img width="1097" height="443" alt="Screenshot 2026-06-18 at 16 30 01" src="https://github.com/user-attachments/assets/89888ac1-ede0-450d-9270-1bd931d6cb89" />
<img width="1017" height="449" alt="Screenshot 2026-06-18 at 16 30 07" src="https://github.com/user-attachments/assets/2e1b8f54-af92-44cc-910c-ba7008adc1f1" />



[PEAS-54]: https://pins-ds.atlassian.net/browse/PEAS-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ