### PR TITLE
fix: add maximum answers to agent contacts

### DIFF
--- a/apps/manage/src/app/views/s62a/cases/create-a-case/questions.ts
+++ b/apps/manage/src/app/views/s62a/cases/create-a-case/questions.ts
@@ -177,7 +177,8 @@ export function getQuestions(journeyResponse: JourneyResponse, isQuestionView: b
 			titleSingular: 'Contact',
 			emptyListText: 'No agent contacts found',
 			showAnswersInSummary: true,
-			emptyStateAddStyle: 'force'
+			emptyStateAddStyle: 'force',
+			maximumAnswers: 10
 		},
 		...multiContactQuestions({
 			prefix: 'agent',


### PR DESCRIPTION
## Describe your changes
- Adds maximum answers limit to agent contacts

## Issue ticket number and link
[PEAS-252](https://pins-ds.atlassian.net/browse/PEAS-252)


[PEAS-252]: https://pins-ds.atlassian.net/browse/PEAS-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ