### PR TITLE
Feat/crown 1633 audit logging for direct fields

### DIFF
--- a/apps/manage/src/app/audit/actions.test.ts
+++ b/apps/manage/src/app/audit/actions.test.ts
@@ -42,4 +42,49 @@ describe('resolveTemplate', () => {
 		const result = resolveTemplate(AUDIT_ACTIONS.CASE_CREATED, { reference: 'DRT/PER/00015', extra: 'ignored' });
 		assert.strictEqual(result, 'DRT/PER/00015 was created');
 	});
+
+	describe('FIELD_SET action', () => {
+		it('should resolve FIELD_SET template with fieldName and newValue', () => {
+			const result = resolveTemplate(AUDIT_ACTIONS.FIELD_SET, {
+				fieldName: 'Site area (ha)',
+				newValue: '12.5'
+			});
+			assert.strictEqual(result, 'Site area (ha) was set to 12.5');
+		});
+	});
+
+	describe('FIELD_CLEARED action', () => {
+		it('should resolve FIELD_CLEARED template with fieldName and oldValue', () => {
+			const result = resolveTemplate(AUDIT_ACTIONS.FIELD_CLEARED, {
+				fieldName: 'LPA reference',
+				oldValue: 'ABC/123'
+			});
+			assert.strictEqual(result, 'LPA reference (ABC/123) was removed');
+		});
+	});
+
+	describe('FIELD_UPDATED action', () => {
+		it('should resolve FIELD_UPDATED template with all placeholders', () => {
+			const result = resolveTemplate(AUDIT_ACTIONS.FIELD_UPDATED, {
+				fieldName: 'Hearing venue',
+				oldValue: 'Town Hall',
+				newValue: 'City Hall'
+			});
+			assert.strictEqual(result, 'Hearing venue was updated from Town Hall to City Hall');
+		});
+	});
+});
+
+describe('AUDIT_ACTIONS', () => {
+	it('should have FIELD_SET action', () => {
+		assert.strictEqual(AUDIT_ACTIONS.FIELD_SET, 'FIELD_SET');
+	});
+
+	it('should have FIELD_CLEARED action', () => {
+		assert.strictEqual(AUDIT_ACTIONS.FIELD_CLEARED, 'FIELD_CLEARED');
+	});
+
+	it('should have FIELD_UPDATED action', () => {
+		assert.strictEqual(AUDIT_ACTIONS.FIELD_UPDATED, 'FIELD_UPDATED');
+	});
 });

--- a/apps/manage/src/app/audit/actions.ts
+++ b/apps/manage/src/app/audit/actions.ts
@@ -11,7 +11,12 @@
 
 export const AUDIT_ACTIONS = {
 	// Case
-	CASE_CREATED: 'CASE_CREATED'
+	CASE_CREATED: 'CASE_CREATED',
+
+	// Standard fields
+	FIELD_SET: 'FIELD_SET',
+	FIELD_UPDATED: 'FIELD_UPDATED',
+	FIELD_CLEARED: 'FIELD_CLEARED'
 } as const;
 
 export type AuditAction = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];
@@ -36,7 +41,12 @@ export function isAuditAction(value: string): value is AuditAction {
  */
 export const AUDIT_TEMPLATES: Record<AuditAction, string> = {
 	// Case
-	[AUDIT_ACTIONS.CASE_CREATED]: '{reference} was created'
+	[AUDIT_ACTIONS.CASE_CREATED]: '{reference} was created',
+
+	// Standard fields
+	[AUDIT_ACTIONS.FIELD_SET]: '{fieldName} was set to {newValue}',
+	[AUDIT_ACTIONS.FIELD_UPDATED]: '{fieldName} was updated from {oldValue} to {newValue}',
+	[AUDIT_ACTIONS.FIELD_CLEARED]: '{fieldName} ({oldValue}) was removed'
 };
 
 /**

--- a/apps/manage/src/app/audit/resolvers/README.md
+++ b/apps/manage/src/app/audit/resolvers/README.md
@@ -1,33 +1,72 @@
 # Audit Resolvers
 
-This directory is for **resolvers** that translate raw database and form data into human-readable audit entries.
+This directory contains **resolvers** that translate raw database and form data into human-readable audit trail entries.
 
-> **Status: not yet implemented.** This directory is currently empty. The audit
-> system today records only simple, self-describing events (e.g. `CASE_CREATED`)
-> whose metadata is supplied directly at the call site. Resolvers will be added
-> when the audit trail is extended to cover field-level and list changes. This
-> README describes the intended pattern for that work — it does not describe code
-> that exists yet.
+## Why resolvers exist
 
-## Why resolvers will exist
+When a user saves a form, all we get is raw data — database IDs, field keys, and values. But the audit trail needs to show things like _"Inspector was updated from Alice to Bob"_, not _"inspectorId was updated from f62dd2d8-c46c-454c-9542-3e6ac8db156a to 7c4709fd-4f4e-40dc-b2b8-ffb5e9dd443d"_.
 
-When a user saves a form, the raw data is database IDs, field keys, and values. An audit trail should read _"Status was updated from New to Accepted"_, not _"statusId was updated from new to accepted"_. A resolver knows how to translate one type of field from raw data into something a person can read.
+Each resolver knows how to translate one type of field from raw data into something a person can read.
 
-## Intended pattern
+## Field resolvers (`field-resolver.ts`)
 
-### Field resolvers (scalar fields)
+Handle scalar fields on the `CrownDevelopment` model. They take the old DB value and the new form value, and return display-friendly `{ oldValue, newValue }` strings.
 
-For simple scalar fields on the `CrownDevelopment` model (status, procedure, case officer, etc.), a field resolver would take the old DB value and the new form value and return display-friendly `{ oldValue, newValue }` strings. Fields without a specific resolver would fall through to a default that stringifies the raw value.
+### Key functions
 
-### List resolvers (one-to-many relationships)
+- **`resolveFieldValues(fieldName, previousCase, newAnswer)`** — looks up a field-specific resolver or falls back to the default resolver which stringifies raw values
+- **`getFieldDisplayName(fieldName)`** — returns a human-readable display name using `FIELD_DISPLAY_NAMES` from `questions.js`, falling back to sentence case conversion
 
-For one-to-many relationships, a list resolver would compare the old and new lists, determine what was added, removed, or changed, and produce the appropriate audit entries for each difference. Each entity type would get its own resolver.
+### Adding a new field resolver
 
-## When you add resolver support for a new field or entity
+To add special handling for a field (e.g. it needs formatting, or the form value differs from the DB column), add an entry to the `FIELD_RESOLVERS` map in `field-resolver.ts`. Fields not in the map fall through to the default resolver.
 
-1. **Add audit action(s)** in `audit/actions.ts` (e.g. `MY_ENTITY_ADDED`, `MY_ENTITY_UPDATED`, `MY_ENTITY_DELETED`).
-2. **Add matching templates** in `AUDIT_TEMPLATES` in the same file.
-3. **Create the resolver here** — a field resolver for a scalar field, or a new list resolver for a new entity type.
-4. **Wire it into the relevant save/update controller** so the resolver runs after the database write and the resulting entries are passed to `audit.recordMany()`.
+Currently registered resolvers:
 
-Update this README's status note once the first resolver lands.
+| Field | Description |
+|-------|-------------|
+| `siteAddress` | Formats address object into comma-separated string |
+
+### Auditable fields
+
+Not all fields are yet audited — only those listed in `AUDITABLE_SCALAR_FIELDS` in `update-case.ts`:
+
+- `siteArea`
+- `lpaReference`
+- `agentOrganisationName`
+- `hearingVenue`
+- `inquiryVenue`
+
+## List resolvers
+
+> **Not yet implemented** (see CROWN-1641). This section describes the intended pattern for when list resolvers are added.
+
+List resolvers will handle one-to-many relationships (contacts, inspectors, etc.). They will compare the old list to the new list, determine what was added, removed, or changed, and produce the right audit entries for each difference.
+
+## Adding audit support for a new field
+
+When you add a new field to the case model:
+
+1. **Add it to `AUDITABLE_SCALAR_FIELDS`** in `update-case.ts`
+2. **Optionally add a field-specific resolver** in `FIELD_RESOLVERS` if the field needs special formatting
+3. **Ensure the field has a display name** via a question definition (which populates `FIELD_DISPLAY_NAMES`)
+
+For new audit actions beyond field updates:
+
+1. **Add an audit action** in `audit/actions.ts` (e.g. `MY_ENTITY_ADDED`)
+2. **Add a template** in `AUDIT_TEMPLATES` in the same file
+
+## Shared formatters
+
+Common formatting functions live in `packages/lib/util/audit-formatters.ts` and are shared across all resolvers:
+
+| Function | Description |
+|----------|-------------|
+| `formatAddress` | Formats address object into comma-separated string |
+| `formatDate` | Formats date for display (optionally with time) |
+| `formatDateTime` | Formats date with time |
+| `formatValue` | Formats scalar values; returns `-` for null/undefined |
+| `formatNumber` | Formats numeric values |
+| `formatBoolean` | Formats boolean to Yes/No |
+| `formatYesNo` | Normalises 'yes'/'no' form strings to 'Yes'/'No' |
+| `formatMonetaryValue` | Formats value as GBP currency |

--- a/apps/manage/src/app/audit/resolvers/field-resolver.test.ts
+++ b/apps/manage/src/app/audit/resolvers/field-resolver.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('Field Resolver', () => {
+	// Set environment before importing modules that depend on it
+	before(() => {
+		process.env.ENVIRONMENT = 'test';
+	});
+
+	describe('getFieldDisplayName', () => {
+		it('should return display name from FIELD_DISPLAY_NAMES for known fields', async () => {
+			const { getFieldDisplayName } = await import('./field-resolver.ts');
+			assert.strictEqual(getFieldDisplayName('siteArea'), 'Site area (ha)');
+			assert.strictEqual(getFieldDisplayName('lpaReference'), 'LPA reference');
+		});
+
+		it('should fall back to sentence case for unknown fields', async () => {
+			const { getFieldDisplayName } = await import('./field-resolver.ts');
+			assert.strictEqual(getFieldDisplayName('unknownFieldName'), 'Unknown field name');
+			assert.strictEqual(getFieldDisplayName('someOtherField'), 'Some other field');
+		});
+	});
+
+	describe('resolveFieldValues', () => {
+		it('should resolve simple scalar field values', async () => {
+			const { resolveFieldValues } = await import('./field-resolver.ts');
+			const previousCase = { siteArea: 10.5 };
+			const newAnswer = 15.0;
+
+			const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
+
+			assert.strictEqual(oldValue, '10.5');
+			assert.strictEqual(newValue, '15');
+		});
+
+		it('should return "-" for null previous value', async () => {
+			const { resolveFieldValues } = await import('./field-resolver.ts');
+			const previousCase = { siteArea: null };
+			const newAnswer = 12.5;
+
+			const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
+
+			assert.strictEqual(oldValue, '-');
+			assert.strictEqual(newValue, '12.5');
+		});
+
+		it('should return "-" for null new value', async () => {
+			const { resolveFieldValues } = await import('./field-resolver.ts');
+			const previousCase = { siteArea: 10.5 };
+			const newAnswer = null;
+
+			const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
+
+			assert.strictEqual(oldValue, '10.5');
+			assert.strictEqual(newValue, '-');
+		});
+
+		it('should return "-" for undefined previous value', async () => {
+			const { resolveFieldValues } = await import('./field-resolver.ts');
+			const previousCase = {};
+			const newAnswer = 'New Value';
+
+			const { oldValue, newValue } = resolveFieldValues('lpaReference', previousCase, newAnswer);
+
+			assert.strictEqual(oldValue, '-');
+			assert.strictEqual(newValue, 'New Value');
+		});
+
+		it('should handle string values', async () => {
+			const { resolveFieldValues } = await import('./field-resolver.ts');
+			const previousCase = { lpaReference: 'ABC/123' };
+			const newAnswer = 'XYZ/456';
+
+			const { oldValue, newValue } = resolveFieldValues('lpaReference', previousCase, newAnswer);
+
+			assert.strictEqual(oldValue, 'ABC/123');
+			assert.strictEqual(newValue, 'XYZ/456');
+		});
+
+		it('should use siteAddress resolver for address fields', async () => {
+			const { resolveFieldValues } = await import('./field-resolver.ts');
+			const previousCase = {
+				SiteAddress: {
+					line1: '123 Old Street',
+					townCity: 'London',
+					postcode: 'SW1A 1AA'
+				}
+			};
+			const newAnswer = {
+				addressLine1: '456 New Road',
+				townCity: 'Manchester',
+				postcode: 'M1 1AA'
+			};
+
+			const { oldValue, newValue } = resolveFieldValues('siteAddress', previousCase, newAnswer);
+
+			assert.strictEqual(oldValue, '123 Old Street, London, SW1A 1AA');
+			assert.strictEqual(newValue, '456 New Road, Manchester, M1 1AA');
+		});
+
+		it('should return "-" for null address', async () => {
+			const { resolveFieldValues } = await import('./field-resolver.ts');
+			const previousCase = { SiteAddress: null };
+			const newAnswer = null;
+
+			const { oldValue, newValue } = resolveFieldValues('siteAddress', previousCase, newAnswer);
+
+			assert.strictEqual(oldValue, '-');
+			assert.strictEqual(newValue, '-');
+		});
+	});
+});

--- a/apps/manage/src/app/audit/resolvers/field-resolver.ts
+++ b/apps/manage/src/app/audit/resolvers/field-resolver.ts
@@ -1,0 +1,86 @@
+import { formatAddress, formatValue } from '@pins/crowndev-lib/util/audit-formatters.ts';
+import { camelCaseToSentenceCase } from '@pins/crowndev-lib/util/string.ts';
+import { FIELD_DISPLAY_NAMES } from '../../views/cases/view/questions.js';
+
+interface ResolverContext {
+	userDisplayNameMap?: Map<string, string>;
+}
+
+/**
+ * Returns a human-readable display name for a field.
+ * Uses the FIELD_DISPLAY_NAMES lookup, falling back to sentence case conversion.
+ */
+export function getFieldDisplayName(fieldName: string): string {
+	return FIELD_DISPLAY_NAMES[fieldName] ?? camelCaseToSentenceCase(fieldName);
+}
+
+/**
+ * A field resolver takes the previous case row and the new form answer
+ * and returns human-readable old/new values for the audit trail.
+ */
+interface FieldResolver {
+	resolve(
+		previousCase: Record<string, unknown>,
+		newAnswer: unknown,
+		context?: ResolverContext
+	): { oldValue: string; newValue: string };
+}
+
+/**
+ * Default resolver for simple scalar fields where the form field name
+ * matches the DB column name (e.g. externalReference, name, location).
+ */
+function defaultResolver(fieldName: string): FieldResolver {
+	return {
+		resolve(previousCase, newAnswer) {
+			return {
+				oldValue: formatValue(previousCase[fieldName]),
+				newValue: formatValue(newAnswer)
+			};
+		}
+	};
+}
+
+/**
+ * Registry of field-specific resolvers.
+ *
+ * Add an entry here whenever a field needs special handling — e.g. the
+ * form value is a composite ID, the DB column has a different name, or
+ * the value needs to be looked up from a reference table.
+ *
+ * Fields not in this map fall through to the default resolver, which
+ * simply stringifies the raw values.
+ */
+const FIELD_RESOLVERS: Record<string, FieldResolver> = {
+	/**
+	 * Site address — the form submits an address object, the DB stores it
+	 * as a relation. Formats both as a comma-separated address string.
+	 */
+	siteAddress: {
+		resolve(previousCase, newAnswer) {
+			const oldAddress = previousCase.SiteAddress as Record<string, unknown> | null;
+			const newAddress = newAnswer as Record<string, unknown> | null;
+
+			return {
+				oldValue: formatAddress(oldAddress),
+				newValue: formatAddress(newAddress)
+			};
+		}
+	}
+};
+
+/**
+ * Resolves human-readable old and new values for a given field.
+ *
+ * Looks up a field-specific resolver first; falls back to the default
+ * scalar resolver if none is registered.
+ */
+export function resolveFieldValues(
+	fieldName: string,
+	previousCase: Record<string, unknown>,
+	newAnswer: unknown,
+	context?: ResolverContext
+): { oldValue: string; newValue: string } {
+	const resolver = FIELD_RESOLVERS[fieldName] ?? defaultResolver(fieldName);
+	return resolver.resolve(previousCase, newAnswer, context);
+}

--- a/apps/manage/src/app/audit/resolvers/index.ts
+++ b/apps/manage/src/app/audit/resolvers/index.ts
@@ -1,1 +1,1 @@
-// Barrel export
+export { resolveFieldValues, getFieldDisplayName } from './field-resolver.ts';

--- a/apps/manage/src/app/views/cases/create-a-case/questions.js
+++ b/apps/manage/src/app/views/cases/create-a-case/questions.js
@@ -6,10 +6,7 @@ import { createQuestions } from '@planning-inspectorate/dynamic-forms/src/questi
 import { questionClasses } from '@planning-inspectorate/dynamic-forms/src/questions/questions.js';
 import { COMPONENT_TYPES } from '@planning-inspectorate/dynamic-forms';
 import { APPLICATION_TYPES, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.ts';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.ts';
 import { multiContactQuestions } from './question-utils.js';
-import { ENVIRONMENT_NAME, loadEnvironmentConfig } from '../../../config.js';
 import AddressValidator from '@planning-inspectorate/dynamic-forms/src/validator/address-validator.js';
 import CoordinatesValidator from '@planning-inspectorate/dynamic-forms/src/validator/coordinates-validator.js';
 import SameAnswerValidator from '@planning-inspectorate/dynamic-forms/src/validator/same-answer-validator.js';
@@ -18,6 +15,7 @@ import CustomManageListValidator from '@pins/crowndev-lib/forms/custom-component
 import { yesNoToBoolean } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
 import { getApplicantOrganisationOptions } from '../util/applicant-organisation-options.js';
 import { getApplicantContactsValidator } from '@pins/crowndev-lib/validators/applicant-contacts-validator.ts';
+import { getLpaOptions } from '@pins/crowndev-lib/util/questions.ts';
 
 /** @typedef {import('@planning-inspectorate/dynamic-forms/src/journey/journey-response').JourneyResponse} JourneyResponse */
 
@@ -28,17 +26,6 @@ import { getApplicantContactsValidator } from '@pins/crowndev-lib/validators/app
  * @returns
  */
 export function getQuestions(journeyResponse, isQuestionView = false) {
-	const env = loadEnvironmentConfig();
-
-	// this is to avoid a database read when the data is static - but it does vary by environment
-	// the options here should match the dev/prod seed scripts
-	const LPAs = env === ENVIRONMENT_NAME.PROD ? LOCAL_PLANNING_AUTHORITIES_PROD : LOCAL_PLANNING_AUTHORITIES_DEV;
-	const lpaOptions = [
-		{ text: '', value: '' }, // ensure there is a 'null' option so the first LPA isn't selected by default
-		...LPAs.map((t) => ({ text: t.name, value: t.id }))
-		// todo: sort LPA list?
-	];
-
 	// derive applicant organisation radio options from manageApplicants answers held in the journey response
 	const manageApplicantDetails = journeyResponse?.answers?.manageApplicantDetails;
 	const applicantOrganisationOptions = getApplicantOrganisationOptions(
@@ -73,7 +60,7 @@ export function getQuestions(journeyResponse, isQuestionView = false) {
 				),
 				new RequiredValidator('Select the local planning authority')
 			],
-			options: lpaOptions
+			options: getLpaOptions()
 		},
 
 		manageApplicants: {
@@ -191,7 +178,7 @@ export function getQuestions(journeyResponse, isQuestionView = false) {
 				),
 				new RequiredValidator('Select the secondary local planning authority')
 			],
-			options: lpaOptions
+			options: getLpaOptions()
 		},
 		hasAgent: {
 			type: COMPONENT_TYPES.BOOLEAN,

--- a/apps/manage/src/app/views/cases/view/controller.test.js
+++ b/apps/manage/src/app/views/cases/view/controller.test.js
@@ -24,7 +24,6 @@ describe('case details', () => {
 
 	describe('buildGetJourneyMiddleware', () => {
 		it('should throw if no id', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockReq = { params: {} };
 			const mockRes = { locals: {} };
 			const mockDb = {
@@ -44,7 +43,6 @@ describe('case details', () => {
 			assert.strictEqual(next.mock.callCount(), 0);
 		});
 		it('should call next without error and populate locals', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockReq = { params: { id: 'case-1' }, baseUrl: 'case-1' };
 			const mockRes = { locals: {} };
 			const mockDb = {
@@ -66,7 +64,6 @@ describe('case details', () => {
 			assert.ok(mockRes.locals.journeyResponse);
 		});
 		it('should render 404 if not found', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockReq = { params: { id: 'case-1' }, baseUrl: 'case-1', session: {} };
 			const mockDb = {
 				crownDevelopment: {
@@ -83,7 +80,6 @@ describe('case details', () => {
 			await assertRenders404Page(middleware, mockReq, true);
 		});
 		it('should add a back link if on an edit page', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockReq = { params: { id: 'case-1' }, baseUrl: '/case-1', originalUrl: '/case-1/edit' };
 			const mockRes = { locals: {} };
 			const mockDb = {
@@ -106,7 +102,6 @@ describe('case details', () => {
 		});
 
 		it('should set backLinkUrl to baseUrl when section is present and manageListQuestion is not present', async () => {
-			process.env.ENVIRONMENT = 'dev';
 			const mockReq = { params: { id: 'case-1', section: 'details' }, baseUrl: '/cases/case-1' };
 			const mockRes = { locals: {} };
 			const mockDb = {
@@ -129,7 +124,6 @@ describe('case details', () => {
 			assert.strictEqual(mockRes.locals.backLinkUrl, '/cases/case-1');
 		});
 		it('should not set backLinkUrl from section branch when manageListQuestion is present', async () => {
-			process.env.ENVIRONMENT = 'dev';
 			const mockReq = {
 				params: { id: 'case-1', section: 'details', manageListQuestion: 'manageListQuestion' },
 				baseUrl: '/cases/case-1',
@@ -181,7 +175,6 @@ describe('case details', () => {
 			await assert.rejects(() => viewCaseDetails(mockReq, mockRes), /must be a single string value/);
 		});
 		it('should render without error, with case reference', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = { params: { id: 'case-1' }, baseUrl: 'case-1', query: {} };
 			const mockDb = {
@@ -207,7 +200,6 @@ describe('case details', () => {
 			assert.strictEqual(viewData.reference, 'C/A/1');
 		});
 		it('should include case updated banner if present in session', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -242,7 +234,6 @@ describe('case details', () => {
 		});
 		it('should display a publish button if publishDate is defined and not in the future', async (context) => {
 			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00.000Z') });
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -278,7 +269,6 @@ describe('case details', () => {
 			assert.strictEqual(viewData.casePublished, true);
 		});
 		it('should include case updated banner with published message if case is published', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -315,7 +305,6 @@ describe('case details', () => {
 			assert.match(viewData.banner.html, /Any updates made to this case will be automatically published./);
 		});
 		it('should display an unpublish button if publishDate is not defined', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -347,7 +336,6 @@ describe('case details', () => {
 		});
 		it('should display an unpublish button if publishDate is in the future', async (context) => {
 			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-01-01T03:24:00.000Z') });
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -381,7 +369,6 @@ describe('case details', () => {
 			assert.strictEqual(viewData.casePublished, false);
 		});
 		it('should display error messages in errorSummary', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -415,7 +402,6 @@ describe('case details', () => {
 			assert.strictEqual(mockReq.session.cases['case-1'].errors, undefined);
 		});
 		it('should pass last modified info to the view', async () => {
-			process.env.ENVIRONMENT = 'dev';
 			const mockRes = newMockRes();
 			const mockReq = { params: { id: 'case-1' }, baseUrl: 'case-1', query: {}, session: {} };
 			const mockDb = {
@@ -447,7 +433,6 @@ describe('case details', () => {
 			assert.strictEqual(viewData.lastModifiedBy, 'Jane Smith');
 		});
 		it('should show a sharepoint link if available', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -482,7 +467,6 @@ describe('case details', () => {
 			assert.strictEqual(viewData.sharePointLink, 'https://example.com');
 		});
 		it('should set linked case banner appropriately when there is case linked', async () => {
-			process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -626,7 +610,6 @@ describe('case details', () => {
 			assert.ok(!viewData.banner);
 		});
 		it('should show "You need to add" banner text when agentStatusUpdated is in session', async () => {
-			process.env.ENVIRONMENT = 'dev';
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -675,7 +658,6 @@ describe('case details', () => {
 		});
 
 		it('should show "You need to add" banner text when applicantOrgAdded is in session and hasAgent is no', async () => {
-			process.env.ENVIRONMENT = 'dev';
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -724,7 +706,6 @@ describe('case details', () => {
 		});
 
 		it('should show "This application is missing information" banner when applicantOrgAdded is in session but hasAgent is yes', async () => {
-			process.env.ENVIRONMENT = 'dev';
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },
@@ -760,7 +741,6 @@ describe('case details', () => {
 		});
 
 		it('should set an invalid state info banner when required contact information is missing', async () => {
-			process.env.ENVIRONMENT = 'dev';
 			const mockRes = newMockRes();
 			const mockReq = {
 				params: { id: 'case-1' },

--- a/apps/manage/src/app/views/cases/view/journey.test.js
+++ b/apps/manage/src/app/views/cases/view/journey.test.js
@@ -13,7 +13,6 @@ describe('case details journey', () => {
 	const mockReq = { params: { id: 'project-1' }, baseUrl: '/cases/project-1' };
 
 	it('all questions should be defined for journey', () => {
-		process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 		const questions = getQuestions();
 		const answers = {};
 		const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -37,7 +36,6 @@ describe('case details journey', () => {
 		shouldDisplayHearing,
 		shouldDisplayWrittenReps
 	) => {
-		process.env.ENVIRONMENT = 'dev'; // used by get questions for loading LPAs
 		const questions = getQuestions();
 		const answers = {
 			procedureId

--- a/apps/manage/src/app/views/cases/view/question-utils.js
+++ b/apps/manage/src/app/views/cases/view/question-utils.js
@@ -211,18 +211,6 @@ export function subCategoriesToRadioOptions(categories) {
 	return referenceDataToRadioOptions(subCategories);
 }
 
-/**
- * @param {{id: string, name: string}[]} lpaList
- * @returns {import('@planning-inspectorate/dynamic-forms/src/questions/question-props.js').Option[]}
- */
-export function lpaListToRadioOptions(lpaList) {
-	return [
-		{ text: '', value: '' }, // ensure there is a 'null' option so the first LPA isn't selected by default
-		// todo: sort LPA list?
-		...lpaList.map((t) => ({ text: t.name, value: t.id }))
-	];
-}
-
 export function filteredStagesToRadioOptions(procedureId) {
 	const stageIds = [
 		APPLICATION_STAGE_ID.ACCEPTANCE,

--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -14,21 +14,12 @@ import {
 	CATEGORIES,
 	ORGANISATION_ROLES_ID
 } from '@pins/crowndev-database/src/seed/data-static.ts';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.ts';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.ts';
-import {
-	dateQuestion,
-	eventQuestions,
-	lpaListToRadioOptions,
-	subCategoriesToRadioOptions,
-	CIL_DATA
-} from './question-utils.js';
-import { ENVIRONMENT_NAME, loadEnvironmentConfig } from '../../../config.js';
+import { dateQuestion, eventQuestions, subCategoriesToRadioOptions, CIL_DATA } from './question-utils.js';
 import AddressValidator from '@planning-inspectorate/dynamic-forms/src/validator/address-validator.js';
 import CoordinatesValidator from '@planning-inspectorate/dynamic-forms/src/validator/coordinates-validator.js';
 import CustomDatePeriodValidator from '@pins/crowndev-lib/validators/custom-date-period-validator.js';
 import DateValidator from '@planning-inspectorate/dynamic-forms/src/validator/date-validator.js';
-import { referenceDataToRadioOptions } from '@pins/crowndev-lib/util/questions.ts';
+import { getLpaOptions, referenceDataToRadioOptions } from '@pins/crowndev-lib/util/questions.ts';
 import { CUSTOM_COMPONENT_CLASSES, CUSTOM_COMPONENTS } from '@pins/crowndev-lib/forms/custom-components/index.ts';
 import FeeAmountValidator from '@pins/crowndev-lib/forms/custom-components/fee-amount/fee-amount-validator.js';
 import DateTimeValidator from '@planning-inspectorate/dynamic-forms/src/validator/date-time-validator.js';
@@ -53,11 +44,6 @@ export function getQuestions(
 		isQuestionView: false
 	}
 ) {
-	const env = loadEnvironmentConfig();
-
-	// this is to avoid a database read when the data is static - but it does vary by environment
-	// the options here should match the dev/prod seed scripts
-	const LPAs = env === ENVIRONMENT_NAME.PROD ? LOCAL_PLANNING_AUTHORITIES_PROD : LOCAL_PLANNING_AUTHORITIES_DEV;
 	const applicantContactsValidator = getApplicantContactsValidator(overrides.hasAgentAnswer);
 
 	/** @type {Record<string, import('@planning-inspectorate/dynamic-forms/src/questions/question-props.js').QuestionProps>} */
@@ -130,7 +116,7 @@ export function getQuestions(
 				),
 				new RequiredValidator('Select the local planning authority')
 			],
-			options: lpaListToRadioOptions(LPAs)
+			options: getLpaOptions()
 		},
 		hasSecondaryLpa: {
 			type: COMPONENT_TYPES.BOOLEAN,
@@ -153,7 +139,7 @@ export function getQuestions(
 				),
 				new RequiredValidator('Select the secondary local planning authority')
 			],
-			options: lpaListToRadioOptions(LPAs),
+			options: getLpaOptions(),
 			viewData: {
 				extraActionButtons: [
 					{

--- a/apps/manage/src/app/views/cases/view/questions.js
+++ b/apps/manage/src/app/views/cases/view/questions.js
@@ -974,3 +974,14 @@ export function getQuestions(
 	};
 	return createQuestions(questions, classes, {}, textOverrides);
 }
+
+/**
+ * Human-readable display names for fields, derived from question definitions.
+ * Uses fieldName as the key and title as the value.
+ * @type {Record<string, string>}
+ */
+export const FIELD_DISPLAY_NAMES = Object.fromEntries(
+	Object.values(getQuestions())
+		.filter((q) => q?.fieldName && q?.title)
+		.map((q) => [q.fieldName, q.title])
+);

--- a/apps/manage/src/app/views/cases/view/questions.test.js
+++ b/apps/manage/src/app/views/cases/view/questions.test.js
@@ -1,0 +1,49 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert';
+
+describe('FIELD_DISPLAY_NAMES', () => {
+	// Set environment before importing modules that depend on it
+	before(() => {
+		process.env.ENVIRONMENT = 'test';
+	});
+
+	it('should be an object', async () => {
+		const { FIELD_DISPLAY_NAMES } = await import('./questions.js');
+		assert.ok(typeof FIELD_DISPLAY_NAMES === 'object');
+		assert.ok(FIELD_DISPLAY_NAMES !== null);
+	});
+
+	it('should contain display names for key fields', async () => {
+		const { FIELD_DISPLAY_NAMES } = await import('./questions.js');
+		// These should be derived from question definitions
+		assert.ok('siteArea' in FIELD_DISPLAY_NAMES, 'should have siteArea');
+		assert.ok('lpaReference' in FIELD_DISPLAY_NAMES, 'should have lpaReference');
+		assert.ok('description' in FIELD_DISPLAY_NAMES, 'should have description');
+	});
+
+	it('should have string values for all keys', async () => {
+		const { FIELD_DISPLAY_NAMES } = await import('./questions.js');
+		for (const [key, value] of Object.entries(FIELD_DISPLAY_NAMES)) {
+			assert.strictEqual(typeof value, 'string', `${key} should have a string value`);
+			assert.ok(value.length > 0, `${key} should not be empty`);
+		}
+	});
+
+	it('should derive display name from question title', async () => {
+		const { FIELD_DISPLAY_NAMES } = await import('./questions.js');
+		// siteArea question has title "Site area (ha)"
+		assert.strictEqual(FIELD_DISPLAY_NAMES.siteArea, 'Site area (ha)');
+	});
+
+	it('should have lpaReference with correct display name', async () => {
+		const { FIELD_DISPLAY_NAMES } = await import('./questions.js');
+		assert.strictEqual(FIELD_DISPLAY_NAMES.lpaReference, 'LPA reference');
+	});
+
+	it('should have hearing and inquiry venue fields', async () => {
+		const { FIELD_DISPLAY_NAMES } = await import('./questions.js');
+		// These come from eventQuestions('hearing') and eventQuestions('inquiry')
+		assert.ok('hearingVenue' in FIELD_DISPLAY_NAMES, 'should have hearingVenue');
+		assert.ok('inquiryVenue' in FIELD_DISPLAY_NAMES, 'should have inquiryVenue');
+	});
+});

--- a/apps/manage/src/app/views/cases/view/questions.test.js
+++ b/apps/manage/src/app/views/cases/view/questions.test.js
@@ -1,12 +1,7 @@
-import { describe, it, before } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
 describe('FIELD_DISPLAY_NAMES', () => {
-	// Set environment before importing modules that depend on it
-	before(() => {
-		process.env.ENVIRONMENT = 'test';
-	});
-
 	it('should be an object', async () => {
 		const { FIELD_DISPLAY_NAMES } = await import('./questions.js');
 		assert.ok(typeof FIELD_DISPLAY_NAMES === 'object');

--- a/apps/manage/src/app/views/cases/view/update-case.test.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.test.ts
@@ -5,13 +5,12 @@ import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
 import { APPLICATION_PROCEDURE_ID, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
+import { AUDIT_ACTIONS } from '../../../audit/index.ts';
 
 /**
  * buildUpdateCase now uses an interactive transaction: db.$transaction(async (tx) => { ... }).
  * Most tests use a plain mocked db object as the tx client, so we make $transaction invoke
  * the callback with that same object.
- *
- * @param {any} mockDb
  */
 function makeTransactionInteractive(mockDb) {
 	mockDb.$transaction.mock.mockImplementation(async (arg) => {
@@ -2536,5 +2535,302 @@ describe('case details', () => {
 
 			assert.strictEqual(db.contact.update.mock.callCount(), 0);
 		});
+	});
+});
+
+describe('audit recording', () => {
+	const createMockAudit = () => ({
+		recordMany: mock.fn(() => Promise.resolve())
+	});
+
+	const buildDbForAudit = (existingCaseData = {}) => {
+		const mockDb = {
+			$transaction: mock.fn(() => Promise.resolve()),
+			crownDevelopment: {
+				update: mock.fn(),
+				findUnique: mock.fn(() => ({
+					id: 'case-1',
+					...existingCaseData
+				}))
+			}
+		};
+		makeTransactionInteractive(mockDb);
+		return mockDb;
+	};
+
+	it('should record audit entry with FIELD_SET action when setting a field from null', async () => {
+		const logger = mockLogger();
+		const mockAudit = createMockAudit();
+		const mockDb = buildDbForAudit({ siteArea: null });
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: { account: { localAccountId: 'user-123' } }
+		};
+		const mockRes = { locals: {} };
+		const data = {
+			answers: {
+				siteArea: 10.5
+			}
+		};
+
+		await updateCase({ req: mockReq, res: mockRes, data });
+
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
+		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		assert.strictEqual(entries.length, 1);
+		assert.strictEqual(entries[0].caseId, 'case-1');
+		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_SET);
+		assert.strictEqual(entries[0].userId, 'user-123');
+		assert.strictEqual(entries[0].metadata.fieldName, 'Site area (ha)');
+		assert.strictEqual(entries[0].metadata.oldValue, '-');
+		assert.strictEqual(entries[0].metadata.newValue, '10.5');
+	});
+
+	it('should record audit entry with FIELD_CLEARED action when clearing a field to null', async () => {
+		const logger = mockLogger();
+		const mockAudit = createMockAudit();
+		const mockDb = buildDbForAudit({ lpaReference: 'ABC/123' });
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit }, true);
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: { account: { localAccountId: 'user-456' } }
+		};
+		const mockRes = { locals: {} };
+		const data = {
+			answers: {
+				lpaReference: 'ABC/123' // Will be cleared to null because clearAnswer=true
+			}
+		};
+
+		await updateCase({ req: mockReq, res: mockRes, data });
+
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
+		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		assert.strictEqual(entries.length, 1);
+		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_CLEARED);
+		assert.strictEqual(entries[0].metadata.fieldName, 'LPA reference');
+		assert.strictEqual(entries[0].metadata.oldValue, 'ABC/123');
+		assert.strictEqual(entries[0].metadata.newValue, '-');
+	});
+
+	it('should record audit entry with FIELD_UPDATED action when changing a field value', async () => {
+		const logger = mockLogger();
+		const mockAudit = createMockAudit();
+		const mockDb = buildDbForAudit({ lpaReference: 'OLD/REF' });
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: { account: { localAccountId: 'user-789' } }
+		};
+		const mockRes = { locals: {} };
+		const data = {
+			answers: {
+				lpaReference: 'NEW/REF'
+			}
+		};
+
+		await updateCase({ req: mockReq, res: mockRes, data });
+
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
+		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		assert.strictEqual(entries.length, 1);
+		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_UPDATED);
+		assert.strictEqual(entries[0].metadata.fieldName, 'LPA reference');
+		assert.strictEqual(entries[0].metadata.oldValue, 'OLD/REF');
+		assert.strictEqual(entries[0].metadata.newValue, 'NEW/REF');
+	});
+
+	it('should not record audit entry when field value has not changed', async () => {
+		const logger = mockLogger();
+		const mockAudit = createMockAudit();
+		const mockDb = buildDbForAudit({ lpaReference: 'ABC/123' });
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: { account: { localAccountId: 'user-123' } }
+		};
+		const mockRes = { locals: {} };
+		const data = {
+			answers: {
+				lpaReference: 'ABC/123' // Same value as existing
+			}
+		};
+
+		await updateCase({ req: mockReq, res: mockRes, data });
+
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
+		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		assert.strictEqual(entries.length, 0);
+	});
+
+	it('should not block user operation when audit recording fails', async () => {
+		const logger = mockLogger();
+		const mockAudit = {
+			recordMany: mock.fn(() => Promise.reject(new Error('Audit service unavailable')))
+		};
+		const mockDb = buildDbForAudit({ siteArea: null });
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: { account: { localAccountId: 'user-123' } }
+		};
+		const mockRes = { locals: {} };
+		const data = {
+			answers: {
+				siteArea: 10.5
+			}
+		};
+
+		// Should not throw
+		await assert.doesNotReject(() => updateCase({ req: mockReq, res: mockRes, data }));
+
+		// Verify the case was still updated
+		assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
+
+		// Verify error was logged
+		assert.strictEqual(logger.error.mock.callCount(), 1);
+		const errorCall = logger.error.mock.calls[0];
+		assert.strictEqual(errorCall.arguments[0].caseId, 'case-1');
+		assert.strictEqual(errorCall.arguments[1], 'Failed to record audit events');
+	});
+
+	it('should not call audit when database transaction fails', async () => {
+		const logger = mockLogger();
+		const mockAudit = createMockAudit();
+		const mockDb = {
+			$transaction: mock.fn(() => Promise.reject(new Error('Database error'))),
+			crownDevelopment: {
+				update: mock.fn(),
+				findUnique: mock.fn(() => ({ id: 'case-1', siteArea: null }))
+			}
+		};
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: { account: { localAccountId: 'user-123' } }
+		};
+		const mockRes = { locals: {} };
+		const data = {
+			answers: {
+				siteArea: 10.5
+			}
+		};
+
+		await assert.rejects(() => updateCase({ req: mockReq, res: mockRes, data }));
+
+		// Verify audit was NOT called because the update failed
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 0);
+	});
+
+	it('should handle undefined userId in audit entries', async () => {
+		const logger = mockLogger();
+		const mockAudit = createMockAudit();
+		const mockDb = buildDbForAudit({ siteArea: null });
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: {} // No account/localAccountId
+		};
+		const mockRes = { locals: {} };
+		const data = {
+			answers: {
+				siteArea: 10.5
+			}
+		};
+
+		await updateCase({ req: mockReq, res: mockRes, data });
+
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
+		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		assert.strictEqual(entries[0].userId, undefined);
+	});
+
+	it('should record audit entry for hearingVenue field', async () => {
+		const logger = mockLogger();
+		const mockAudit = createMockAudit();
+		const mockDb = buildDbForAudit({ hearingVenue: null });
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: { account: { localAccountId: 'user-123' } }
+		};
+		const mockRes = {
+			locals: {
+				originalAnswers: {
+					eventId: 'event-1',
+					procedureId: 'hearing'
+				}
+			}
+		};
+		const data = {
+			answers: {
+				hearingVenue: 'Bristol Hearing Centre'
+			}
+		};
+
+		await updateCase({ req: mockReq, res: mockRes, data });
+
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
+		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		assert.strictEqual(entries.length, 1);
+		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_SET);
+		assert.strictEqual(entries[0].metadata.fieldName, 'Hearing venue');
+		assert.strictEqual(entries[0].metadata.newValue, 'Bristol Hearing Centre');
+	});
+
+	it('should record audit entry for agentOrganisationName field', async () => {
+		const logger = mockLogger();
+		const mockAudit = createMockAudit();
+		const mockDb = {
+			$transaction: mock.fn(() => Promise.resolve()),
+			organisation: {
+				create: mock.fn(() => ({ id: 'new-agent-org-1' })),
+				update: mock.fn(() => ({ kind: 'organisation.update' }))
+			},
+			crownDevelopmentToOrganisation: {
+				create: mock.fn((args) => args)
+			},
+			crownDevelopment: {
+				update: mock.fn(() => ({})),
+				findUnique: mock.fn(() => ({
+					id: 'case-1',
+					linkedParentId: null,
+					ChildrenCrownDevelopment: [],
+					Organisations: []
+				})),
+				findMany: mock.fn(() => Promise.resolve([{ id: 'case-1', Organisations: [] }]))
+			}
+		};
+		makeTransactionInteractive(mockDb);
+
+		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
+		const mockReq = {
+			params: { id: 'case-1' },
+			session: { account: { localAccountId: 'user-123' } }
+		};
+		const mockRes = { locals: {} };
+		const data = {
+			answers: {
+				agentOrganisationName: 'New Agent Org Ltd'
+			}
+		};
+
+		await updateCase({ req: mockReq, res: mockRes, data });
+
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
+		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		assert.strictEqual(entries.length, 1);
+		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_SET);
+		assert.strictEqual(entries[0].metadata.fieldName, 'Agent organisation name');
+		assert.strictEqual(entries[0].metadata.newValue, 'New Agent Org Ltd');
 	});
 });

--- a/apps/manage/src/app/views/cases/view/update-case.test.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.test.ts
@@ -2737,7 +2737,7 @@ describe('audit recording', () => {
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 0);
 	});
 
-	it('should handle undefined userId in audit entries', async () => {
+	it('should skip audit and log warning when userId is undefined', async () => {
 		const logger = mockLogger();
 		const mockAudit = createMockAudit();
 		const mockDb = buildDbForAudit({ siteArea: null });
@@ -2756,9 +2756,12 @@ describe('audit recording', () => {
 
 		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
-		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
-		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
-		assert.strictEqual(entries[0].userId, undefined);
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 0);
+
+		assert.strictEqual((logger as any).warn.mock.callCount(), 1);
+		const warnCall = (logger as any).warn.mock.calls[0];
+		assert.strictEqual(warnCall.arguments[0].caseId, 'case-1');
+		assert.strictEqual(warnCall.arguments[1], 'Skipping audit: no userId available');
 	});
 
 	it('should record audit entry for hearingVenue field', async () => {

--- a/apps/manage/src/app/views/cases/view/update-case.test.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.test.ts
@@ -2,6 +2,7 @@ import { describe, it, mock } from 'node:test';
 import { buildUpdateCase } from './update-case.ts';
 import assert from 'node:assert';
 import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
+import { asReq, asRes } from '@pins/crowndev-lib/testing/mock-express.ts';
 import { APPLICATION_PROCEDURE_ID, ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/components/boolean/question.js';
@@ -12,8 +13,8 @@ import { AUDIT_ACTIONS } from '../../../audit/index.ts';
  * Most tests use a plain mocked db object as the tx client, so we make $transaction invoke
  * the callback with that same object.
  */
-function makeTransactionInteractive(mockDb) {
-	mockDb.$transaction.mock.mockImplementation(async (arg) => {
+function makeTransactionInteractive(mockDb: any) {
+	mockDb.$transaction.mock.mockImplementation(async (arg: any) => {
 		if (typeof arg === 'function') {
 			return arg(mockDb);
 		}
@@ -31,7 +32,7 @@ describe('case details', () => {
 			const mockReq = { params: {} };
 			const mockRes = { locals: {} };
 			const data = {};
-			await assert.rejects(() => updateCase({ req: mockReq, res: mockRes, data }));
+			await assert.rejects(() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any));
 		});
 		it('should do nothing if no updates', async () => {
 			const logger = mockLogger();
@@ -46,10 +47,10 @@ describe('case details', () => {
 			const mockReq = { params: { id: 'case-1' } };
 			const mockRes = { locals: {} };
 			const data = {};
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 0);
-			assert.strictEqual(logger.info.mock.callCount(), 2);
-			const args = logger.info.mock.calls[1].arguments[1];
+			assert.strictEqual((logger.info as any).mock.callCount(), 2);
+			const args = (logger.info as any).mock.calls[1].arguments[1];
 			assert.strictEqual(args, 'no case updates to apply');
 		});
 		it('should call db update and add to session', async () => {
@@ -73,11 +74,11 @@ describe('case details', () => {
 					description: 'My new application description'
 				}
 			};
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
-			assert.strictEqual(mockReq.session?.cases?.case1.updated, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.updated, true);
 		});
 
 		it('should set agent status updated when agent is removed', async () => {
@@ -110,9 +111,9 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
-			assert.strictEqual(mockReq.session?.cases?.case1.agentStatusUpdated, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.agentStatusUpdated, true);
 		});
 
 		it('should set agent status updated when agent is added', async () => {
@@ -145,9 +146,9 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
-			assert.strictEqual(mockReq.session?.cases?.case1.agentStatusUpdated, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.agentStatusUpdated, true);
 		});
 
 		it('should not set agent status updated when agent status does not change', async () => {
@@ -180,9 +181,9 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
-			assert.strictEqual(mockReq.session?.cases?.case1.agentStatusUpdated, undefined);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.agentStatusUpdated, undefined);
 		});
 
 		it('should set applicant organisation added when applicant organisation count increases', async () => {
@@ -215,9 +216,9 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
-			assert.strictEqual(mockReq.session?.cases?.case1.applicantOrgAdded, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.applicantOrgAdded, true);
 		});
 
 		it('should not set applicant organisation added when applicant organisation count does not increase', async () => {
@@ -250,9 +251,9 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
-			assert.strictEqual(mockReq.session?.cases?.case1.applicantOrgAdded, undefined);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.applicantOrgAdded, undefined);
 		});
 		it('should update both parent case and linked child case if child linked case id is present and field not in deLinked field list', async () => {
 			const logger = mockLogger();
@@ -282,14 +283,14 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 2);
 
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
 
-			const updateLinkedCaseArg = mockDb.crownDevelopment.update.mock.calls[1].arguments[0];
+			const updateLinkedCaseArg = (mockDb.crownDevelopment.update.mock.calls[1] as any).arguments[0];
 			assert.strictEqual(updateLinkedCaseArg.where?.id, 'linked-case-id-1');
 		});
 		it('should update both child case and linked parent case if child linked case id is present and field not in deLinked field list', async () => {
@@ -316,14 +317,14 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 2);
 
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'linked-case-id-1');
 
-			const updateLinkedCaseArg = mockDb.crownDevelopment.update.mock.calls[1].arguments[0];
+			const updateLinkedCaseArg = (mockDb.crownDevelopment.update.mock.calls[1] as any).arguments[0];
 			assert.strictEqual(updateLinkedCaseArg.where?.id, 'case1');
 		});
 		it('should call update case but not the linked case if linkedCaseId present and field is in deLinked field list', async () => {
@@ -353,7 +354,7 @@ describe('case details', () => {
 					statusId: 'acceptance'
 				}
 			};
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
 		});
 
@@ -404,16 +405,16 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			// Linked-case flow: organisation is created once, then both cases are linked via the join table
 			assert.strictEqual(mockDb.organisation.create.mock.callCount(), 1);
-			const orgCreateArg = mockDb.organisation.create.mock.calls[0].arguments[0];
+			const orgCreateArg = (mockDb.organisation.create.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(orgCreateArg.data?.name, 'New Applicant Org');
 
 			// All writes are submitted via a single transaction
 			assert.strictEqual(mockDb.$transaction.mock.callCount(), 1);
-			assert.strictEqual(typeof mockDb.$transaction.mock.calls[0].arguments[0], 'function');
+			assert.strictEqual(typeof (mockDb.$transaction.mock.calls[0] as any).arguments[0], 'function');
 
 			assert.strictEqual(mockDb.crownDevelopmentToOrganisation.create.mock.callCount(), 2);
 			const linkCalls = mockDb.crownDevelopmentToOrganisation.create.mock.calls.map((c) => c.arguments[0]);
@@ -466,12 +467,12 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			assert.strictEqual(mockDb.organisation.create.mock.callCount(), 1);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
 			assert.strictEqual(mockDb.crownDevelopmentToOrganisation.create.mock.callCount(), 1);
-			const linkArg = mockDb.crownDevelopmentToOrganisation.create.mock.calls[0].arguments[0];
+			const linkArg = (mockDb.crownDevelopmentToOrganisation.create.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(linkArg.data?.crownDevelopmentId, 'case1');
 			assert.strictEqual(linkArg.data?.role, ORGANISATION_ROLES_ID.APPLICANT);
 		});
@@ -526,11 +527,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			// Should update the existing address once
 			assert.strictEqual(mockDb.address.update.mock.callCount(), 1);
-			const addressUpdateArg = mockDb.address.update.mock.calls[0].arguments[0];
+			const addressUpdateArg = (mockDb.address.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(addressUpdateArg.where?.id, 'existing-address-1');
 			assert.strictEqual(addressUpdateArg.data?.line1, '123 Main Street');
 			assert.strictEqual(addressUpdateArg.data?.postcode, 'SW1A 1AA');
@@ -539,8 +540,8 @@ describe('case details', () => {
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 2);
 
 			// Both cases should be connected to the same address
-			const parentUpdate = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
-			const childUpdate = mockDb.crownDevelopment.update.mock.calls[1].arguments[0];
+			const parentUpdate = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
+			const childUpdate = (mockDb.crownDevelopment.update.mock.calls[1] as any).arguments[0];
 			assert.strictEqual(parentUpdate.where?.id, 'parent-case-id');
 			assert.strictEqual(childUpdate.where?.id, 'child-lbc-case-id');
 			assert.strictEqual(parentUpdate.data?.SiteAddress?.connect?.id, 'existing-address-1');
@@ -596,11 +597,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			// Should update the parent's existing address
 			assert.strictEqual(mockDb.address.update.mock.callCount(), 1);
-			const addressUpdateArg = mockDb.address.update.mock.calls[0].arguments[0];
+			const addressUpdateArg = (mockDb.address.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(addressUpdateArg.where?.id, 'existing-address-1');
 			assert.strictEqual(addressUpdateArg.data?.line1, '456 Updated Street');
 
@@ -608,8 +609,8 @@ describe('case details', () => {
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 2);
 
 			// Both cases should be connected to the same address
-			const childUpdate = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
-			const parentUpdate = mockDb.crownDevelopment.update.mock.calls[1].arguments[0];
+			const childUpdate = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
+			const parentUpdate = (mockDb.crownDevelopment.update.mock.calls[1] as any).arguments[0];
 			assert.strictEqual(childUpdate.where?.id, 'child-lbc-case-id');
 			assert.strictEqual(parentUpdate.where?.id, 'parent-case-id');
 			assert.strictEqual(childUpdate.data?.SiteAddress?.connect?.id, 'existing-address-1');
@@ -665,11 +666,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			// Should update the child's existing address instead of creating a new one
 			assert.strictEqual(mockDb.address.update.mock.callCount(), 1);
-			const addressUpdateArg = mockDb.address.update.mock.calls[0].arguments[0];
+			const addressUpdateArg = (mockDb.address.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(addressUpdateArg.where?.id, 'child-address-1');
 			assert.strictEqual(addressUpdateArg.data?.line1, '123 Child Street');
 
@@ -677,8 +678,8 @@ describe('case details', () => {
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 2);
 
 			// Both cases should be connected to the child's address
-			const childUpdate = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
-			const parentUpdate = mockDb.crownDevelopment.update.mock.calls[1].arguments[0];
+			const childUpdate = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
+			const parentUpdate = (mockDb.crownDevelopment.update.mock.calls[1] as any).arguments[0];
 			assert.strictEqual(childUpdate.where?.id, 'child-lbc-case-id');
 			assert.strictEqual(parentUpdate.where?.id, 'parent-case-id');
 			assert.strictEqual(childUpdate.data?.SiteAddress?.connect?.id, 'child-address-1');
@@ -735,11 +736,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			// Should create a new address
 			assert.strictEqual(mockDb.address.create.mock.callCount(), 1);
-			const addressCreateArg = mockDb.address.create.mock.calls[0].arguments[0];
+			const addressCreateArg = (mockDb.address.create.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(addressCreateArg.data?.line1, '789 New Street');
 			assert.strictEqual(addressCreateArg.data?.townCity, 'Birmingham');
 
@@ -747,8 +748,8 @@ describe('case details', () => {
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 2);
 
 			// Both cases should be connected to the new address
-			const parentUpdate = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
-			const childUpdate = mockDb.crownDevelopment.update.mock.calls[1].arguments[0];
+			const parentUpdate = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
+			const childUpdate = (mockDb.crownDevelopment.update.mock.calls[1] as any).arguments[0];
 			assert.strictEqual(parentUpdate.data?.SiteAddress?.connect?.id, 'new-address-1');
 			assert.strictEqual(childUpdate.data?.SiteAddress?.connect?.id, 'new-address-1');
 		});
@@ -788,11 +789,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			// Should update only the single case (normal behavior)
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'single-case-id');
 			// For single cases, the address upsert is handled in the normal way (nested in the case update)
 			assert.ok(updateArg.data?.SiteAddress?.upsert);
@@ -826,10 +827,10 @@ describe('case details', () => {
 					inquiryVenue: 'some place'
 				}
 			};
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			assert.strictEqual(mockReq.session?.cases?.case1.updated, true);
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.updated, true);
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
 			assert.strictEqual(updateArg.data?.Event?.upsert?.where?.id, 'event-1');
 			assert.strictEqual(updateArg.data?.Event?.upsert?.create.venue, 'some place');
@@ -880,11 +881,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			assert.strictEqual(mockReq.session?.cases?.case1.updated, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.updated, true);
 
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
 			assert.strictEqual(updateArg.data?.lpaQuestionnaireReceivedDate, date);
 			assert.strictEqual(updateArg.data?.lpaQuestionnaireReceivedEmailSent, true);
@@ -947,11 +948,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			assert.strictEqual(mockReq.session?.cases?.case1.updated, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.updated, true);
 
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
 			assert.strictEqual(updateArg.data?.lpaQuestionnaireReceivedDate, date);
 			assert.strictEqual(updateArg.data?.lpaQuestionnaireReceivedEmailSent, true);
@@ -1016,7 +1017,7 @@ describe('case details', () => {
 				}
 			};
 
-			await assert.rejects(() => updateCase({ req: mockReq, res: mockRes, data }));
+			await assert.rejects(() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any));
 		});
 		it('should dispatch Application Received Date Notification with fee', async () => {
 			const logger = mockLogger();
@@ -1082,11 +1083,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			assert.strictEqual(mockReq.session?.cases?.case1.updated, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.updated, true);
 
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
 			assert.strictEqual(updateArg.data?.applicationReceivedDate, date);
 			assert.strictEqual(updateArg.data?.applicationReceivedDateEmailSent, true);
@@ -1167,11 +1168,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			assert.strictEqual(mockReq.session?.cases?.case1.updated, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.updated, true);
 
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
 			assert.strictEqual(updateArg.data?.applicationReceivedDate, date);
 			assert.strictEqual(updateArg.data?.applicationReceivedDateEmailSent, true);
@@ -1221,19 +1222,19 @@ describe('case details', () => {
 			};
 
 			await assert.rejects(
-				() => updateCase({ req: mockReq, res: mockRes, data }),
+				() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any),
 				(err) => {
-					assert.strictEqual(err.name, 'Error');
-					assert.strictEqual(err.errorSummary.length, 3);
-					assert.strictEqual(err.errorSummary[0].text, 'Enter the site address');
-					assert.strictEqual(err.errorSummary[0].href, '/cases/case1/overview/site-address');
-					assert.strictEqual(err.errorSummary[1].text, 'Enter the site coordinates');
-					assert.strictEqual(err.errorSummary[1].href, '/cases/case1/overview/site-coordinates');
+					assert.strictEqual((err as any).name, 'Error');
+					assert.strictEqual((err as any).errorSummary.length, 3);
+					assert.strictEqual((err as any).errorSummary[0].text, 'Enter the site address');
+					assert.strictEqual((err as any).errorSummary[0].href, '/cases/case1/overview/site-address');
+					assert.strictEqual((err as any).errorSummary[1].text, 'Enter the site coordinates');
+					assert.strictEqual((err as any).errorSummary[1].href, '/cases/case1/overview/site-coordinates');
 					assert.strictEqual(
-						err.errorSummary[2].text,
+						(err as any).errorSummary[2].text,
 						'Confirm whether there is an application fee, and enter the amount if applicable'
 					);
-					assert.strictEqual(err.errorSummary[2].href, '/cases/case1/fee/fee-amount');
+					assert.strictEqual((err as any).errorSummary[2].href, '/cases/case1/fee/fee-amount');
 					return true;
 				}
 			);
@@ -1273,12 +1274,12 @@ describe('case details', () => {
 			};
 
 			await assert.rejects(
-				() => updateCase({ req: mockReq, res: mockRes, data }),
+				() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any),
 				(err) => {
-					assert.strictEqual(err.name, 'Error');
-					assert.strictEqual(err.errorSummary.length, 2);
-					assert.strictEqual(err.errorSummary[0].text, 'Enter the site address');
-					assert.strictEqual(err.errorSummary[1].text, 'Enter the site coordinates');
+					assert.strictEqual((err as any).name, 'Error');
+					assert.strictEqual((err as any).errorSummary.length, 2);
+					assert.strictEqual((err as any).errorSummary[0].text, 'Enter the site address');
+					assert.strictEqual((err as any).errorSummary[1].text, 'Enter the site coordinates');
 					return true;
 				}
 			);
@@ -1318,12 +1319,12 @@ describe('case details', () => {
 			};
 
 			await assert.rejects(
-				() => updateCase({ req: mockReq, res: mockRes, data }),
+				() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any),
 				(err) => {
-					assert.strictEqual(err.name, 'Error');
-					assert.strictEqual(err.errorSummary.length, 1);
+					assert.strictEqual((err as any).name, 'Error');
+					assert.strictEqual((err as any).errorSummary.length, 1);
 					assert.strictEqual(
-						err.errorSummary[0].text,
+						(err as any).errorSummary[0].text,
 						'Confirm whether there is an application fee, and enter the amount if applicable'
 					);
 					return true;
@@ -1380,7 +1381,7 @@ describe('case details', () => {
 				}
 			};
 
-			await assert.rejects(() => updateCase({ req: mockReq, res: mockRes, data }));
+			await assert.rejects(() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any));
 		});
 		it('should dispatch Application not of national importance Notification', async () => {
 			const logger = mockLogger();
@@ -1441,11 +1442,11 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			assert.strictEqual(mockReq.session?.cases?.case1.updated, true);
+			assert.strictEqual((mockReq.session as any)?.cases?.case1.updated, true);
 
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
 			assert.strictEqual(updateArg.data?.turnedAwayDate, date);
 			assert.strictEqual(updateArg.data?.notNationallyImportantEmailSent, true);
@@ -1510,7 +1511,7 @@ describe('case details', () => {
 				}
 			};
 
-			await assert.rejects(() => updateCase({ req: mockReq, res: mockRes, data }));
+			await assert.rejects(() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any));
 		});
 		it('should not throw Prisma errors', async () => {
 			const logger = mockLogger();
@@ -1518,7 +1519,7 @@ describe('case details', () => {
 				$transaction: mock.fn(() => Promise.resolve()),
 				crownDevelopment: {
 					findUnique: mock.fn(() => {
-						throw new Prisma.PrismaClientKnownRequestError('Error', { code: 'E101' });
+						throw new Prisma.PrismaClientKnownRequestError('Error', { code: 'E101', clientVersion: '' });
 					})
 				}
 			};
@@ -1535,10 +1536,10 @@ describe('case details', () => {
 				}
 			};
 			await assert.rejects(
-				() => updateCase({ req: mockReq, res: mockRes, data }),
+				() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any),
 				(err) => {
-					assert.strictEqual(err.name, 'Error');
-					assert.strictEqual(err.message, 'Error updating case (E101)');
+					assert.strictEqual((err as any).name, 'Error');
+					assert.strictEqual((err as any).message, 'Error updating case (E101)');
 					return true;
 				}
 			);
@@ -1566,9 +1567,9 @@ describe('case details', () => {
 					siteNorthing: '000123'
 				}
 			};
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
-			const updateArg = mockDb.crownDevelopment.update.mock.calls[0].arguments[0];
+			const updateArg = (mockDb.crownDevelopment.update.mock.calls[0] as any).arguments[0];
 			assert.strictEqual(updateArg.where?.id, 'case1');
 			assert.strictEqual(updateArg.data.siteNorthing, null);
 		});
@@ -1595,7 +1596,7 @@ describe('case details', () => {
 					description: 'the description'
 				}
 			};
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 			assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 0);
 		});
 
@@ -1630,8 +1631,8 @@ describe('case details', () => {
 				}
 			};
 
-			await assert.rejects(() => updateCase({ req: mockReq, res: mockRes, data }));
-			assert.strictEqual(data.answers.lpaQuestionnaireSpecialEmailSent, undefined);
+			await assert.rejects(() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any));
+			assert.strictEqual((data.answers as Record<string, unknown>).lpaQuestionnaireSpecialEmailSent, undefined);
 		});
 		it('should send LPA Questionnaire Sent Notification and update', async () => {
 			const logger = mockLogger();
@@ -1667,10 +1668,10 @@ describe('case details', () => {
 				}
 			};
 
-			await updateCase({ req: mockReq, res: mockRes, data });
+			await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 			assert.strictEqual(mockNotifyClient.sendLpaQuestionnaireNotification.mock.callCount(), 1);
-			assert.strictEqual(data.answers.lpaQuestionnaireSpecialEmailSent, true);
+			assert.strictEqual((data.answers as Record<string, unknown>).lpaQuestionnaireSpecialEmailSent, true);
 		});
 
 		it('should update shared agent organisation once and link it to both cases when updating linked cases', async () => {
@@ -1720,21 +1721,25 @@ describe('case details', () => {
 			const mockReq = { params: { id: 'case1' }, session: {} };
 			const mockRes = { locals: {} };
 			await updateCase({
-				req: mockReq,
-				res: mockRes,
+				req: asReq(mockReq),
+				res: asRes(mockRes),
 				data: {
 					answers: {
 						agentOrganisationName: 'Updated Agent Org'
 					}
 				}
-			});
+			} as any);
 
 			assert.strictEqual(mockDb.organisation.update.mock.callCount(), 1);
-			assert.deepStrictEqual(mockDb.organisation.update.mock.calls[0].arguments[0].where, { id: 'shared-agent-org-1' });
-			assert.deepStrictEqual(mockDb.organisation.update.mock.calls[0].arguments[0].data, { name: 'Updated Agent Org' });
+			assert.deepStrictEqual((mockDb.organisation.update.mock.calls[0] as any).arguments[0].where, {
+				id: 'shared-agent-org-1'
+			});
+			assert.deepStrictEqual((mockDb.organisation.update.mock.calls[0] as any).arguments[0].data, {
+				name: 'Updated Agent Org'
+			});
 
 			assert.strictEqual(mockDb.crownDevelopmentToOrganisation.create.mock.callCount(), 1);
-			assert.deepStrictEqual(mockDb.crownDevelopmentToOrganisation.create.mock.calls[0].arguments[0].data, {
+			assert.deepStrictEqual((mockDb.crownDevelopmentToOrganisation.create.mock.calls[0] as any).arguments[0].data, {
 				crownDevelopmentId: 'linked-parent-1',
 				organisationId: 'shared-agent-org-1',
 				role: ORGANISATION_ROLES_ID.AGENT
@@ -1776,17 +1781,20 @@ describe('case details', () => {
 			const mockReq = { params: { id: 'case1' }, session: {} };
 			const mockRes = { locals: {} };
 			await updateCase({
-				req: mockReq,
-				res: mockRes,
+				req: asReq(mockReq),
+				res: asRes(mockRes),
 				data: {
 					answers: {
 						agentOrganisationName: 'New Shared Agent Org'
 					}
 				}
-			});
+			} as any);
 
 			assert.strictEqual(mockDb.organisation.create.mock.callCount(), 1);
-			assert.strictEqual(mockDb.organisation.create.mock.calls[0].arguments[0].data?.name, 'New Shared Agent Org');
+			assert.strictEqual(
+				(mockDb.organisation.create.mock.calls[0] as any).arguments[0].data?.name,
+				'New Shared Agent Org'
+			);
 
 			assert.strictEqual(mockDb.crownDevelopmentToOrganisation.create.mock.callCount(), 2);
 			const linkCalls = mockDb.crownDevelopmentToOrganisation.create.mock.calls.map((c) => c.arguments[0].data);
@@ -1879,10 +1887,10 @@ describe('case details', () => {
 
 			const updateCase = buildUpdateCase({ db: mockDb, logger, notifyClient: {} });
 			await updateCase({
-				req: { params: { id: 'case-1' }, session: {} },
-				res: { locals: {} },
+				req: asReq({ params: { id: 'case-1' }, session: {} }),
+				res: asRes({ locals: {} }),
 				data: { answers: { hasAgent: false } }
-			});
+			} as any);
 
 			assert.strictEqual(mockDb.crownDevelopment.findMany.mock.callCount(), 1);
 			assert.strictEqual(mockDb.crownDevelopmentToOrganisation.deleteMany.mock.callCount(), 1);
@@ -1900,7 +1908,7 @@ describe('case details', () => {
 		};
 
 		// Patch buildDbWithOrgs to include role and Role
-		const buildDbWithOrgs = (organisations) => {
+		const buildDbWithOrgs = (organisations: any) => {
 			const db = {
 				$transaction: mock.fn(() => Promise.resolve()),
 				contact: {
@@ -1917,7 +1925,7 @@ describe('case details', () => {
 						linkedParentId: null,
 						ChildrenCrownDevelopment: [],
 						ParentCrownDevelopment: null,
-						Organisations: organisations.map((org) => ({
+						Organisations: organisations.map((org: any) => ({
 							...org,
 							role: mockRole.id,
 							Role: mockRole
@@ -1932,7 +1940,7 @@ describe('case details', () => {
 
 		const buildReq = () => ({ params: { id: 'case-1' }, session: {} });
 
-		const buildRes = (originalAnswers) => ({
+		const buildRes = (originalAnswers: any = {}) => ({
 			locals: {
 				journeyResponse: {
 					answers: {}
@@ -1941,15 +1949,15 @@ describe('case details', () => {
 			}
 		});
 
-		const runUpdateCase = async ({ db, logger, req, res, answers }) => {
+		const runUpdateCase = async ({ db, logger, req, res, answers }: any) => {
 			const updateCase = buildUpdateCase({ db, logger, notifyClient: {} });
 			await updateCase({
-				req,
-				res,
+				req: asReq(req),
+				res: asRes(res),
 				data: {
 					answers
 				}
-			});
+			} as any);
 		};
 
 		it('should update a single existing contact when details have changed', async () => {
@@ -2014,7 +2022,7 @@ describe('case details', () => {
 			});
 
 			assert.strictEqual(db.contact.update.mock.callCount(), 1);
-			const arg = db.contact.update.mock.calls[0].arguments[0];
+			const arg = (db.contact.update.mock.calls[0] as any).arguments[0];
 			assert.deepStrictEqual(arg.where, { id: 'contact-1' });
 			assert.deepStrictEqual(arg.data, {
 				firstName: 'New',
@@ -2122,8 +2130,8 @@ describe('case details', () => {
 			});
 
 			assert.strictEqual(db.contact.update.mock.callCount(), 2);
-			assert.deepStrictEqual(db.contact.update.mock.calls[0].arguments[0].where, { id: 'contact-1' });
-			assert.deepStrictEqual(db.contact.update.mock.calls[1].arguments[0].where, { id: 'contact-2' });
+			assert.deepStrictEqual((db.contact.update.mock.calls[0] as any).arguments[0].where, { id: 'contact-1' });
+			assert.deepStrictEqual((db.contact.update.mock.calls[1] as any).arguments[0].where, { id: 'contact-2' });
 		});
 
 		it('should not update an existing contact when no contact fields have changed', async () => {
@@ -2164,14 +2172,14 @@ describe('case details', () => {
 			};
 
 			await updateCase({
-				req,
-				res,
+				req: asReq(req),
+				res: asRes(res),
 				data: {
 					answers: {
 						manageApplicantDetails: [{ id: 'org-1', organisationRelationId: 'rel-1' }]
 					}
 				}
-			});
+			} as any);
 
 			assert.strictEqual(db.contact.update.mock.callCount(), 0);
 		});
@@ -2204,14 +2212,14 @@ describe('case details', () => {
 			};
 
 			await updateCase({
-				req,
-				res,
+				req: asReq(req),
+				res: asRes(res),
 				data: {
 					answers: {
 						manageApplicantDetails: [{ id: 'org-1', organisationRelationId: 'rel-1' }]
 					}
 				}
-			});
+			} as any);
 
 			assert.strictEqual(db.contact.update.mock.callCount(), 0);
 		});
@@ -2224,7 +2232,7 @@ describe('case details', () => {
 		};
 
 		// Patch buildDbWithOrgs to include role and Role
-		const buildDbWithOrgs = (organisations) => {
+		const buildDbWithOrgs = (organisations: any) => {
 			const db = {
 				$transaction: mock.fn(() => Promise.resolve()),
 				organisation: {
@@ -2248,7 +2256,7 @@ describe('case details', () => {
 						linkedParentId: null,
 						ChildrenCrownDevelopment: [],
 						ParentCrownDevelopment: null,
-						Organisations: organisations.map((org) => ({
+						Organisations: organisations.map((org: any) => ({
 							...org,
 							role: mockRole.id,
 							Role: mockRole
@@ -2258,7 +2266,7 @@ describe('case details', () => {
 						Promise.resolve([
 							{
 								id: 'case-1',
-								Organisations: organisations.map((org) => ({
+								Organisations: organisations.map((org: any) => ({
 									...org,
 									role: mockRole.id,
 									Role: mockRole
@@ -2275,7 +2283,7 @@ describe('case details', () => {
 
 		const buildReq = () => ({ params: { id: 'case-1' }, session: {} });
 
-		const buildRes = (originalAnswers) => ({
+		const buildRes = (originalAnswers: any = {}) => ({
 			locals: {
 				journeyResponse: {
 					answers: {}
@@ -2284,15 +2292,15 @@ describe('case details', () => {
 			}
 		});
 
-		const runUpdateCase = async ({ db, logger, req, res, answers }) => {
+		const runUpdateCase = async ({ db, logger, req, res, answers }: any) => {
 			const updateCase = buildUpdateCase({ db, logger, notifyClient: {} });
 			await updateCase({
-				req,
-				res,
+				req: asReq(req),
+				res: asRes(res),
 				data: {
 					answers
 				}
-			});
+			} as any);
 		};
 
 		it('should update a single existing contact when details have changed', async () => {
@@ -2357,7 +2365,7 @@ describe('case details', () => {
 			});
 
 			assert.strictEqual(db.contact.update.mock.callCount(), 1);
-			const arg = db.contact.update.mock.calls[0].arguments[0];
+			const arg = (db.contact.update.mock.calls[0] as any).arguments[0];
 			assert.deepStrictEqual(arg.where, { id: 'contact-1' });
 			assert.deepStrictEqual(arg.data, {
 				firstName: 'New',
@@ -2437,8 +2445,8 @@ describe('case details', () => {
 			});
 
 			assert.strictEqual(db.contact.update.mock.callCount(), 2);
-			assert.deepStrictEqual(db.contact.update.mock.calls[0].arguments[0].where, { id: 'contact-1' });
-			assert.deepStrictEqual(db.contact.update.mock.calls[1].arguments[0].where, { id: 'contact-2' });
+			assert.deepStrictEqual((db.contact.update.mock.calls[0] as any).arguments[0].where, { id: 'contact-1' });
+			assert.deepStrictEqual((db.contact.update.mock.calls[1] as any).arguments[0].where, { id: 'contact-2' });
 		});
 
 		it('should not update an existing contact when no contact fields have changed', async () => {
@@ -2575,10 +2583,10 @@ describe('audit recording', () => {
 			}
 		};
 
-		await updateCase({ req: mockReq, res: mockRes, data });
+		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
-		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
 		assert.strictEqual(entries.length, 1);
 		assert.strictEqual(entries[0].caseId, 'case-1');
 		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_SET);
@@ -2605,10 +2613,10 @@ describe('audit recording', () => {
 			}
 		};
 
-		await updateCase({ req: mockReq, res: mockRes, data });
+		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
-		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
 		assert.strictEqual(entries.length, 1);
 		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_CLEARED);
 		assert.strictEqual(entries[0].metadata.fieldName, 'LPA reference');
@@ -2633,10 +2641,10 @@ describe('audit recording', () => {
 			}
 		};
 
-		await updateCase({ req: mockReq, res: mockRes, data });
+		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
-		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
 		assert.strictEqual(entries.length, 1);
 		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_UPDATED);
 		assert.strictEqual(entries[0].metadata.fieldName, 'LPA reference');
@@ -2661,10 +2669,10 @@ describe('audit recording', () => {
 			}
 		};
 
-		await updateCase({ req: mockReq, res: mockRes, data });
+		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
-		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
 		assert.strictEqual(entries.length, 0);
 	});
 
@@ -2688,14 +2696,14 @@ describe('audit recording', () => {
 		};
 
 		// Should not throw
-		await assert.doesNotReject(() => updateCase({ req: mockReq, res: mockRes, data }));
+		await assert.doesNotReject(() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any));
 
 		// Verify the case was still updated
 		assert.strictEqual(mockDb.crownDevelopment.update.mock.callCount(), 1);
 
 		// Verify error was logged
-		assert.strictEqual(logger.error.mock.callCount(), 1);
-		const errorCall = logger.error.mock.calls[0];
+		assert.strictEqual((logger.error as any).mock.callCount(), 1);
+		const errorCall = (logger.error as any).mock.calls[0];
 		assert.strictEqual(errorCall.arguments[0].caseId, 'case-1');
 		assert.strictEqual(errorCall.arguments[1], 'Failed to record audit events');
 	});
@@ -2723,7 +2731,7 @@ describe('audit recording', () => {
 			}
 		};
 
-		await assert.rejects(() => updateCase({ req: mockReq, res: mockRes, data }));
+		await assert.rejects(() => updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any));
 
 		// Verify audit was NOT called because the update failed
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 0);
@@ -2746,10 +2754,10 @@ describe('audit recording', () => {
 			}
 		};
 
-		await updateCase({ req: mockReq, res: mockRes, data });
+		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
-		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
 		assert.strictEqual(entries[0].userId, undefined);
 	});
 
@@ -2777,10 +2785,10 @@ describe('audit recording', () => {
 			}
 		};
 
-		await updateCase({ req: mockReq, res: mockRes, data });
+		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
-		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
 		assert.strictEqual(entries.length, 1);
 		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_SET);
 		assert.strictEqual(entries[0].metadata.fieldName, 'Hearing venue');
@@ -2824,10 +2832,10 @@ describe('audit recording', () => {
 			}
 		};
 
-		await updateCase({ req: mockReq, res: mockRes, data });
+		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
-		const entries = mockAudit.recordMany.mock.calls[0].arguments[0];
+		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
 		assert.strictEqual(entries.length, 1);
 		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_SET);
 		assert.strictEqual(entries[0].metadata.fieldName, 'Agent organisation name');

--- a/apps/manage/src/app/views/cases/view/update-case.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.ts
@@ -433,6 +433,13 @@ async function recordAuditEntries(
 	updatedFieldNames: string[],
 	logger: Logger
 ): Promise<void> {
+	// Bail out early if userId is missing — audit.recordMany requires a userId for every entry
+	// and will throw/log when missing. This avoids noisy error logs and wasted work.
+	if (!userId) {
+		logger.warn({ caseId, updatedFieldNames }, 'Skipping audit: no userId available');
+		return;
+	}
+
 	try {
 		const allAuditEntries: AuditEntry[] = [];
 

--- a/apps/manage/src/app/views/cases/view/update-case.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.ts
@@ -32,6 +32,9 @@ import type {
 import type { ErrorSummaryItem } from '@pins/crowndev-lib/util/types.ts';
 import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { getStringParam } from '@pins/crowndev-lib/util/params.ts';
+import { AUDIT_ACTIONS, type AuditService, type AuditEntry, type AuditAction } from '../../../audit/index.ts';
+import { resolveFieldValues, getFieldDisplayName } from '../../../audit/resolvers/index.ts';
+import type { Logger } from 'pino';
 
 function typedObjectKeys<T extends object>(obj: T): Array<keyof T> {
 	return Object.keys(obj) as Array<keyof T>;
@@ -63,6 +66,18 @@ function isClearableSaveKey(key: keyof CrownDevelopmentSaveModel): key is CrownD
 	return CLEARABLE_SAVE_KEY_SET.has(key as CrownDevelopmentClearableKey);
 }
 
+/**
+ * Scalar fields that should be audited when updated.
+ * Only these fields will produce audit entries in recordAuditEntries.
+ */
+const AUDITABLE_SCALAR_FIELDS = new Set([
+	'siteArea',
+	'lpaReference',
+	'agentOrganisationName',
+	'hearingVenue',
+	'inquiryVenue'
+]);
+
 type ErrorWithSummary = Error & { errorSummary: ErrorSummaryItem[] };
 
 function buildSummaryError(message: string, errorSummary: ErrorSummaryItem[]): ErrorWithSummary {
@@ -79,8 +94,9 @@ function buildSummaryError(message: string, errorSummary: ErrorSummaryItem[]): E
  */
 export function buildUpdateCase(service: ManageService, clearAnswer: boolean = false): SaveDataFn {
 	return async ({ req, res, data }: { req: Request; res: Response; data: { answers?: CrownDevelopmentSaveModel } }) => {
-		const { db, logger } = service;
+		const { db, logger, audit } = service;
 		const id = getStringParam(req.params, 'id');
+		const userId = req.session?.account?.localAccountId;
 
 		logger.info({ id }, 'case update');
 
@@ -99,6 +115,11 @@ export function buildUpdateCase(service: ManageService, clearAnswer: boolean = f
 			logger.info({ id }, 'no case updates to apply');
 			return;
 		}
+
+		// Capture the field names and snapshot of answers for audit
+		const updatedFieldNames = Object.keys(toSave);
+		const answersSnapshot = { ...toSave };
+
 		const fullViewModel = res.locals?.journeyResponse?.answers || {};
 		const originalAnswers: Partial<CrownDevelopmentViewModel> = res.locals?.originalAnswers || {};
 
@@ -118,6 +139,10 @@ export function buildUpdateCase(service: ManageService, clearAnswer: boolean = f
 		) {
 			addSessionData(req, id, { applicantOrgAdded: true });
 		}
+
+		// Capture previous values for auditable fields before the update
+		const previousValues: Record<string, unknown> = {};
+		let updateSucceeded = false;
 
 		try {
 			// Build a deterministic write-plan (no shared nested Organisations writes) and execute it
@@ -139,6 +164,14 @@ export function buildUpdateCase(service: ManageService, clearAnswer: boolean = f
 
 				// Fresh DB view model gives correct relation ids (organisationRelationId / organisationToContactRelationId)
 				const dbViewModel = crownDevelopmentToViewModel(crownDevelopment);
+
+				// Capture previous values for auditable fields before making changes
+				for (const fieldName of updatedFieldNames) {
+					if (AUDITABLE_SCALAR_FIELDS.has(fieldName)) {
+						previousValues[fieldName] = dbViewModel[fieldName as keyof CrownDevelopmentViewModel];
+					}
+				}
+
 				const viewModelForUpdates: CrownDevelopmentViewModel = { ...dbViewModel };
 				for (const [key, value] of typedObjectEntries(originalAnswers)) {
 					if (viewModelForUpdates[key] === undefined || viewModelForUpdates[key] === null) {
@@ -205,6 +238,7 @@ export function buildUpdateCase(service: ManageService, clearAnswer: boolean = f
 				});
 				await executeCaseUpdateWritePlan(plan, tx);
 			});
+			updateSucceeded = true;
 		} catch (error) {
 			wrapPrismaError({
 				error,
@@ -212,6 +246,10 @@ export function buildUpdateCase(service: ManageService, clearAnswer: boolean = f
 				message: 'updating case',
 				logParams: { id }
 			});
+		}
+
+		if (updateSucceeded) {
+			await recordAuditEntries(audit, id, userId, previousValues, answersSnapshot, updatedFieldNames, logger);
 		}
 
 		// show a banner to the user on success
@@ -374,4 +412,69 @@ function updateContainsDeLinkedField(updateInput: Prisma.CrownDevelopmentUpdateI
 		'applicationFee'
 	];
 	return Object.keys(updateInput).some((key) => deLinkedFields.includes(key));
+}
+
+/**
+ * Records all audit entries for a case update.
+ *
+ * Handles two categories of fields:
+ *   1. Scalar fields — compared individually via resolveFieldValues
+ *   2. TODO CROWN-1641 List fields — diffed via entity-specific resolvers (contacts, inspectors, etc.)
+ *
+ * Wrapped in try/catch so audit failures never block the user's operation —
+ * the case data has already been saved by the time this runs.
+ */
+async function recordAuditEntries(
+	audit: AuditService,
+	caseId: string,
+	userId: string | undefined,
+	previousValues: Record<string, unknown>,
+	answersSnapshot: Record<string, unknown>,
+	updatedFieldNames: string[],
+	logger: Logger
+): Promise<void> {
+	try {
+		const allAuditEntries: AuditEntry[] = [];
+
+		// ── Scalar fields ────────────────────────────────────────────────
+		for (const fieldName of updatedFieldNames) {
+			// Only audit fields in the auditable set
+			if (!AUDITABLE_SCALAR_FIELDS.has(fieldName)) {
+				continue;
+			}
+
+			const { oldValue, newValue } = resolveFieldValues(fieldName, previousValues, answersSnapshot[fieldName]);
+
+			if (oldValue === newValue) {
+				continue;
+			}
+
+			let action: AuditAction;
+
+			if (oldValue === '-') {
+				action = AUDIT_ACTIONS.FIELD_SET;
+			} else if (newValue === '-') {
+				action = AUDIT_ACTIONS.FIELD_CLEARED;
+			} else {
+				action = AUDIT_ACTIONS.FIELD_UPDATED;
+			}
+
+			allAuditEntries.push({
+				caseId,
+				action,
+				userId,
+				metadata: {
+					fieldName: getFieldDisplayName(fieldName),
+					oldValue,
+					newValue
+				}
+			});
+		}
+
+		await audit.recordMany(allAuditEntries);
+	} catch (error: unknown) {
+		// Audit failures should never block the user's operation.
+		// The case data has already been saved successfully above.
+		logger.error({ error, caseId }, 'Failed to record audit events');
+	}
 }

--- a/apps/manage/src/app/views/s62a/cases/create-a-case/questions.ts
+++ b/apps/manage/src/app/views/s62a/cases/create-a-case/questions.ts
@@ -21,16 +21,14 @@ import {
 	PRE_APPLICATION_OR_APPLICATION_ID
 } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
 import { APPLICATION_TYPES } from '@pins/crowndev-database/src/seed/data-static.ts';
-import { ENVIRONMENT_NAME, loadEnvironmentConfig } from '../../../../config.js';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.ts';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.ts';
+import { getLpaOptions } from '@pins/crowndev-lib/util/questions.ts';
 import { CREATE_A_CASE_QUESTION_TEXT } from './constants.ts';
 import { createLpaContactQuestion, multiContactQuestions } from './question-factories.ts';
 import { CUSTOM_COMPONENT_CLASSES, CUSTOM_COMPONENTS } from '@pins/crowndev-lib/forms/custom-components/index.ts';
 import { getApplicantOrganisationOptions } from '../../../../views/cases/util/applicant-organisation-options.js';
 import MultiFieldInputValidator from '@pins/crowndev-lib/validators/multi-field-input-validator.js';
 import { SEPARATOR_TYPE } from '@pins/crowndev-lib/forms/custom-components/custom-multi-field-input/question.js';
-import { formatLpaOptions, getApplicantContactsValidator, isApplicationType } from '../util/questions.ts';
+import { getApplicantContactsValidator, isApplicationType } from '../util/questions.ts';
 
 type ApplicantOrg = {
 	id: string;
@@ -39,10 +37,6 @@ type ApplicantOrg = {
 };
 
 export function getQuestions(journeyResponse: JourneyResponse, isQuestionView: boolean) {
-	const env = loadEnvironmentConfig();
-	const lpas = env === ENVIRONMENT_NAME.PROD ? LOCAL_PLANNING_AUTHORITIES_PROD : LOCAL_PLANNING_AUTHORITIES_DEV;
-	const lpaOptions = formatLpaOptions(lpas);
-
 	const preAppOrAppPath = isApplicationType(journeyResponse.answers.applicationPhase)
 		? journeyResponse.answers.applicationPhase
 		: PRE_APPLICATION_OR_APPLICATION_ID.APPLICATION;
@@ -98,7 +92,7 @@ export function getQuestions(journeyResponse: JourneyResponse, isQuestionView: b
 					'Local planning authority cannot be the same as the secondary local planning authority'
 				)
 			],
-			options: lpaOptions
+			options: getLpaOptions()
 		},
 		lpaContactDetails: createLpaContactQuestion(false),
 		hasSecondaryLpa: {
@@ -122,7 +116,7 @@ export function getQuestions(journeyResponse: JourneyResponse, isQuestionView: b
 					'Secondary local planning authority cannot be the same as the local planning authority'
 				)
 			],
-			options: lpaOptions
+			options: getLpaOptions()
 		},
 		secondaryLpaContactDetails: createLpaContactQuestion(true),
 		hasAgent: {

--- a/apps/manage/src/app/views/s62a/cases/util/questions.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/util/questions.test.ts
@@ -1,14 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import {
-	isApplicationType,
-	formatLpaOptions,
-	type ApplicantContact,
-	type ApplicantOrganisation,
-	getApplicantContactsValidator
-} from './questions.ts';
+import { isApplicationType, getApplicantContactsValidator } from './questions.ts';
 import { PRE_APPLICATION_OR_APPLICATION_ID } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
-import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
+import type {
+	ApplicantContact,
+	ApplicantOrganisation
+} from '@pins/crowndev-lib/validators/applicant-contacts-validator.ts';
 
 describe('questions.utils', () => {
 	describe('isApplicationType', () => {
@@ -30,32 +27,6 @@ describe('questions.utils', () => {
 		it('should return false for null or undefined', () => {
 			assert.strictEqual(isApplicationType(null), false);
 			assert.strictEqual(isApplicationType(undefined), false);
-		});
-	});
-
-	describe('formatLpaOptions', () => {
-		it('should prepend an empty option to an empty array', () => {
-			const lpas: Prisma.LpaCreateInput[] = [];
-			const result = formatLpaOptions(lpas);
-
-			assert.strictEqual(result.length, 1);
-			assert.deepStrictEqual(result[0], { text: '', value: '' });
-		});
-
-		it('should format a list of LPAs and prepend the empty option', () => {
-			const mockLpas = [
-				{ id: 'lpa-1', name: 'Westminster City Council' },
-				{ id: 'lpa-2', name: 'Camden Council' }
-			] as Prisma.LpaCreateInput[];
-
-			const result = formatLpaOptions(mockLpas);
-
-			assert.strictEqual(result.length, 3);
-
-			assert.deepStrictEqual(result[0], { text: '', value: '' });
-
-			assert.deepStrictEqual(result[1], { text: 'Westminster City Council', value: 'lpa-1' });
-			assert.deepStrictEqual(result[2], { text: 'Camden Council', value: 'lpa-2' });
 		});
 	});
 

--- a/apps/manage/src/app/views/s62a/cases/util/questions.ts
+++ b/apps/manage/src/app/views/s62a/cases/util/questions.ts
@@ -1,18 +1,8 @@
-import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { CrossQuestionValidator } from '@planning-inspectorate/dynamic-forms';
 import { applicantContactsValidationFn } from '@pins/crowndev-lib/validators/applicant-contacts-validator.ts';
 import { PRE_APPLICATION_OR_APPLICATION_ID } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
 
 export type AppType = (typeof PRE_APPLICATION_OR_APPLICATION_ID)[keyof typeof PRE_APPLICATION_OR_APPLICATION_ID];
-
-export interface ApplicantContact {
-	applicantContactOrganisation?: string;
-}
-
-export interface ApplicantOrganisation {
-	id?: string;
-	organisationName?: string;
-}
 
 /**
  * Checks to make sure answer is one of the two app types, for typescript
@@ -22,15 +12,6 @@ export const isApplicationType = (answer: unknown): answer is AppType => {
 		answer === PRE_APPLICATION_OR_APPLICATION_ID.PRE_APPLICATION ||
 		answer === PRE_APPLICATION_OR_APPLICATION_ID.APPLICATION
 	);
-};
-
-/**
- * Formats LPA list with null value first and unsorted LPAs as received
- * from file, ready for use as an options array.
- */
-export const formatLpaOptions = (lpas: Prisma.LpaCreateInput[]) => {
-	const lpaOptions = [{ text: '', value: '' }, ...lpas.map((t) => ({ text: t.name, value: t.id }))];
-	return lpaOptions;
 };
 
 /**

--- a/apps/manage/src/app/views/s62a/cases/view/questions.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/questions.ts
@@ -26,13 +26,11 @@ import {
 } from '@planning-inspectorate/dynamic-forms';
 import type { S62aCaseViewModel } from './view-model.ts';
 import { CUSTOM_COMPONENT_CLASSES, CUSTOM_COMPONENTS } from '@pins/crowndev-lib/forms/custom-components/index.ts';
-import { ENVIRONMENT_NAME, loadEnvironmentConfig } from '../../../../config.js';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.ts';
-import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.ts';
 import { SEPARATOR_TYPE } from '@pins/crowndev-lib/forms/custom-components/custom-multi-field-input/question.js';
 import MultiFieldInputValidator from '@pins/crowndev-lib/validators/multi-field-input-validator.js';
 import { CASE_DETAILS_QUESTION_TEXT } from './constants.ts';
-import { formatLpaOptions, isApplicationType } from '../util/questions.ts';
+import { isApplicationType } from '../util/questions.ts';
+import { getLpaOptions } from '@pins/crowndev-lib/util/questions.ts';
 
 export function getQuestions(answers: S62aCaseViewModel) {
 	const isLbcCase = answers?.typeId === APPLICATION_TYPE_ID.PLANNING_AND_LISTED_BUILDING_CONSENT;
@@ -46,10 +44,6 @@ export function getQuestions(answers: S62aCaseViewModel) {
 	const preAppOrAppPath = isApplicationType(answers.applicationPhaseId)
 		? answers.applicationPhaseId
 		: PRE_APPLICATION_OR_APPLICATION_ID.APPLICATION;
-
-	const env = loadEnvironmentConfig();
-	const lpas = env === ENVIRONMENT_NAME.PROD ? LOCAL_PLANNING_AUTHORITIES_PROD : LOCAL_PLANNING_AUTHORITIES_DEV;
-	const lpaOptions = formatLpaOptions(lpas);
 
 	const questions = {
 		reference: {
@@ -181,7 +175,7 @@ export function getQuestions(answers: S62aCaseViewModel) {
 					'Local planning authority cannot be the same as the secondary local planning authority'
 				)
 			],
-			options: lpaOptions
+			options: getLpaOptions()
 		},
 		hasSecondaryLpa: {
 			type: COMPONENT_TYPES.BOOLEAN,
@@ -204,7 +198,7 @@ export function getQuestions(answers: S62aCaseViewModel) {
 					'Secondary local planning authority cannot be the same as the local planning authority'
 				)
 			],
-			options: lpaOptions
+			options: getLpaOptions()
 		},
 		siteAddress: {
 			type: COMPONENT_TYPES.ADDRESS,

--- a/packages/lib/testing/mock-express.ts
+++ b/packages/lib/testing/mock-express.ts
@@ -1,0 +1,16 @@
+import type { Request, Response } from 'express';
+
+/**
+ * Test helpers for working with Express `Request`/`Response` mocks without
+ * scattering `as any` / `as unknown as` casts through the suites.
+ *
+ * Tests only ever build partial mocks (a `params` bag, a `render` spy, ...),
+ * so a single narrowing cast per object is both unavoidable and safe: the
+ * assertions immediately verify the behaviour that relies on the shape.
+ */
+
+/** Cast a partial mock object to an Express `Request`. */
+export const asReq = (obj: object = {}): Request => obj as unknown as Request;
+
+/** Cast a partial mock object to an Express `Response`. */
+export const asRes = (obj: object = {}): Response => obj as unknown as Response;

--- a/packages/lib/util/questions.test.js
+++ b/packages/lib/util/questions.test.js
@@ -1,6 +1,7 @@
-import { describe, it } from 'node:test';
+import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert';
 import {
+	getLpaOptions,
 	getSubmittedForId,
 	referenceDataToRadioOptions,
 	referenceDataToRadioOptionsWithHintText,
@@ -202,6 +203,77 @@ describe('questions', () => {
 					value: 'personal-reasons'
 				}
 			]);
+		});
+	});
+	describe('getLpaOptions', () => {
+		const originalEnv = process.env.ENVIRONMENT;
+
+		afterEach(() => {
+			// Restore original environment after each test
+			if (originalEnv === undefined) {
+				delete process.env.ENVIRONMENT;
+			} else {
+				process.env.ENVIRONMENT = originalEnv;
+			}
+		});
+
+		it('should return an array of options', () => {
+			const options = getLpaOptions();
+			assert.ok(Array.isArray(options));
+			assert.ok(options.length > 0);
+		});
+
+		it('should have an empty first option', () => {
+			const options = getLpaOptions();
+			assert.deepStrictEqual(options[0], { text: '', value: '' });
+		});
+
+		it('should have text and value properties for all options', () => {
+			const options = getLpaOptions();
+			for (const option of options) {
+				assert.ok(typeof option.text === 'string', 'text should be a string');
+				assert.ok(typeof option.value === 'string', 'value should be a string');
+			}
+		});
+
+		it('should be sorted alphabetically by text (excluding empty first option)', () => {
+			const options = getLpaOptions();
+			const nonEmptyOptions = options.slice(1);
+			for (let i = 1; i < nonEmptyOptions.length; i++) {
+				const prev = nonEmptyOptions[i - 1].text;
+				const curr = nonEmptyOptions[i].text;
+				assert.ok(prev.localeCompare(curr) <= 0, `Options should be sorted: "${prev}" should come before "${curr}"`);
+			}
+		});
+
+		it('should use DEV data when ENVIRONMENT is not set', () => {
+			delete process.env.ENVIRONMENT;
+			const options = getLpaOptions();
+			// DEV data has fewer LPAs than prod, just verify we get options
+			assert.ok(options.length > 1, 'Should have LPA options');
+			assert.match(options[1].text, /Test/, 'Should have test LPA option');
+		});
+
+		it('should use DEV data when ENVIRONMENT is "dev"', () => {
+			process.env.ENVIRONMENT = 'dev';
+			const options = getLpaOptions();
+			assert.ok(options.length > 1, 'Should have LPA options');
+			assert.match(options[1].text, /Test/, 'Should have test LPA option');
+		});
+
+		it('should not throw when ENVIRONMENT is "prod"', () => {
+			process.env.ENVIRONMENT = 'prod';
+			// Just verify the function doesn't throw and returns valid structure
+			// PROD data is not available in test environment due to JSON import
+			assert.doesNotThrow(() => {
+				const options = getLpaOptions();
+				assert.ok(Array.isArray(options), 'Should return an array');
+				assert.deepStrictEqual(options[0], { text: '', value: '' }, 'Should have empty first option');
+				assert.ok(
+					options.length === 1,
+					'Prod data not yet available in test environment, should return only empty option'
+				);
+			});
 		});
 	});
 });

--- a/packages/lib/util/questions.ts
+++ b/packages/lib/util/questions.ts
@@ -1,4 +1,6 @@
 import { REPRESENTATION_SUBMITTED_FOR_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
+import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.ts';
+import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.ts';
 import type { Option } from '@planning-inspectorate/dynamic-forms';
 
 const MAX_LENGTH = 500;
@@ -72,4 +74,35 @@ export function truncateComment(comment: string): string {
  */
 export function truncatedReadMoreCommentLink(href: string): string {
 	return `<a class="govuk-link govuk-link--no-visited-state" href="${href}">Read more</a>`;
+}
+
+/**
+ * Environment names for LPA selection
+ */
+const ENVIRONMENT_NAME = {
+	PROD: 'prod'
+} as const;
+
+/**
+ * Get LPA options for radio/select fields.
+ * Deferred evaluation of environment from process.env.ENVIRONMENT to avoid issues at module load time (e.g., in tests).
+ * Falls back to DEV data if environment is not set or not 'prod'.
+ * @returns Array of LPA options with empty first option, sorted alphabetically
+ */
+export function getLpaOptions(): Option[] {
+	let LPAs: typeof LOCAL_PLANNING_AUTHORITIES_DEV;
+	try {
+		const env = process.env.ENVIRONMENT;
+		// this is to avoid a database read when the data is static - but it does vary by environment
+		// the options here should match the dev/prod seed scripts
+		LPAs = env === ENVIRONMENT_NAME.PROD ? LOCAL_PLANNING_AUTHORITIES_PROD : LOCAL_PLANNING_AUTHORITIES_DEV;
+	} catch {
+		// Fallback to dev data if there's an issue, to ensure the app can still function.
+		// This would likely only be triggered by tests.
+		LPAs = LOCAL_PLANNING_AUTHORITIES_DEV;
+	}
+	return [
+		{ text: '', value: '' }, // ensure there is a 'null' option so the first LPA isn't selected by default
+		...LPAs.map((t) => ({ text: t.name ?? '', value: t.id ?? '' })).sort((a, b) => a.text.localeCompare(b.text))
+	];
 }


### PR DESCRIPTION
## Describe your changes

Add audit logging for direct scalar fields in Crown.

- Add field resolver for direct fields (no data adjustment)
- Because this references FIELD_DISPLAY_NAMES, which uses `getQuestions()`, I refactored how LPAs are obtained in questions across both services. It uses the MPESC try-catch pattern that removes the requirement to set environment variables in tests
- Add audit logging to update-case for certain fields. This pattern is aligned with MPESC as much as possible, but does calculate previousValue in a different way
- Update readme for audit resolvers to reflect current status
- I've fixed type issues in `update-case.test.ts`. Not quite sure what the best approach is here: I added `asRes` and `asReq` type helpers to help with repetitive casting, but perhaps this is overkill?

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1633
<img width="1504" height="589" alt="Screenshot 2026-07-13 093739" src="https://github.com/user-attachments/assets/6ebd9154-1d9a-490d-8e01-05922834c441" />
