### PR TITLE
fix(manage): reorder validation for lpa to avoid edgcase

### DIFF
--- a/apps/manage/src/app/views/s62a/cases/create-a-case/questions.ts
+++ b/apps/manage/src/app/views/s62a/cases/create-a-case/questions.ts
@@ -96,11 +96,11 @@ export function getQuestions(journeyResponse: JourneyResponse, isQuestionView: b
 			fieldName: 'lpaId',
 			url: 'local-planning-authority',
 			validators: [
+				new RequiredValidator('Enter the local planning authority'),
 				new SameAnswerValidator(
 					['secondaryLpaId'],
 					'Local planning authority cannot be the same as the secondary local planning authority'
-				),
-				new RequiredValidator('Enter the local planning authority')
+				)
 			],
 			options: lpaOptions
 		},
@@ -120,11 +120,11 @@ export function getQuestions(journeyResponse: JourneyResponse, isQuestionView: b
 			fieldName: 'secondaryLpaId',
 			url: 'secondary-local-planning-authority',
 			validators: [
+				new RequiredValidator('Enter the secondary local planning authority'),
 				new SameAnswerValidator(
 					['lpaId'],
 					'Secondary local planning authority cannot be the same as the local planning authority'
-				),
-				new RequiredValidator('Enter the secondary local planning authority')
+				)
 			],
 			options: lpaOptions
 		},


### PR DESCRIPTION
## Describe your changes
- Fixes a bug where if you entered junk into the LPA or 2nd LPA question, or selected a real answer and then deleted a part of it, the error message would fallback to the one about clashing names, rather than the expected "please enter an answer" message.
- Fix was to reorder the validation to make sure the RequiredValidator is checked first.

## Issue ticket number and link
[PEAS-239](https://pins-ds.atlassian.net/browse/PEAS-239)


[PEAS-239]: https://pins-ds.atlassian.net/browse/PEAS-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ