### PR TITLE
Feat/peas 201 s62a manage application list search case reference

### DIFF
--- a/apps/manage/src/app/views/s62a/cases/list/controller.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.test.ts
@@ -5,6 +5,7 @@ import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
 import type { ManageService } from '#service';
 import type { BaseLogger } from 'pino';
 import type { Request, Response } from 'express';
+import { configureNunjucks } from '../../../../nunjucks.js';
 
 const PAGINATION_TEST_CASES = [
 	{
@@ -144,8 +145,7 @@ describe('case list', () => {
 
 			const applicationList = buildCaseListPage({
 				db: mockDb,
-				logger: mockLogger() as unknown as BaseLogger,
-				s62aDevContactInfo: { email: 's62a.dev@gov.uk' }
+				logger: mockLogger() as unknown as BaseLogger
 			} as unknown) as any;
 
 			await assert.doesNotReject(() => applicationList(mockReq, mockRes));
@@ -156,7 +156,7 @@ describe('case list', () => {
 			assert.strictEqual(mockResData.render.mock.calls[0].arguments[1].pageTitle, 'Manage Section 62A applications');
 			assert.strictEqual(mockResData.render.mock.calls[0].arguments[1].s62aCasesViewModels.length, 2);
 		});
-		it('should render page without error when no crown dev cases returned', async () => {
+		it('should render page without error when no Section 62a dev cases returned', async () => {
 			const mockReq = {
 				params: {
 					id: 'some-id'
@@ -204,64 +204,87 @@ describe('case list', () => {
 				}
 			});
 		});
-		describe('Pagination permutations', () => {
-			PAGINATION_TEST_CASES.forEach(({ name, totalItems, itemsPerPage, requestedPage, expected }) => {
-				it(name, async () => {
-					const mockRes = {
-						render: mock.fn((view, data) => nunjucks.render(view, data))
-					} as any;
+		it('should call db with search criteria', async () => {
+			const nunjucks = configureNunjucks();
+			// mock response that calls nunjucks to render a result
+			const mockRes = {
+				render: mock.fn((view, data) => nunjucks.render(view, data))
+			} as unknown as Response;
+			const mockReq = {
+				query: { searchCriteria: 'case/ref' }
+			} as unknown as Request;
+			const mockDb = {
+				s62aCase: {
+					findMany: mock.fn(() => [{ id: 'id-1' }, { id: 'id-2' }]),
+					count: mock.fn(() => 2)
+				}
+			} as unknown;
+			const listCases = buildCaseListPage({ db: mockDb, logger: mockLogger() });
+			await assert.doesNotReject(() => listCases(mockReq, mockRes));
+			assert.strictEqual(mockDb.s62aCase.findMany.mock.callCount(), 1);
+			assert.deepStrictEqual(mockDb.s62aCase.findMany.mock.calls[0].arguments[0].where, {
+				AND: [{ OR: [{ reference: { contains: 'case/ref' } }] }]
+			});
+		});
+	});
+	describe('Pagination permutations', () => {
+		const nunjucks = configureNunjucks();
+		PAGINATION_TEST_CASES.forEach(({ name, totalItems, itemsPerPage, requestedPage, expected }) => {
+			it(name, async () => {
+				const mockRes = {
+					render: mock.fn((view, data) => nunjucks.render(view, data))
+				} as any;
 
-					const mockReq = {
-						query: {
-							itemsPerPage: itemsPerPage,
-							page: requestedPage
-						},
-						params: {
-							id: 'some-id'
-						}
-					} as unknown as Request;
+				const mockReq = {
+					query: {
+						itemsPerPage: itemsPerPage,
+						page: requestedPage
+					},
+					params: {
+						id: 'some-id'
+					}
+				} as unknown as Request;
 
-					const mockDb = {
-						s62aCase: {
-							findMany: mock.fn(() => createMockCases(expected.resultsEndNumber - expected.resultsStartNumber + 1)),
-							count: mock.fn(() => totalItems)
-						}
-					} as unknown;
+				const mockDb = {
+					s62aCase: {
+						findMany: mock.fn(() => createMockCases(expected.resultsEndNumber - expected.resultsStartNumber + 1)),
+						count: mock.fn(() => totalItems)
+					}
+				} as unknown;
 
-					const service = {
-						db: mockDb,
-						logger: mockLogger() as unknown as BaseLogger,
-						s62aDevContactInfo: { email: 's62a.dev@gov.uk' }
-					} as unknown as ManageService;
+				const service = {
+					db: mockDb,
+					logger: mockLogger() as unknown as BaseLogger,
+					s62aDevContactInfo: { email: 's62a.dev@gov.uk' }
+				} as unknown as ManageService;
 
-					const applicationList = buildCaseListPage(service);
-					await assert.doesNotReject(() => applicationList(mockReq, mockRes));
+				const applicationList = buildCaseListPage(service);
+				await assert.doesNotReject(() => applicationList(mockReq, mockRes));
 
-					assert.strictEqual(mockRes.render.mock.callCount(), 1);
+				assert.strictEqual(mockRes.render.mock.callCount(), 1);
 
-					const onlyRelevantKeys = {
-						...mockRes.render.mock.calls[0].arguments[1]
-					};
-					delete onlyRelevantKeys.s62aCasesViewModels;
+				const onlyRelevantKeys = {
+					...mockRes.render.mock.calls[0].arguments[1]
+				};
+				delete onlyRelevantKeys.s62aCasesViewModels;
 
-					assert.deepStrictEqual(onlyRelevantKeys, {
-						pageTitle: 'Manage Section 62A applications',
-						baseUrl: '/s62a/cases',
-						currentUrl: undefined,
-						containerClasses: 'pins-container-wide',
-						queryParams: {
-							itemsPerPage: itemsPerPage,
-							page: requestedPage
-						},
-						paginationParams: {
-							pageNumber: requestedPage,
-							resultsEndNumber: expected.resultsEndNumber,
-							resultsStartNumber: expected.resultsStartNumber,
-							selectedItemsPerPage: itemsPerPage,
-							totalItems: totalItems,
-							totalPages: expected.totalPages
-						}
-					});
+				assert.deepStrictEqual(onlyRelevantKeys, {
+					pageTitle: 'Manage Section 62A applications',
+					baseUrl: '/s62a/cases',
+					currentUrl: undefined,
+					containerClasses: 'pins-container-wide',
+					queryParams: {
+						itemsPerPage: itemsPerPage,
+						page: requestedPage
+					},
+					paginationParams: {
+						pageNumber: requestedPage,
+						resultsEndNumber: expected.resultsEndNumber,
+						resultsStartNumber: expected.resultsStartNumber,
+						selectedItemsPerPage: itemsPerPage,
+						totalItems: totalItems,
+						totalPages: expected.totalPages
+					}
 				});
 			});
 		});

--- a/apps/manage/src/app/views/s62a/cases/list/controller.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.ts
@@ -2,6 +2,7 @@ import type { ManageService } from '#service';
 import type { AsyncRequestHandler } from '@pins/crowndev-lib/util/async-handler.ts';
 import { wrapPrismaError } from '@pins/crowndev-lib/util/database.ts';
 import { createPaginationParams, getPaginationParams } from '@pins/crowndev-lib/views/pagination/pagination-utils.ts';
+import { normaliseSearchQuery, splitStringQueries, createWhereClause } from '@pins/crowndev-lib/util/search-queries.js';
 
 import { s62aToViewModel, s62aCaseSelect } from './view-model.ts';
 import type { S62ACaseView, S62ACasePayload } from './view-model.ts';
@@ -11,12 +12,19 @@ export function buildCaseListPage(service: ManageService): AsyncRequestHandler {
 	return async (req, res) => {
 		const { pageSize, skipSize } = getPaginationParams(req);
 
+		const rawSearchCriteria = req.query?.searchCriteria;
+		const searchCriteriaParam = normaliseSearchQuery(rawSearchCriteria);
+		const searchCriteria = createWhereClause(splitStringQueries(searchCriteriaParam), [
+			{ fields: ['reference'], searchType: 'contains' }
+		]);
+
 		let s62aCases: S62ACasePayload[] = [];
 		let totalItems: number = 0;
 
 		try {
 			[s62aCases, totalItems] = await Promise.all([
 				db.s62aCase.findMany({
+					where: searchCriteria,
 					select: s62aCaseSelect,
 					orderBy: {
 						reference: 'desc'

--- a/apps/manage/src/app/views/s62a/cases/list/view.njk
+++ b/apps/manage/src/app/views/s62a/cases/list/view.njk
@@ -18,22 +18,42 @@
 {% block pageContent %}
 
     <div class="govuk-grid-row row-inline">
-       
-
-    <div id="pagination" class="govuk-body">
-        {% if s62aCasesViewModels|length == 0 %}
-            <p class="govuk-body">No results were found.</p>
-            <p class="govuk-body"><a href="/s62a/cases" class="govuk-link govuk-link--no-visited-state">Clear search</a> to view all cases.</p>
-        {% else %}
-            <p class="govuk-body govuk-clearfix">
-                Showing <strong>{{ paginationParams.resultsStartNumber }}</strong>
-                to <strong>{{ paginationParams.resultsEndNumber if paginationParams.totalItems > paginationParams.resultsEndNumber else paginationParams.totalItems }}</strong>
-                of <strong>{{ paginationParams.totalItems }}</strong> results
-            </p>
-            {{ paginationOptions.renderPagination(paginationParams.selectedItemsPerPage, paginationParams.totalItems, baseUrl, queryParams) }}
-            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-            {{ casesTable(s62aCasesViewModels) }}
-        {% endif %}
+        <div class="govuk-grid-column-two-thirds pins-dashboard-box">
+            <form id="search-bar-form" method="GET" action="{{ buildUrlWithParams(baseUrl, queryParams, { page: 1 }) }}">
+                {{ searchBar({
+                    input: {
+                        label: {
+                            text: "Search cases"
+                        },
+                        hint: {
+                            text: "To find a specific case, search by reference."
+                        },
+                        classes: "govuk-input govuk-input--width-30"
+                    },
+                    button: {
+                        text: "Search",
+                        classes: "govuk-button"
+                    }
+                }, searchValue) }}
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row row-inline">
+        <div id="pagination" class="govuk-body">
+            {% if s62aCasesViewModels|length == 0 %}
+                <p class="govuk-body">No results were found.</p>
+                <p class="govuk-body"><a href="/s62a/cases" class="govuk-link govuk-link--no-visited-state">Clear search</a> to view all cases.</p>
+            {% else %}
+                <p class="govuk-body govuk-clearfix">
+                    Showing <strong>{{ paginationParams.resultsStartNumber }}</strong>
+                    to <strong>{{ paginationParams.resultsEndNumber if paginationParams.totalItems > paginationParams.resultsEndNumber else paginationParams.totalItems }}</strong>
+                    of <strong>{{ paginationParams.totalItems }}</strong> results
+                </p>
+                {{ paginationOptions.renderPagination(paginationParams.selectedItemsPerPage, paginationParams.totalItems, baseUrl, queryParams) }}
+                <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+                {{ casesTable(s62aCasesViewModels) }}
+            {% endif %}
+        </div>
     </div>
 
     {# if pageNumber and totalPages values are both 1 then pagination options not shown #}

--- a/packages/lib/util/search-queries.js
+++ b/packages/lib/util/search-queries.js
@@ -13,6 +13,17 @@ export function splitStringQueries(query) {
 }
 
 /**
+ * Normalise a query input into a string or undefined
+ * @param {string | QueryString.ParsedQs | (string | QueryString.ParsedQs)[] | undefined} query - Query string, array of strings, or parsed query object
+ * @returns {string | undefined} - Normalised string, or undefined
+ */
+export const normaliseSearchQuery = (query) => {
+	const normalisedString = Array.isArray(query) ? query[0] : query;
+
+	return typeof normalisedString === 'string' ? normalisedString : undefined;
+};
+
+/**
  * @typedef {Object} SearchOption
  * @property {string} [parent] - The parent field to search in (optional), used for nested queries.
  * @property {string[]} fields - The fields to search in.

--- a/packages/lib/util/search-queries.test.js
+++ b/packages/lib/util/search-queries.test.js
@@ -1,6 +1,35 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { splitStringQueries, createWhereClause } from './search-queries.js';
+import { splitStringQueries, createWhereClause, normaliseSearchQuery } from './search-queries.js';
+
+describe('normaliseSearchQuery', () => {
+	it('returns string when input is string', () => {
+		assert.equal(normaliseSearchQuery('0000123'), '0000123');
+	});
+
+	it('returns undefined when input is undefined', () => {
+		assert.equal(normaliseSearchQuery(undefined), undefined);
+	});
+
+	it('returns undefined for non-specified input types', () => {
+		assert.equal(normaliseSearchQuery(123), undefined);
+		assert.equal(normaliseSearchQuery(true), undefined);
+		assert.equal(normaliseSearchQuery(null), undefined);
+	});
+
+	it('returns undefined when input is an empty array', () => {
+		assert.equal(normaliseSearchQuery([]), undefined);
+	});
+
+	it('returns undefined when input is a ParsedQs', () => {
+		const parsedQsObject = { key: 'value' };
+		assert.equal(normaliseSearchQuery(parsedQsObject), undefined);
+	});
+
+	it('returns first item of input if it is an array of strings', () => {
+		assert.equal(normaliseSearchQuery(['first', 'second']), 'first');
+	});
+});
 
 describe('getStringQueries', () => {
 	it('should split comma-separated values', () => {


### PR DESCRIPTION
## Describe your changes
Adding case search to the S62A manage application list ‘all cases’ page to allow back-office users to search for a case by reference. 

Depends on PEAS-111 (Back office case list)

## Issue ticket number and link
[https://pins-ds.atlassian.net/browse/PEAS-201](url)

[CROWN-1328]: https://pins-ds.atlassian.net/browse/CROWN-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PEAS-242]: https://pins-ds.atlassian.net/browse/PEAS-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ