### PR TITLE
fix(manage): adds optional to phone question

### DIFF
--- a/apps/manage/src/app/views/s62a/cases/create-a-case/question-factories.ts
+++ b/apps/manage/src/app/views/s62a/cases/create-a-case/question-factories.ts
@@ -30,7 +30,7 @@ export const createLpaContactQuestion = (isSecondary: boolean) => {
 			{ fieldName: `${prefix}FirstName`, label: 'First name', formatJoinString: ' ' },
 			{ fieldName: `${prefix}LastName`, label: 'Last name' },
 			{ fieldName: `${prefix}EmailAddress`, label: 'Email address' },
-			{ fieldName: `${prefix}PhoneNumber`, label: 'Phone number' }
+			{ fieldName: `${prefix}PhoneNumber`, label: 'Phone number (optional)' }
 		],
 		validators: [
 			new MultiFieldInputValidator({


### PR DESCRIPTION
## Describe your changes
- Phone number question in LPA questions was missing the specced `(optional)` text

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PEAS-240
