### PR TITLE
feat/peas 111 manage s62a application list case table 

### DIFF
--- a/apps/manage/src/app/router.js
+++ b/apps/manage/src/app/router.js
@@ -45,13 +45,11 @@ export function buildRouter(service) {
 
 	router.get('/', (req, res) => res.redirect('/cases'));
 	router.use('/cases', casesRoutes);
-
 	if (service.isS62ALive) {
 		router.use('/s62a', s62aRoutes);
 	} else {
 		service.logger.warn('S62A not enabled; routes skipped');
 	}
-
 	router.use('/error', createErrorRoutes(service));
 
 	return router;

--- a/apps/manage/src/app/views/layouts/components/header.njk
+++ b/apps/manage/src/app/views/layouts/components/header.njk
@@ -1,4 +1,4 @@
-{% macro header(serviceName) %}
+{% macro header(serviceName, allCasesLink) %}
     <header class="govuk-header" id="pins-header" role="banner" data-module="govuk-header">
         <div class="pins-width-container">
             <div class="pins-row">
@@ -15,7 +15,7 @@
                     <nav class="govuk-header__navigation pins-header-navigation" aria-label="Menu">
                         <ul class="govuk-header__navigation-list">
                             <li class="govuk-header__navigation-item">
-                                <a class="govuk-header__link" href="/cases">All cases</a>
+                                <a class="govuk-header__link" href= {{ allCasesLink }} >All cases</a>
                             </li>
                             <li class="govuk-header__navigation-item">
                                 <a class="govuk-header__link" href="/auth/signout">Sign out</a>

--- a/apps/manage/src/app/views/layouts/main.njk
+++ b/apps/manage/src/app/views/layouts/main.njk
@@ -19,7 +19,7 @@
 {% endblock %}
 
 {% block header %}
-	{{ header('Manage a Crown Development Application') }}
+	{{ header('Manage a Crown Development Application', '/cases') }}
 {% endblock %}
 
 {% block containerStart %}

--- a/apps/manage/src/app/views/s62a/cases/index.ts
+++ b/apps/manage/src/app/views/s62a/cases/index.ts
@@ -1,13 +1,17 @@
-import { Router as createRouter } from 'express';
-import { createRoutes as createCreateACaseRoutes } from './create-a-case/index.ts';
-import { createRoutes as createCaseRoutes } from './view/index.ts';
 import type { ManageService } from '#service';
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '@pins/crowndev-lib/util/async-handler.ts';
+import { createRoutes as createCaseRoutes } from './view/index.ts';
+import { createRoutes as createCreateACaseRoutes } from './create-a-case/index.ts';
+import { buildCaseListPage } from './list/controller.ts';
 
 export function createRoutes(service: ManageService) {
 	const router = createRouter({ mergeParams: true });
 	const createACaseRoutes = createCreateACaseRoutes(service);
 	const caseRoutes = createCaseRoutes(service);
+	const homePageController = buildCaseListPage(service);
 
+	router.get('/', asyncHandler(homePageController));
 	router.use('/create-a-case', createACaseRoutes);
 	router.use('/:id', caseRoutes);
 

--- a/apps/manage/src/app/views/s62a/cases/list/controller.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import { buildCaseListPage } from './controller.ts';
+import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
+import type { ManageService } from '#service';
+import type { BaseLogger } from 'pino';
+import type { Request, Response } from 'express';
+
+const PAGINATION_TEST_CASES = [
+	{
+		name: 'should generate 1 page for 25 total items requested from page 1',
+		totalItems: 25,
+		itemsPerPage: 25,
+		requestedPage: 1,
+		expected: { totalPages: 1, resultsStartNumber: 1, resultsEndNumber: 25 }
+	},
+	{
+		name: 'should generate 2 pages and return the first 25 items for 50 total items requested from page 1',
+		totalItems: 50,
+		itemsPerPage: 25,
+		requestedPage: 1,
+		expected: { totalPages: 2, resultsStartNumber: 1, resultsEndNumber: 25 }
+	},
+	{
+		name: 'should generate 2 pages and return the last 25 items for 50 total items requested from page 2',
+		totalItems: 50,
+		itemsPerPage: 25,
+		requestedPage: 2,
+		expected: { totalPages: 2, resultsStartNumber: 26, resultsEndNumber: 50 }
+	},
+	{
+		name: 'should generate 3 pages and return the 2nd set of 25 items for 60 total items requested from page 2',
+		totalItems: 60,
+		itemsPerPage: 25,
+		requestedPage: 2,
+		expected: { totalPages: 3, resultsStartNumber: 26, resultsEndNumber: 50 }
+	},
+	{
+		name: 'should generate 3 pages and return the final 10 items for 60 total items requested from page 3 (partial page)',
+		totalItems: 60,
+		itemsPerPage: 25,
+		requestedPage: 3,
+		expected: { totalPages: 3, resultsStartNumber: 51, resultsEndNumber: 60 }
+	},
+	{
+		name: 'should generate 4 pages and return the 3rd set of 25 items for 100 total items requested from page 3',
+		totalItems: 100,
+		itemsPerPage: 25,
+		requestedPage: 3,
+		expected: { totalPages: 4, resultsStartNumber: 51, resultsEndNumber: 75 }
+	},
+	{
+		name: 'should generate 4 pages and return the last 25 items for 100 total items requested from page 4',
+		totalItems: 100,
+		itemsPerPage: 25,
+		requestedPage: 4,
+		expected: { totalPages: 4, resultsStartNumber: 76, resultsEndNumber: 100 }
+	}
+];
+
+/**
+ * Creates Mock cases, currently used for the pagination tests
+ * as they need a lot of data.
+ */
+const createMockCases = (count: number) => {
+	const cases = [];
+	for (let i = 1; i <= count; i++) {
+		cases.push({
+			id: `id-${i}`,
+			reference: `S62A/${i}`,
+			ApplicantContact: {
+				orgName: `Applicant ${i}`
+			},
+			Lpa: {
+				name: 'Test Council'
+			},
+			Stage: {
+				displayName: 'Test Stage'
+			},
+			Type: {
+				displayName: 'Test Type'
+			}
+		});
+	}
+	return cases;
+};
+
+describe('case list', () => {
+	describe('list published cases', () => {
+		const nunjucks = {
+			render: mock.fn((view, data) => 'mocked render' + view + data)
+		};
+		it('should render page without error', async () => {
+			const mockReq = {
+				params: {
+					id: 'some-id'
+				}
+			} as unknown as Request;
+
+			const mockResData = {
+				render: mock.fn((view, data) => nunjucks.render(view, data))
+			};
+			const mockRes = mockResData as unknown as Response;
+
+			const mockDb = {
+				s62aCase: {
+					findMany: mock.fn(() => [
+						{
+							id: 'id-1',
+							reference: 'S62A/1',
+							ApplicantContact: {
+								orgName: 'John Smith'
+							},
+							Lpa: {
+								name: 'System Test Borough Council'
+							},
+							Stage: {
+								displayName: 'Inquiry'
+							},
+							Type: {
+								displayName: 'Planning permission'
+							}
+						},
+						{
+							id: 'id-2',
+							reference: 'S62A/2',
+							ApplicantContact: {
+								orgName: 'Dave James'
+							},
+							Lpa: {
+								name: 'System Test Borough Council'
+							},
+							Stage: {
+								displayName: 'Hearing'
+							},
+							Type: {
+								displayName: 'Outline planning permission with some matters reserved'
+							}
+						}
+					]),
+					count: mock.fn(() => 2)
+				}
+			} as unknown;
+
+			const applicationList = buildCaseListPage({
+				db: mockDb,
+				logger: mockLogger() as unknown as BaseLogger,
+				s62aDevContactInfo: { email: 's62a.dev@gov.uk' }
+			} as unknown) as any;
+
+			await assert.doesNotReject(() => applicationList(mockReq, mockRes));
+
+			assert.strictEqual(mockResData.render.mock.callCount(), 1);
+			assert.strictEqual(mockResData.render.mock.calls[0].arguments.length, 2);
+			assert.strictEqual(mockResData.render.mock.calls[0].arguments[0], './views/s62a/cases/list/view.njk');
+			assert.strictEqual(mockResData.render.mock.calls[0].arguments[1].pageTitle, 'Manage Section 62A applications');
+			assert.strictEqual(mockResData.render.mock.calls[0].arguments[1].s62aCasesViewModels.length, 2);
+		});
+		it('should render page without error when no crown dev cases returned', async () => {
+			const mockReq = {
+				params: {
+					id: 'some-id'
+				}
+			} as unknown as Request;
+			const mockResData = {
+				render: mock.fn((view, data) => nunjucks.render(view, data))
+			};
+			const mockRes = mockResData as unknown as Response;
+
+			const mockDb = {
+				s62aCase: {
+					findMany: mock.fn(() => []),
+					count: mock.fn(() => 0)
+				}
+			} as unknown;
+
+			const service = {
+				db: mockDb,
+				logger: mockLogger() as unknown as BaseLogger,
+				s62aDevContactInfo: { email: 's62a.dev@gov.uk' }
+			} as unknown as ManageService;
+
+			const applicationList = buildCaseListPage(service);
+
+			await assert.doesNotReject(() => applicationList(mockReq, mockRes));
+
+			assert.strictEqual(mockResData.render.mock.callCount(), 1);
+			assert.strictEqual(mockResData.render.mock.calls[0].arguments.length, 2);
+			assert.strictEqual(mockResData.render.mock.calls[0].arguments[0], './views/s62a/cases/list/view.njk');
+			assert.deepStrictEqual(mockResData.render.mock.calls[0].arguments[1], {
+				pageTitle: 'Manage Section 62A applications',
+				s62aCasesViewModels: [],
+				baseUrl: '/s62a/cases',
+				containerClasses: 'pins-container-wide',
+				currentUrl: undefined,
+				queryParams: undefined,
+				paginationParams: {
+					pageNumber: 1,
+					resultsEndNumber: 0,
+					resultsStartNumber: 0,
+					selectedItemsPerPage: 25,
+					totalItems: 0,
+					totalPages: 0
+				}
+			});
+		});
+		describe('Pagination permutations', () => {
+			PAGINATION_TEST_CASES.forEach(({ name, totalItems, itemsPerPage, requestedPage, expected }) => {
+				it(name, async () => {
+					const mockRes = {
+						render: mock.fn((view, data) => nunjucks.render(view, data))
+					} as any;
+
+					const mockReq = {
+						query: {
+							itemsPerPage: itemsPerPage,
+							page: requestedPage
+						},
+						params: {
+							id: 'some-id'
+						}
+					} as unknown as Request;
+
+					const mockDb = {
+						s62aCase: {
+							findMany: mock.fn(() => createMockCases(expected.resultsEndNumber - expected.resultsStartNumber + 1)),
+							count: mock.fn(() => totalItems)
+						}
+					} as unknown;
+
+					const service = {
+						db: mockDb,
+						logger: mockLogger() as unknown as BaseLogger,
+						s62aDevContactInfo: { email: 's62a.dev@gov.uk' }
+					} as unknown as ManageService;
+
+					const applicationList = buildCaseListPage(service);
+					await assert.doesNotReject(() => applicationList(mockReq, mockRes));
+
+					assert.strictEqual(mockRes.render.mock.callCount(), 1);
+
+					const onlyRelevantKeys = {
+						...mockRes.render.mock.calls[0].arguments[1]
+					};
+					delete onlyRelevantKeys.s62aCasesViewModels;
+
+					assert.deepStrictEqual(onlyRelevantKeys, {
+						pageTitle: 'Manage Section 62A applications',
+						baseUrl: '/s62a/cases',
+						currentUrl: undefined,
+						containerClasses: 'pins-container-wide',
+						queryParams: {
+							itemsPerPage: itemsPerPage,
+							page: requestedPage
+						},
+						paginationParams: {
+							pageNumber: requestedPage,
+							resultsEndNumber: expected.resultsEndNumber,
+							resultsStartNumber: expected.resultsStartNumber,
+							selectedItemsPerPage: itemsPerPage,
+							totalItems: totalItems,
+							totalPages: expected.totalPages
+						}
+					});
+				});
+			});
+		});
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/list/controller.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.ts
@@ -1,0 +1,54 @@
+import type { ManageService } from '#service';
+import type { AsyncRequestHandler } from '@pins/crowndev-lib/util/async-handler.ts';
+import { wrapPrismaError } from '@pins/crowndev-lib/util/database.ts';
+import { createPaginationParams, getPaginationParams } from '@pins/crowndev-lib/views/pagination/pagination-utils.ts';
+
+import { s62aToViewModel, s62aCaseSelect } from './view-model.ts';
+import type { S62ACaseView, S62ACasePayload } from './view-model.ts';
+
+export function buildCaseListPage(service: ManageService): AsyncRequestHandler {
+	const { db, logger } = service;
+	return async (req, res) => {
+		const { pageSize, skipSize } = getPaginationParams(req);
+
+		let s62aCases: S62ACasePayload[] = [];
+		let totalItems: number = 0;
+
+		try {
+			[s62aCases, totalItems] = await Promise.all([
+				db.s62aCase.findMany({
+					select: s62aCaseSelect,
+					orderBy: {
+						reference: 'desc'
+					},
+					skip: skipSize,
+					take: pageSize
+				}),
+				db.s62aCase.count()
+			]);
+		} catch (error) {
+			wrapPrismaError({
+				error,
+				logger,
+				message: 'fetching database entries',
+				logParams: {}
+			});
+		}
+
+		logger.info(`Section 62A development list page: ${s62aCases.length} case(s) fetched`);
+
+		const s62aCasesViewModels: S62ACaseView[] = s62aCases.map((s62aCase) => s62aToViewModel(s62aCase));
+
+		const paginationParams = createPaginationParams(req, totalItems);
+
+		return res.render('./views/s62a/cases/list/view.njk', {
+			pageTitle: 'Manage Section 62A applications',
+			s62aCasesViewModels,
+			containerClasses: 'pins-container-wide',
+			currentUrl: req.originalUrl,
+			paginationParams,
+			baseUrl: '/s62a/cases',
+			queryParams: req.query && Object.keys(req.query).length > 0 ? req.query : undefined
+		});
+	};
+}

--- a/apps/manage/src/app/views/s62a/cases/list/view-model.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/view-model.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { s62aToViewModel } from './view-model.ts';
+import type { S62ACasePayload, S62ACaseView } from './view-model.ts';
+import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
+
+describe('Case list view model', () => {
+	describe('genericDevelopmentToViewModel', () => {
+		const input = {
+			id: 'id-1',
+			reference: 'reference-id-1',
+			Type: {
+				displayName: 'Planning permission'
+			},
+			ApplicantContact: {
+				orgName: 'Applicant Name'
+			},
+			Lpa: {
+				name: 'Test LPA'
+			},
+			SecondaryLpa: {
+				name: 'Test SecondaryLPA'
+			},
+			Stage: {
+				displayName: 'Inquiry'
+			},
+			Procedure: {
+				displayName: 'Inquiry'
+			},
+			Event: {
+				date: '2025-04-01T23:00:00.000Z',
+				venue: 'City hall',
+				statementsDate: '2025-04-30T23:00:00.000Z',
+				proofsOfEvidenceDate: '2025-10-09T23:00:00.000Z'
+			},
+			applicationAcceptedDate: '2025-10-09T23:00:00.000Z',
+			representationsPeriodStartDate: '2025-10-09T23:00:00.000Z',
+			representationsPeriodEndDate: '2025-10-09T23:00:00.000Z',
+			representationsPublishDate: '2025-10-09T09:00:00.000Z',
+			decisionDate: '2025-10-09T23:00:00.000Z',
+			DecisionOutcome: {
+				displayName: 'Approved'
+			},
+			description: 'A significant project',
+			SiteAddress: {
+				line1: 'Site Street',
+				townCity: 'Site Town',
+				postcode: 'Site ONE'
+			},
+			containsDistressingContent: true,
+			withdrawnDate: null,
+			S62aToApplicants: [
+				{
+					roleId: ORGANISATION_ROLES_ID.APPLICANT,
+					Organisation: { name: 'Applicant organisation 1' },
+					id: 'rel-1',
+					s62aId: 'case-1',
+					organisationId: 'org-1',
+					contactId: null
+				},
+				{
+					roleId: ORGANISATION_ROLES_ID.APPLICANT,
+					Organisation: { name: 'Applicant organisation 2' },
+					id: 'rel-2',
+					s62aId: 'case-1',
+					organisationId: 'org-2',
+					contactId: null
+				},
+				{
+					roleId: 'agent',
+					Organisation: { name: 'Agent organisation' },
+					id: 'rel-3',
+					s62aId: 'case-1',
+					organisationId: 'org-3',
+					contactId: null
+				}
+			]
+		};
+
+		it(`should map development view model`, () => {
+			const result = s62aToViewModel(input as unknown as S62ACasePayload) as S62ACaseView;
+			assert.deepStrictEqual(result, {
+				id: 'id-1',
+				reference: 'reference-id-1',
+				lpaName: 'Test LPA',
+				status: undefined,
+				type: 'Planning permission',
+				applicantOrganisations: ['Applicant organisation 1', 'Applicant organisation 2'],
+				location: 'Site Street, Site Town, Site ONE'
+			});
+		});
+		it('should map applicantOrganisations if present', () => {
+			const result = s62aToViewModel(input as unknown as S62ACasePayload) as S62ACaseView;
+			assert.ok(result.applicantOrganisations);
+			assert.ok(Array.isArray(result.applicantOrganisations));
+			assert.ok(result.applicantOrganisations.length === 2);
+			assert.strictEqual(result.applicantOrganisations[0], 'Applicant organisation 1');
+			assert.strictEqual(result.applicantOrganisations[1], 'Applicant organisation 2');
+		});
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/list/view-model.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/view-model.ts
@@ -1,0 +1,67 @@
+import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
+import { addressToViewModel } from '@pins/crowndev-lib/util/address.ts';
+import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
+
+export interface S62ACaseView {
+	id: string;
+	reference: string;
+	lpaName: string | undefined;
+	applicationType?: string;
+	applicationSubType?: string;
+	applicantOrganisations: string[];
+	location: string;
+	type?: string;
+	status?: string;
+	withdrawnDate?: Date | null;
+}
+
+export const s62aCaseSelect = {
+	id: true,
+	reference: true,
+	Lpa: { select: { name: true } },
+	description: true,
+	Type: { select: { displayName: true } },
+	S62aToApplicants: { include: { Organisation: { select: { name: true } } } },
+	SecondaryLpa: true,
+	S62aStatus: true,
+	SiteAddress: true,
+	siteEasting: true,
+	siteNorthing: true
+} satisfies Prisma.S62aCaseSelect;
+
+export type S62ACasePayload = Prisma.S62aCaseGetPayload<{
+	select: typeof s62aCaseSelect;
+}>;
+
+export function s62aToViewModel(s62aCases: S62ACasePayload) {
+	const fields = {
+		id: s62aCases.id,
+		reference: s62aCases.reference,
+		lpaName: s62aCases.Lpa?.name,
+		status: s62aCases.S62aStatus?.displayName ?? undefined,
+		type: s62aCases.Type?.displayName ?? undefined,
+		applicantOrganisations:
+			s62aCases.S62aToApplicants?.filter(
+				(relation) =>
+					relation.roleId === ORGANISATION_ROLES_ID.APPLICANT && typeof relation.Organisation?.name === 'string'
+			).map((item) => item.Organisation!.name) ?? [],
+		location: ''
+	};
+	if (s62aCases.SiteAddress) {
+		const address = addressToViewModel(s62aCases.SiteAddress);
+		fields.location = [
+			address?.addressLine1,
+			address?.addressLine2,
+			address?.townCity,
+			address?.county,
+			address?.postcode
+		]
+			.filter(Boolean)
+			.join(', ');
+	} else if (s62aCases.siteEasting || s62aCases.siteNorthing) {
+		fields.location = `Easting: ${s62aCases.siteEasting?.toString().padStart(6, '0') || '-'}\n`;
+		fields.location += `Northing: ${s62aCases.siteNorthing?.toString().padStart(6, '0') || '-'}`;
+	}
+
+	return fields;
+}

--- a/apps/manage/src/app/views/s62a/cases/list/view.njk
+++ b/apps/manage/src/app/views/s62a/cases/list/view.njk
@@ -1,0 +1,111 @@
+{% extends "views/layouts/main.njk" %}
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% import "pagination/pagination.njk" as pagination %}
+{% import "pagination/pagination-options.njk" as paginationOptions %}
+{% from "views/layouts/components/header.njk" import header %}
+{% from "search-bar/search-bar.njk" import searchBar %}
+
+{% block pageTitle %}
+    Case list - All Cases - Manage a Section 62A Development Application
+{% endblock %}
+
+{% block header %}
+	{{ header('Manage a Section 62A Application', baseUrl ) }}
+{% endblock %}
+
+{% block pageContent %}
+
+    <div class="govuk-grid-row row-inline">
+       
+
+    <div id="pagination" class="govuk-body">
+        {% if s62aCasesViewModels|length == 0 %}
+            <p class="govuk-body">No results were found.</p>
+            <p class="govuk-body"><a href="/s62a/cases" class="govuk-link govuk-link--no-visited-state">Clear search</a> to view all cases.</p>
+        {% else %}
+            <p class="govuk-body govuk-clearfix">
+                Showing <strong>{{ paginationParams.resultsStartNumber }}</strong>
+                to <strong>{{ paginationParams.resultsEndNumber if paginationParams.totalItems > paginationParams.resultsEndNumber else paginationParams.totalItems }}</strong>
+                of <strong>{{ paginationParams.totalItems }}</strong> results
+            </p>
+            {{ paginationOptions.renderPagination(paginationParams.selectedItemsPerPage, paginationParams.totalItems, baseUrl, queryParams) }}
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+            {{ casesTable(s62aCasesViewModels) }}
+        {% endif %}
+    </div>
+
+    {# if pageNumber and totalPages values are both 1 then pagination options not shown #}
+    {{ pagination.renderPagination(paginationParams.pageNumber, paginationParams.totalPages, baseUrl, queryParams) }}
+
+{% endblock %}
+
+{% macro casesTable(s62aCases) %}
+    {% set cases = [] %}
+
+    {% for case in s62aCases %}
+        {% set cases = (cases.push([
+            {
+                html: "<a class='govuk-link' href='/s62a/cases/" +  case.id +"'>" + case.reference + "</a>",
+                attributes: {
+                    "data-sort-value": case.reference
+                }
+            },
+            {
+                text: case.location,
+                classes: 'pins-white-space-pre-wrap'
+            },
+            {
+                text: case.lpaName
+            },
+            {
+                text: case.type
+            },
+            {
+                html: govukTag({text: case.status})
+            }
+        ]), cases) %}
+    {% endfor %}
+
+    {% set headers = [
+        {
+            text: 'Reference',
+            attributes: {
+                "aria-sort": "descending"
+            }
+        },
+        {
+            text: 'Site location',
+            attributes: {
+                "aria-sort": "none"
+            }
+        },
+        {
+            text: 'Local planning authority (LPA)',
+            attributes: {
+                "aria-sort": "none"
+            }
+        },
+        {
+          text: 'Application type',
+            attributes: {
+                "aria-sort": "none"
+            }
+        },
+        {
+            text: 'Status',
+            attributes: {
+                "aria-sort": "none"
+            }
+        }
+    ] %}
+
+    {{ govukTable({
+        attributes: {
+            "data-module": "moj-sortable-table"
+        },
+        head: headers,
+        rows: cases
+    }) }}
+{% endmacro %}


### PR DESCRIPTION
## Describe your changes
Application List ('All cases') page which serves as the landing page of the Manage s62A application service. 

- Lists all s62A cases in a sortable table
- Has both an empty state (no cases created) and a populated state
- Reached from the ‘All cases’ tab in the header and also the ‘Return to your case list’ CTA on the final page of the Create a Case journey

Tickets dependent on this branch:
 - PEAS-201 (Back office case list search)
 - PEAS-242 (Back office header)

## Issue ticket number and link
[https://pins-ds.atlassian.net/browse/PEAS-111](url)

[CROWN-1328]: https://pins-ds.atlassian.net/browse/CROWN-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PEAS-242]: https://pins-ds.atlassian.net/browse/PEAS-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ