### PR TITLE
feat: wip case view page boilerplate

### DIFF
--- a/apps/manage/src/app/sass/style.scss
+++ b/apps/manage/src/app/sass/style.scss
@@ -8,6 +8,7 @@ $font-family: arial, helvetica, sans-serif;
 );
 @use 'node_modules/govuk-frontend/dist/govuk/index' as govuk;
 @use './header';
+@use './sub-navigation';
 
 // set font-family for any autocomplete menu items
 .autocomplete__menu {

--- a/apps/manage/src/app/sass/sub-navigation.scss
+++ b/apps/manage/src/app/sass/sub-navigation.scss
@@ -1,0 +1,18 @@
+@use 'packages/lib/views/brand/pins-colors.scss' as brand;
+
+// Used on the S62A case details page, unlike standard has a green
+// background and a bold highlight.
+.pins-sub-navigation {
+	.moj-sub-navigation__item--active {
+		.moj-sub-navigation__link {
+			font-weight: bold;
+			text-decoration: none;
+		}
+	}
+
+	.moj-sub-navigation__link[aria-current='page'] {
+		&::before {
+			background-color: brand.$pins-green-200;
+		}
+	}
+}

--- a/apps/manage/src/app/views/s62a/cases/index.ts
+++ b/apps/manage/src/app/views/s62a/cases/index.ts
@@ -1,12 +1,15 @@
 import { Router as createRouter } from 'express';
 import { createRoutes as createCreateACaseRoutes } from './create-a-case/index.ts';
+import { createRoutes as createCaseRoutes } from './view/index.ts';
 import type { ManageService } from '#service';
 
 export function createRoutes(service: ManageService) {
 	const router = createRouter({ mergeParams: true });
 	const createACaseRoutes = createCreateACaseRoutes(service);
+	const caseRoutes = createCaseRoutes(service);
 
 	router.use('/create-a-case', createACaseRoutes);
+	router.use('/:id', caseRoutes);
 
 	return router;
 }

--- a/apps/manage/src/app/views/s62a/cases/view/controller.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/controller.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { buildViewCaseDetails, buildGetJourneyMiddleware } from './controller.ts';
+import type { ManageService } from '../../../../service.js';
+import type { Request, Response } from 'express';
+import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
+
+describe('S62A Controller Middleware', () => {
+	describe('buildGetJourneyMiddleware', () => {
+		let mockService: ManageService;
+		let dbFindUniqueCalls: Prisma.S62aCaseFindUniqueArgs[];
+
+		beforeEach(() => {
+			dbFindUniqueCalls = [];
+			mockService = {
+				db: {
+					s62aCase: {
+						findUnique: async (args: Prisma.S62aCaseFindUniqueArgs) => {
+							dbFindUniqueCalls.push(args);
+							return {
+								id: 'case-123',
+								reference: 'S62A/2026/0001',
+								description: 'Test',
+								S62aStatus: { id: 'NEW', name: 'New' }
+							};
+						}
+					}
+				},
+				logger: {
+					info: () => {},
+					error: () => {}
+				}
+			} as unknown as ManageService;
+		});
+
+		it('populates res.locals and calls next() on success', async () => {
+			const handler = buildGetJourneyMiddleware(mockService);
+
+			const req = {
+				params: { id: 'case-123', tab: 'overview' },
+				baseUrl: '/s62a/cases/case-123/overview'
+			} as unknown as Request;
+
+			const res = { locals: {} } as unknown as Response;
+			let nextCalled = false;
+
+			await handler(req, res, () => {
+				nextCalled = true;
+			});
+
+			assert.strictEqual(dbFindUniqueCalls.length, 1);
+			assert.deepStrictEqual(dbFindUniqueCalls[0].where, { id: 'case-123' });
+
+			assert.ok(res.locals.originalAnswers, 'originalAnswers should be populated');
+			assert.ok(res.locals.journeyResponse, 'journeyResponse should be instantiated');
+			assert.ok(res.locals.journey, 'journey should be created');
+			assert.strictEqual(res.locals.backLinkUrl, '/s62a/cases/case-123/overview');
+
+			assert.strictEqual(nextCalled, true, 'next() should be called on success');
+		});
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/view/controller.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/controller.ts
@@ -1,0 +1,66 @@
+import type { ManageService } from '#service';
+import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.ts';
+import type { AsyncRequestHandler } from '@pins/crowndev-lib/util/async-handler.ts';
+import { JourneyResponse, list } from '@planning-inspectorate/dynamic-forms';
+import { createJourney, JOURNEY_ID } from './journey.ts';
+import { getQuestions } from './questions.ts';
+import { getStringParam } from '@pins/crowndev-lib/util/params.ts';
+import { VIEW_TAB_ID, VIEW_TABS } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
+import { s62aCaseToViewModel } from './view-model.ts';
+
+export function buildViewCaseDetails(): AsyncRequestHandler {
+	return async (req, res) => {
+		const id = getStringParam(req.params, 'id');
+		const reference = getStringParam(res?.locals?.journeyResponse?.answers, 'reference');
+
+		const baseUrl = req.baseUrl;
+
+		await list(req, res, '', {
+			caseId: id,
+			reference,
+			baseUrl,
+			backLinkUrl: res.locals.backLinkUrl || '/s62a/cases',
+			backLinkText: 'Back to all applications',
+			currentUrl: req.originalUrl,
+			currentTab: req.params.tab || VIEW_TAB_ID.OVERVIEW,
+			viewTabs: VIEW_TABS,
+			// URL without the /:tab slug, needed for routing uses in FE.
+			cleanUrl: `/s62a/cases/${id}`
+		});
+	};
+}
+
+export function buildGetJourneyMiddleware(service: ManageService): AsyncRequestHandler {
+	const { db, logger } = service;
+
+	return async (req, res, next) => {
+		const id = getStringParam(req.params, 'id');
+
+		logger.info({ id }, 'view S62A case');
+
+		const s62aCase = await db.s62aCase.findUnique({
+			include: {
+				S62aStatus: true
+			},
+			where: { id }
+		});
+
+		if (s62aCase === null) {
+			return notFoundHandler(req, res);
+		}
+
+		const answers = s62aCaseToViewModel(s62aCase);
+
+		const questions = getQuestions();
+
+		// @ts-expect-error - we haven't defined the view model on the locals object
+		res.locals.originalAnswers = { ...answers };
+		// @ts-expect-error - we haven't defined the view model on the locals object
+		res.locals.journeyResponse = new JourneyResponse(JOURNEY_ID, 'ref', answers);
+		res.locals.journey = createJourney(questions, res.locals.journeyResponse, req);
+
+		res.locals.backLinkUrl = req.baseUrl;
+
+		if (next) next();
+	};
+}

--- a/apps/manage/src/app/views/s62a/cases/view/index.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/index.ts
@@ -1,0 +1,49 @@
+import type { ManageService } from '#service';
+import { Router as createRouter } from 'express';
+import { buildGetJourneyMiddleware, buildViewCaseDetails } from './controller.ts';
+import { asyncHandler } from '@pins/crowndev-lib/util/async-handler.ts';
+import { VIEW_TAB_ID } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
+import {
+	buildGetJourneyResponseFromSession,
+	buildSave,
+	question,
+	validate,
+	validationErrorHandler
+} from '@planning-inspectorate/dynamic-forms';
+import { JOURNEY_ID } from './journey.ts';
+import { buildS62aUpdateCase } from './update-case.ts';
+
+export function createRoutes(service: ManageService) {
+	const router = createRouter({ mergeParams: true });
+
+	const getJourney = asyncHandler(buildGetJourneyMiddleware(service));
+	const viewCaseDetails = buildViewCaseDetails();
+	const getQuestionJourney = asyncHandler(buildGetJourneyMiddleware(service));
+	const updateCaseFn = buildS62aUpdateCase(service);
+	const updateCase = buildSave(updateCaseFn, true);
+	const getJourneyResponse = buildGetJourneyResponseFromSession(JOURNEY_ID);
+
+	router.get('/', (req, res) => {
+		res.redirect(`${req.baseUrl}/${VIEW_TAB_ID.OVERVIEW}`);
+	});
+
+	// We mount a subrouter here so the baseUrl is correct for dynamic forms.
+	// Because it's tightly coupled with this parent, keeping in same module.
+	const tabRouter = createRouter({ mergeParams: true });
+	tabRouter.get('/', getJourney, asyncHandler(viewCaseDetails));
+
+	tabRouter.get('/:section/:question', getJourneyResponse, getQuestionJourney, asyncHandler(question));
+
+	tabRouter.post(
+		'/:section/:question',
+		getJourneyResponse,
+		getQuestionJourney,
+		validate,
+		validationErrorHandler,
+		asyncHandler(updateCase)
+	);
+
+	router.use('/:tab', tabRouter);
+
+	return router;
+}

--- a/apps/manage/src/app/views/s62a/cases/view/journey.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/journey.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createJourney, JOURNEY_ID } from './journey.ts';
+import type { Question, JourneyResponse } from '@planning-inspectorate/dynamic-forms';
+import type { Request } from 'express';
+
+describe('s62a case details journey', () => {
+	it('should error if used with the wrong router structure', () => {
+		const mockQuestions = {} as Record<string, Question>;
+		const mockRes = {} as unknown as JourneyResponse;
+		const mockReq = {
+			params: { id: 'case-123', tab: 'overview' },
+			baseUrl: '/s62a/cases/wrong-path/overview'
+		} as unknown as Request;
+
+		assert.throws(() => createJourney(mockQuestions, mockRes, mockReq), {
+			message: `not a valid request for the ${JOURNEY_ID} journey (invalid baseUrl)`
+		});
+	});
+
+	it('should create a journey with the correct configuration', () => {
+		const mockRes = {} as unknown as JourneyResponse;
+		const mockReq = {
+			params: { id: 'case-123', tab: 'overview' },
+			baseUrl: '/s62a/cases/case-123/overview'
+		} as unknown as Request;
+
+		const mockQuestions = new Proxy(
+			{},
+			{
+				get: (_target, prop) => ({ fieldName: prop })
+			}
+		) as unknown as Record<string, Question>;
+
+		const journey = createJourney(mockQuestions, mockRes, mockReq);
+
+		assert.strictEqual(journey.journeyId, JOURNEY_ID);
+		assert.strictEqual(journey.journeyTitle, 'Case details');
+		assert.strictEqual(journey.returnToListing, false);
+		assert.strictEqual(journey.journeyTemplate, 'views/layouts/forms-question.njk');
+		assert.strictEqual(journey.taskListTemplate, 'views/s62a/cases/view/view.njk');
+		assert.strictEqual(journey.taskListUrl, '/s62a/cases/case-123/overview');
+
+		assert.strictEqual(journey.makeBaseUrl(mockRes), '/s62a/cases/case-123/overview');
+	});
+
+	it('should create static sections with the correct order and questions', () => {
+		const mockRes = {} as unknown as JourneyResponse;
+		const mockReq = {
+			params: { id: 'case-123', tab: 'overview' },
+			baseUrl: '/s62a/cases/case-123/overview'
+		} as unknown as Request;
+
+		const mockQuestions = new Proxy(
+			{},
+			{
+				get: (_target, prop) => ({ fieldName: prop })
+			}
+		) as unknown as Record<string, Question>;
+
+		const journey = createJourney(mockQuestions, mockRes, mockReq);
+
+		const expectedSections = [
+			{
+				title: '',
+				segment: 'overview',
+				questions: ['developmentDescription']
+			},
+			{
+				title: '',
+				segment: 'details',
+				questions: ['applicationStatus']
+			}
+		];
+
+		assert.strictEqual(
+			journey.sections.length,
+			expectedSections.length,
+			`Journey should have exactly ${expectedSections.length} section(s)`
+		);
+
+		expectedSections.forEach((expected, index) => {
+			const actualSection = journey.sections[index];
+
+			assert.ok(actualSection, `Section '${expected.title}' should exist`);
+			assert.strictEqual(actualSection.name, expected.title, `Section title mismatch at index ${index}`);
+			assert.strictEqual(actualSection.segment, expected.segment, `Section '${expected.title}' segment mismatch`);
+
+			assert.strictEqual(
+				actualSection.questions.length,
+				expected.questions.length,
+				`Section '${expected.title}' has incorrect number of questions`
+			);
+
+			expected.questions.forEach((qKey, qIndex) => {
+				const actualQuestion = actualSection.questions[qIndex];
+				assert.strictEqual(
+					actualQuestion.fieldName,
+					qKey,
+					`Section '${expected.title}' question at index ${qIndex} should be '${qKey}'`
+				);
+			});
+		});
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/view/journey.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/journey.ts
@@ -1,0 +1,34 @@
+import { Journey, type Question, Section, type JourneyResponse } from '@planning-inspectorate/dynamic-forms';
+import { getStringParam } from '@pins/crowndev-lib/util/params.ts';
+import type { Request } from 'express';
+import { VIEW_TAB_ID } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
+
+export const JOURNEY_ID = 's62a-case-details';
+
+export function createJourney(questions: Record<string, Question>, response: JourneyResponse, req: Request) {
+	const id = getStringParam(req.params, 'id');
+	const currentTab = getStringParam(req.params, 'tab');
+
+	if (!req.baseUrl?.includes(id)) {
+		throw new Error(`not a valid request for the ${JOURNEY_ID} journey (invalid baseUrl)`);
+	}
+
+	return new Journey({
+		journeyId: JOURNEY_ID,
+		sections: [
+			new Section('', 'overview')
+				.withSectionCondition(() => currentTab === VIEW_TAB_ID.OVERVIEW)
+				.addQuestion(questions.developmentDescription),
+			new Section('', 'details')
+				.withSectionCondition(() => currentTab === VIEW_TAB_ID.DETAILS)
+				.addQuestion(questions.applicationStatus)
+		],
+		taskListUrl: '',
+		journeyTemplate: 'views/layouts/forms-question.njk',
+		taskListTemplate: 'views/s62a/cases/view/view.njk',
+		journeyTitle: 'Case details',
+		returnToListing: false,
+		makeBaseUrl: () => req.baseUrl,
+		response
+	});
+}

--- a/apps/manage/src/app/views/s62a/cases/view/questions.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/questions.ts
@@ -1,0 +1,40 @@
+import { S62A_STATUSES } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
+import {
+	COMPONENT_TYPES,
+	createQuestions,
+	questionClasses,
+	RequiredValidator,
+	StringValidator
+} from '@planning-inspectorate/dynamic-forms';
+
+export function getQuestions() {
+	const questions = {
+		developmentDescription: {
+			type: COMPONENT_TYPES.TEXT_ENTRY,
+			title: 'Development description',
+			question: 'What is the description of the development?',
+			fieldName: 'developmentDescription',
+			url: 'development-description',
+			validators: [
+				new RequiredValidator('Enter a description of the development'),
+				new StringValidator({
+					maxLength: {
+						maxLength: 1000,
+						maxLengthMessage: 'Description of the development must be 1000 characters or less'
+					}
+				})
+			]
+		},
+		applicationStatus: {
+			type: COMPONENT_TYPES.RADIO,
+			title: 'Status',
+			question: 'Which is the application status?',
+			fieldName: 's62aStatusId',
+			url: 'application-status',
+			validators: [new RequiredValidator('Select the status for this application')],
+			options: S62A_STATUSES.map((t) => ({ text: t.displayName, value: t.id }))
+		}
+	};
+
+	return createQuestions(questions, questionClasses, {});
+}

--- a/apps/manage/src/app/views/s62a/cases/view/s62a-update-case-mapper.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/s62a-update-case-mapper.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { S62aCaseUpdateMapper, type UpdateCaseAnswers } from './s62a-update-case-mapper.ts';
+
+describe('S62aCaseUpdateMapper', () => {
+	describe('Empty and Undefined Payloads', () => {
+		it('returns an empty object if no fields are provided', () => {
+			const answers: UpdateCaseAnswers = {};
+			const mapper = new S62aCaseUpdateMapper(answers);
+
+			const result = mapper.generateUpdateInput();
+
+			assert.deepStrictEqual(result, {}, 'Should return a completely empty object');
+		});
+
+		it('ignores explicitly undefined fields', () => {
+			const answers: UpdateCaseAnswers = {
+				developmentDescription: undefined,
+				s62aStatusId: undefined
+			};
+			const mapper = new S62aCaseUpdateMapper(answers);
+
+			const result = mapper.generateUpdateInput();
+
+			assert.deepStrictEqual(result, {}, 'Should not map fields that are undefined');
+		});
+	});
+
+	describe('Scalar Mapping', () => {
+		it('maps developmentDescription when provided', () => {
+			const answers: UpdateCaseAnswers = {
+				developmentDescription: 'This is an updated description'
+			};
+			const mapper = new S62aCaseUpdateMapper(answers);
+
+			const result = mapper.generateUpdateInput();
+
+			assert.strictEqual(result.description, 'This is an updated description');
+			assert.strictEqual(result.S62aStatus, undefined, 'Should not map unprovided lookup fields');
+		});
+
+		it('allows clearing the developmentDescription with an empty string', () => {
+			const answers: UpdateCaseAnswers = {
+				developmentDescription: ''
+			};
+			const mapper = new S62aCaseUpdateMapper(answers);
+
+			const result = mapper.generateUpdateInput();
+
+			assert.strictEqual(result.description, '');
+		});
+	});
+
+	describe('Lookup Mapping', () => {
+		it('maps s62aStatusId into a Prisma connect object', () => {
+			const answers: UpdateCaseAnswers = {
+				s62aStatusId: 'valid-status-id'
+			};
+			const mapper = new S62aCaseUpdateMapper(answers);
+
+			const result = mapper.generateUpdateInput();
+
+			assert.deepStrictEqual(result.S62aStatus, { connect: { id: 'valid-status-id' } });
+			assert.strictEqual(result.description, undefined, 'Should not map unprovided scalar fields');
+		});
+	});
+
+	describe('Combined Mapping', () => {
+		it('maps multiple fields correctly simultaneously', () => {
+			const answers: UpdateCaseAnswers = {
+				developmentDescription: 'A newly updated case',
+				s62aStatusId: 'status-123'
+			};
+			const mapper = new S62aCaseUpdateMapper(answers);
+
+			const result = mapper.generateUpdateInput();
+
+			assert.deepStrictEqual(result, {
+				description: 'A newly updated case',
+				S62aStatus: { connect: { id: 'status-123' } }
+			});
+		});
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/view/s62a-update-case-mapper.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/s62a-update-case-mapper.ts
@@ -1,0 +1,51 @@
+import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
+
+export interface UpdateCaseAnswers {
+	s62aStatusId?: string;
+	developmentDescription?: string;
+	// Add as we develop more parameters to update.
+}
+
+/**
+ * Class to handle converting data from the view, into something ready for
+ * a database transaction.
+ */
+export class S62aCaseUpdateMapper {
+	private answers: UpdateCaseAnswers;
+
+	constructor(answers: UpdateCaseAnswers) {
+		this.answers = answers;
+	}
+
+	/**
+	 * Transforms the partial update payload into a Prisma Update Input.
+	 */
+	public generateUpdateInput(): Prisma.S62aCaseUpdateInput {
+		const input: Prisma.S62aCaseUpdateInput = {};
+
+		this.mapScalars(input);
+		this.mapLookups(input);
+
+		return input;
+	}
+
+	/**
+	 * Handles basic scalar fields, things that are just columns
+	 * on the base S62A table.
+	 */
+	private mapScalars(input: Prisma.S62aCaseUpdateInput): void {
+		if (this.answers.developmentDescription !== undefined) {
+			input.description = this.answers.developmentDescription;
+		}
+	}
+
+	/**
+	 * Handles fields that are joins onto another table, still basic
+	 * not handling things like many-many complex joins.
+	 */
+	private mapLookups(input: Prisma.S62aCaseUpdateInput): void {
+		if (this.answers.s62aStatusId !== undefined) {
+			input.S62aStatus = { connect: { id: this.answers.s62aStatusId } };
+		}
+	}
+}

--- a/apps/manage/src/app/views/s62a/cases/view/update-case.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/update-case.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { buildS62aUpdateCase } from './update-case.ts';
+import type { Request, Response } from 'express';
+import type { SaveParams } from '@planning-inspectorate/dynamic-forms';
+import type { ManageService } from '../../../../service.js';
+
+describe('buildS62aUpdateCase', () => {
+	let mockDbUpdateCalls: any[];
+	let mockLoggerInfoCalls: any[];
+	let mockService: ManageService;
+	let mockReq: Partial<Request>;
+	let mockRes: Partial<Response>;
+
+	beforeEach(() => {
+		mockDbUpdateCalls = [];
+		mockLoggerInfoCalls = [];
+
+		mockService = {
+			db: {
+				s62aCase: {
+					update: async (args: unknown) => {
+						mockDbUpdateCalls.push(args);
+						return { id: 'case-123' };
+					}
+				}
+			},
+			logger: {
+				info: (meta: unknown, msg: string) => mockLoggerInfoCalls.push({ meta, msg }),
+				error: () => {}
+			}
+		} as unknown as ManageService;
+
+		mockReq = {
+			params: { id: 'case-123' }
+		};
+
+		mockRes = {};
+	});
+
+	it('bails early and does not call DB if answers payload is empty', async () => {
+		const handler = buildS62aUpdateCase(mockService);
+
+		await handler({
+			req: mockReq,
+			res: mockRes,
+			data: { answers: {} }
+		} as unknown as SaveParams);
+
+		assert.strictEqual(mockDbUpdateCalls.length, 0, 'Database update should not be called');
+		assert.strictEqual(mockLoggerInfoCalls[1]?.msg, 'No case updates to apply', 'Should log the early exit reason');
+	});
+
+	it('bails early and does not call DB if answers do not map to any valid update fields', async () => {
+		const handler = buildS62aUpdateCase(mockService);
+
+		await handler({
+			req: mockReq,
+			res: mockRes,
+			data: { answers: { developmentDescription: undefined } }
+		} as unknown as SaveParams);
+
+		assert.strictEqual(mockDbUpdateCalls.length, 0, 'Database update should not be called');
+		assert.strictEqual(
+			mockLoggerInfoCalls[1]?.msg,
+			'No valid database fields mapped for update',
+			'Should log the mapper early exit reason'
+		);
+	});
+
+	it('successfully calls Prisma update with mapped input and current date', async () => {
+		const handler = buildS62aUpdateCase(mockService);
+
+		await handler({
+			req: mockReq,
+			res: mockRes,
+			data: { answers: { developmentDescription: 'An updated description' } }
+		} as unknown as SaveParams);
+
+		assert.strictEqual(mockDbUpdateCalls.length, 1, 'Database update should be called exactly once');
+
+		const updateArgs = mockDbUpdateCalls[0];
+
+		assert.deepStrictEqual(updateArgs.where, { id: 'case-123' }, 'Should query by the correct case ID');
+		assert.strictEqual(updateArgs.data.description, 'An updated description', 'Should map the description');
+		assert.ok(updateArgs.data.updatedDate instanceof Date, 'Should append a new updatedDate timestamp');
+
+		assert.strictEqual(mockLoggerInfoCalls[1]?.msg, 'S62A case updated successfully', 'Should log success');
+	});
+
+	it('catches and delegates Prisma errors to wrapPrismaError', async () => {
+		(mockService.db.s62aCase as any).update = async () => {
+			throw new Error('Database connection failed');
+		};
+
+		const handler = buildS62aUpdateCase(mockService);
+
+		await assert.rejects(async () => {
+			await handler({
+				req: mockReq,
+				res: mockRes,
+				data: { answers: { developmentDescription: 'Valid update' } }
+			} as unknown as SaveParams);
+		});
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/view/update-case.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/update-case.ts
@@ -1,0 +1,53 @@
+import type { Request, Response } from 'express';
+import type { SaveDataFn } from '@planning-inspectorate/dynamic-forms';
+import type { ManageService } from '#service';
+import { getStringParam } from '@pins/crowndev-lib/util/params.ts';
+import { wrapPrismaError } from '@pins/crowndev-lib/util/database.ts';
+import { S62aCaseUpdateMapper, type UpdateCaseAnswers } from './s62a-update-case-mapper.ts';
+
+/**
+ * Save handler for S62A Case updates.
+ * Takes the raw form answers, maps them to Prisma format, and updates the database.
+ */
+export function buildS62aUpdateCase(service: ManageService): SaveDataFn {
+	return async ({ req, data }: { req: Request; res: Response; data: { answers?: UpdateCaseAnswers } }) => {
+		const { db, logger } = service;
+		const id = getStringParam(req.params, 'id');
+
+		logger.info({ id }, 'S62A case update initiated');
+
+		const answers = data?.answers || {};
+
+		if (Object.keys(answers).length === 0) {
+			logger.info({ id }, 'No case updates to apply');
+			return;
+		}
+
+		try {
+			const mapper = new S62aCaseUpdateMapper(answers);
+			const updateInput = mapper.generateUpdateInput();
+
+			if (Object.keys(updateInput).length === 0) {
+				logger.info({ id }, 'No valid database fields mapped for update');
+				return;
+			}
+
+			await db.s62aCase.update({
+				where: { id },
+				data: {
+					...updateInput,
+					updatedDate: new Date()
+				}
+			});
+
+			logger.info({ id }, 'S62A case updated successfully');
+		} catch (error) {
+			wrapPrismaError({
+				error,
+				logger,
+				message: 'updating S62A case',
+				logParams: { id }
+			});
+		}
+	};
+}

--- a/apps/manage/src/app/views/s62a/cases/view/view-model.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/view-model.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { s62aCaseToViewModel, type S62aCaseDbModel } from './view-model.ts';
+
+describe('s62aCaseToViewModel', () => {
+	it('maps a full database record to the view model correctly', () => {
+		const mockDbCase = {
+			id: 'case-123',
+			reference: 'S62A/2026/0001',
+			description: 'A massive new development',
+			S62aStatus: {
+				id: 'status-new',
+				displayName: 'New'
+			}
+		} as S62aCaseDbModel;
+
+		const result = s62aCaseToViewModel(mockDbCase);
+
+		assert.deepStrictEqual(result, {
+			id: 'case-123',
+			reference: 'S62A/2026/0001',
+			developmentDescription: 'A massive new development',
+			s62aStatusId: 'status-new'
+		});
+	});
+
+	it('handles a missing or null status gracefully', () => {
+		const mockDbCase = {
+			id: 'case-456',
+			reference: 'S62A/2026/0002',
+			description: 'Another development',
+			S62aStatus: null
+		} as unknown as S62aCaseDbModel;
+
+		const result = s62aCaseToViewModel(mockDbCase);
+
+		assert.deepStrictEqual(result, {
+			id: 'case-456',
+			reference: 'S62A/2026/0002',
+			developmentDescription: 'Another development',
+			s62aStatusId: undefined
+		});
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/view/view-model.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/view-model.ts
@@ -1,0 +1,26 @@
+import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
+
+export type S62aCaseDbModel = Prisma.S62aCaseGetPayload<{
+	include: {
+		S62aStatus: true;
+	};
+}>;
+
+export interface S62aCaseViewModel {
+	id: string;
+	reference: string;
+	developmentDescription: string;
+	s62aStatusId?: string;
+}
+
+/**
+ * Pure function to map a database record back to the frontend View Model.
+ */
+export function s62aCaseToViewModel(dbCase: S62aCaseDbModel): S62aCaseViewModel {
+	return {
+		id: dbCase.id,
+		reference: dbCase.reference,
+		developmentDescription: dbCase.description,
+		s62aStatusId: dbCase.S62aStatus?.id
+	};
+}

--- a/apps/manage/src/app/views/s62a/cases/view/view.njk
+++ b/apps/manage/src/app/views/s62a/cases/view/view.njk
@@ -1,0 +1,50 @@
+{% extends "views/layouts/main.njk" %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% set title = reference + " - " + journeyTitle + " - Manage a S62A Case" %}
+
+{% block pageTitle %}
+    {{ title }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">
+                {{ reference }}
+            </h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <nav class="moj-sub-navigation pins-sub-navigation" aria-label="Sub navigation">
+                <ul class="moj-sub-navigation__list">
+                    {% for tab in viewTabs %}
+                        <li class="moj-sub-navigation__item {% if currentTab == tab.id %}moj-sub-navigation__item--active{% endif %}">
+                            <a class="moj-sub-navigation__link" {% if currentTab == tab.id %}aria-current="page"{% endif %} href="{{ cleanUrl }}/{{ tab.id }}">
+                                {{ tab.displayName }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </nav>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {% for section in summaryListData.sections %}
+                {% if section.list.rows.length %}
+                    {% if section.heading %}
+                        <h2 class="govuk-heading-m" id="{{ section.heading | lower | replace(' ', '-') }}">
+                            {{ section.heading }}
+                        </h2>
+                    {% endif %}
+                    
+                    {{ govukSummaryList({
+                        rows: section.list.rows
+                    }) }} 
+                {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/packages/database/src/seed/s62a/data-static.ts
+++ b/packages/database/src/seed/s62a/data-static.ts
@@ -79,3 +79,22 @@ export const S62A_STATUSES = [
 		displayName: 'New'
 	}
 ];
+
+export const VIEW_TAB_ID = Object.freeze({
+	OVERVIEW: 'overview',
+	DETAILS: 'details'
+} as const);
+
+/**
+ * The sub-tabs shown on the case details view
+ */
+export const VIEW_TABS = [
+	{
+		id: VIEW_TAB_ID.OVERVIEW,
+		displayName: 'Overview'
+	},
+	{
+		id: VIEW_TAB_ID.DETAILS,
+		displayName: 'Details'
+	}
+];


### PR DESCRIPTION
## Describe your changes
- Adds the boilerplate for the new S62A case details page
- Adds 2 questions, one scalar and one join to give an example of how it will work across 2 tabs too.

## Issue ticket number and link
[PEAS-245](https://pins-ds.atlassian.net/browse/PEAS-245)

## Implementation
<img width="1472" height="557" alt="Screenshot 2026-07-10 at 13 50 58" src="https://github.com/user-attachments/assets/a6fd9b91-b175-4d4a-b167-bcfdce8d1d14" />
<img width="1126" height="518" alt="Screenshot 2026-07-10 at 13 51 03" src="https://github.com/user-attachments/assets/cedb76bd-2fef-47db-a099-0957fcb33a13" />



[PEAS-245]: https://pins-ds.atlassian.net/browse/PEAS-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ