### PR TITLE
refactor(feature-flags): remove upload, notify, application-updates, and multiple applicant flags

### DIFF
--- a/apps/manage/src/app/config-types.d.ts
+++ b/apps/manage/src/app/config-types.d.ts
@@ -34,8 +34,6 @@ interface Config {
 		};
 	};
 	featureFlags: {
-		isRepsUploadDocsLive: boolean;
-		isApplicationUpdatesLive: boolean;
 		isS62ALive: boolean;
 	};
 	gitSha?: string;

--- a/apps/manage/src/app/config.js
+++ b/apps/manage/src/app/config.js
@@ -66,9 +66,6 @@ export function loadConfig() {
 		GOV_NOTIFY_APP_REC_WITHOUT_FEE_TEMPLATE_ID,
 		GOV_NOTIFY_APP_NOT_NAT_IMP_TEMPLATE_ID,
 		GOV_NOTIFY_LPA_QUEST_SENT_TEMPLATE_ID,
-		FEATURE_FLAG_UPLOAD_DOCS_REPS_NOT_LIVE,
-		FEATURE_FLAG_NOTIFY_CALLBACK_NOT_LIVE,
-		FEATURE_FLAG_APPLICATION_UPDATES_NOT_LIVE,
 		FEATURE_FLAG_S62A_MANAGE_NOT_LIVE,
 		BLOB_STORE_DISABLED,
 		BLOB_STORE_HOST,
@@ -205,10 +202,6 @@ export function loadConfig() {
 			}
 		},
 		featureFlags: {
-			// by default with no feature flag set, reps upload docs is live
-			isRepsUploadDocsLive: FEATURE_FLAG_UPLOAD_DOCS_REPS_NOT_LIVE !== 'true',
-			isNotifyCallbackEnabled: FEATURE_FLAG_NOTIFY_CALLBACK_NOT_LIVE !== 'true',
-			isApplicationUpdatesLive: FEATURE_FLAG_APPLICATION_UPDATES_NOT_LIVE !== 'true',
 			// Needed so that we can develop the changes to 'Manage' without interfering with 'Crown Developments' in general.
 			isS62ALive: FEATURE_FLAG_S62A_MANAGE_NOT_LIVE !== 'true'
 		},

--- a/apps/manage/src/app/service.js
+++ b/apps/manage/src/app/service.js
@@ -152,14 +152,6 @@ export class ManageService {
 		return this.#config.gitSha;
 	}
 
-	get isRepsUploadDocsLive() {
-		return this.#config.featureFlags?.isRepsUploadDocsLive;
-	}
-
-	get isApplicationUpdatesLive() {
-		return this.#config.featureFlags?.isApplicationUpdatesLive;
-	}
-
 	get isS62ALive() {
 		return this.#config.featureFlags?.isS62ALive;
 	}

--- a/apps/manage/src/app/views/cases/view/controller.ts
+++ b/apps/manage/src/app/views/cases/view/controller.ts
@@ -171,7 +171,7 @@ async function getBannerMessages(id: string, res: Response, req: Request, db: Ma
 /**
  * Controller for the case details page, which shows the case summary and the list of sections to manage.
  */
-export function buildViewCaseDetails({ db, getSharePointDrive, isApplicationUpdatesLive }: ManageService): Handler {
+export function buildViewCaseDetails({ db, getSharePointDrive }: ManageService): Handler {
 	return async (req, res) => {
 		const reference = getJourneyAnswers(res)?.reference;
 		if (!reference) {
@@ -208,7 +208,6 @@ export function buildViewCaseDetails({ db, getSharePointDrive, isApplicationUpda
 			sharePointLink,
 			hideButton: true,
 			hideStatus: true,
-			isApplicationUpdatesLive,
 			banner,
 			lastModifiedDate,
 			lastModifiedBy

--- a/apps/manage/src/app/views/cases/view/index.js
+++ b/apps/manage/src/app/views/cases/view/index.js
@@ -42,12 +42,8 @@ export function createRoutes(service) {
 	router.get('/', validateIdFormat, getViewJourney, asyncHandler(viewCaseDetails));
 	router.use('/publish', publishCase);
 	router.use('/unpublish', unpublishCase);
-
 	router.use('/manage-representations', repsRoutes);
-
-	if (service.isApplicationUpdatesLive) {
-		router.use('/application-updates', applicationUpdates);
-	}
+	router.use('/application-updates', applicationUpdates);
 
 	// View application history page, /:id/application-history
 	router.use('/application-history', applicationHistoryRoutes);

--- a/apps/manage/src/app/views/cases/view/manage-reps/add/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/add/index.js
@@ -35,9 +35,7 @@ export function createRoutes(service) {
 	const questions = getQuestions({
 		textOverrides: { appName: service.appName }
 	});
-	const getJourney = buildGetJourney((req, journeyResponse) =>
-		createJourney(questions, journeyResponse, req, service.isRepsUploadDocsLive)
-	);
+	const getJourney = buildGetJourney((req, journeyResponse) => createJourney(questions, journeyResponse, req));
 	const getJourneyResponse = buildGetJourneyResponseFromSession(JOURNEY_ID, 'id');
 	const saveDataToSession = buildSaveDataToSession({ reqParam: 'id' });
 	const saveController = buildSaveRepresentationController(service);

--- a/apps/manage/src/app/views/cases/view/manage-reps/add/journey.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/add/journey.js
@@ -3,14 +3,14 @@ import { addRepresentationSection } from '@pins/crowndev-lib/forms/representatio
 
 export const JOURNEY_ID = 'add-representation';
 
-export function createJourney(questions, response, req, isRepsUploadDocsLive) {
+export function createJourney(questions, response, req) {
 	if (!req.baseUrl.endsWith('/' + JOURNEY_ID)) {
 		throw new Error(`not a valid request for the ${JOURNEY_ID} journey`);
 	}
 
 	return new Journey({
 		journeyId: JOURNEY_ID,
-		sections: addRepresentationSection(questions, isRepsUploadDocsLive),
+		sections: addRepresentationSection(questions),
 		taskListUrl: 'check-your-answers',
 		journeyTemplate: 'views/layouts/forms-question.njk',
 		taskListTemplate: 'views/layouts/forms-representation-check-your-answers.njk',

--- a/apps/manage/src/app/views/cases/view/manage-reps/review/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/review/controller.js
@@ -181,6 +181,14 @@ export function buildReviewControllers(service, journeyId) {
 				repItemsReviewStatus?.distressingContentInRepresentation?.reviewDecision
 			);
 			const representationAttachments = representation?.containsAttachments ? representation?.Attachments || [] : [];
+
+			if (representation?.containsAttachments && representationAttachments.length === 0) {
+				logger.warn(
+					{ representationRef, representationId: representation.id },
+					'No documents found for the representation, but representation contains attachments'
+				);
+			}
+
 			const documents = representationAttachments.map((attachment) => {
 				return {
 					title: {

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/controller.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/controller.js
@@ -128,7 +128,7 @@ export async function renderRepresentation(req, res, viewData = {}) {
  * @param {import('#service').ManageService} service
  * @returns {import('express').Handler}
  */
-export function buildGetJourneyMiddleware({ db, logger, isRepsUploadDocsLive }) {
+export function buildGetJourneyMiddleware({ db, logger }) {
 	return async (req, res, next) => {
 		const { id, representationRef } = validateParams(req.params);
 		logger.info({ id, representationRef }, 'fetching representation');
@@ -188,7 +188,7 @@ export function buildGetJourneyMiddleware({ db, logger, isRepsUploadDocsLive }) 
 		// put these on locals for the list controller
 		res.locals.originalAnswers = { ...answers };
 		res.locals.journeyResponse = new JourneyResponse(JOURNEY_ID, 'ref', answers);
-		res.locals.journey = createJourney(questions, res.locals.journeyResponse, req, isRepsUploadDocsLive);
+		res.locals.journey = createJourney(questions, res.locals.journeyResponse, req);
 
 		if (req.originalUrl !== req.baseUrl) {
 			// back link goes to details page

--- a/apps/manage/src/app/views/cases/view/manage-reps/view/journey.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/view/journey.js
@@ -9,10 +9,9 @@ export const JOURNEY_ID = 'manage-representations';
  * @param {Object<string, *>} questions
  * @param {import('@planning-inspectorate/dynamic-forms/src/journey/journey-response.js').JourneyResponse} response
  * @param {import('express').Request} req
- * @param {boolean} isRepsUploadDocsLive
  * @returns {Journey}
  */
-export function createJourney(questions, response, req, isRepsUploadDocsLive) {
+export function createJourney(questions, response, req) {
 	if (!req.baseUrl.includes('/' + JOURNEY_ID)) {
 		throw new Error(`not a valid request for the ${JOURNEY_ID} journey`);
 	}
@@ -21,7 +20,7 @@ export function createJourney(questions, response, req, isRepsUploadDocsLive) {
 
 	return new Journey({
 		journeyId: JOURNEY_ID,
-		sections: haveYourSayManageSections(questions, isRepsUploadDocsLive, isViewJourney),
+		sections: haveYourSayManageSections(questions, isViewJourney),
 		taskListUrl: '',
 		journeyTemplate: 'views/layouts/forms-question.njk',
 		taskListTemplate: 'views/cases/view/manage-reps/view/view.njk',

--- a/apps/manage/src/app/views/cases/view/manage-reps/withdraw/index.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/withdraw/index.js
@@ -36,9 +36,7 @@ export function createRoutes(service, viewOrReview) {
 	const questions = getQuestions({
 		textOverrides: { appName: service.appName }
 	});
-	const getJourney = buildGetJourney((req, journeyResponse) =>
-		createJourney(questions, journeyResponse, req, service.isRepsUploadDocsLive)
-	);
+	const getJourney = buildGetJourney((req, journeyResponse) => createJourney(questions, journeyResponse, req));
 	const getJourneyResponse = buildGetJourneyResponseFromSession(JOURNEY_ID, 'representationRef');
 	const saveDataToSession = buildSaveDataToSession({ reqParam: 'representationRef' });
 

--- a/apps/manage/src/app/views/cases/view/manage-reps/withdraw/journey.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/withdraw/journey.js
@@ -3,7 +3,7 @@ import { Journey } from '@planning-inspectorate/dynamic-forms/src/journey/journe
 
 export const JOURNEY_ID = 'withdraw-representation';
 
-export function createJourney(questions, response, req, isRepsUploadDocsLive) {
+export function createJourney(questions, response, req) {
 	if (!req.baseUrl.endsWith('/' + JOURNEY_ID)) {
 		throw new Error(`not a valid request for the ${JOURNEY_ID} journey`);
 	}
@@ -15,7 +15,6 @@ export function createJourney(questions, response, req, isRepsUploadDocsLive) {
 				.addQuestion(questions.withdrawalRequestDate)
 				.addQuestion(questions.withdrawalReason)
 				.addQuestion(questions.withdrawalRequests)
-				.withCondition(() => isRepsUploadDocsLive === true)
 		],
 		taskListUrl: 'check-your-answers',
 		journeyTemplate: 'views/layouts/forms-question.njk',

--- a/apps/manage/src/app/views/cases/view/manage-reps/withdraw/journey.test.js
+++ b/apps/manage/src/app/views/cases/view/manage-reps/withdraw/journey.test.js
@@ -15,8 +15,7 @@ describe('withdraw-representation journey', () => {
 		};
 		const response = {};
 		const req = { baseUrl: `/some/path/${JOURNEY_ID}` };
-		const isRepsUploadDocsLive = true;
-		const journey = createJourney(questions, response, req, isRepsUploadDocsLive);
+		const journey = createJourney(questions, response, req);
 		assert.strictEqual(journey.journeyId, JOURNEY_ID);
 		assert.strictEqual(journey.sections.length, 1);
 		const section = journey.sections[0];

--- a/apps/manage/src/app/views/cases/view/view.njk
+++ b/apps/manage/src/app/views/cases/view/view.njk
@@ -64,13 +64,11 @@
                 href: manageRepsUrl,
                 classes: "govuk-button--secondary"
             }) }}
-            {% if isApplicationUpdatesLive %}
-                {{ govukButton({
-                    text: "Manage application updates",
-                    href: manageAppUpdatesUrl,
-                    classes: "govuk-button--secondary"
-                }) }}
-            {% endif %}
+            {{ govukButton({
+                text: "Manage application updates",
+                href: manageAppUpdatesUrl,
+                classes: "govuk-button--secondary"
+            }) }}
             {% if casePublished %}
                 {{ govukButton({
                     text: "Unpublish Application",

--- a/apps/manage/src/util/config-middleware.js
+++ b/apps/manage/src/util/config-middleware.js
@@ -1,12 +1,11 @@
 /**
  * Add configuration values to locals.
- * @param {{isRepsUploadDocsLive: boolean, appName: string}} params
+ * @param {{appName: string}} params
  * @returns {import('express').Handler}
  */
-export function addLocalsConfiguration({ isRepsUploadDocsLive, appName }) {
+export function addLocalsConfiguration({ appName }) {
 	return (req, res, next) => {
 		res.locals.config = {
-			isRepsUploadDocsLive,
 			appName
 		};
 		next();

--- a/apps/portal/src/app/config-types.d.ts
+++ b/apps/portal/src/app/config-types.d.ts
@@ -15,8 +15,6 @@ interface Config {
 	};
 	featureFlags: {
 		isLive: boolean;
-		isRepsUploadDocsLive: boolean;
-		isApplicationUpdatesLive: boolean;
 	};
 	gitSha?: string;
 	googleAnalyticsId?: string;

--- a/apps/portal/src/app/config.js
+++ b/apps/portal/src/app/config.js
@@ -30,7 +30,6 @@ export function loadConfig() {
 		DYNAMIC_CACHE_CONTROL_ENABLED,
 		DYNAMIC_CACHE_CONTROL_MAX_AGE,
 		FEATURE_FLAG_PORTAL_NOT_LIVE,
-		FEATURE_FLAG_UPLOAD_DOCS_REPS_NOT_LIVE,
 		GIT_SHA,
 		GOOGLE_ANALYTICS_ID,
 		LOG_LEVEL,
@@ -46,8 +45,7 @@ export function loadConfig() {
 		GOV_NOTIFY_TEST_TEMPLATE_ID,
 		GOV_NOTIFY_PRE_ACK_TEMPLATE_ID,
 		GOV_NOTIFY_ACK_REP_TEMPLATE_ID,
-		CROWN_DEV_CONTACT_EMAIL,
-		FEATURE_FLAG_APPLICATION_UPDATES_NOT_LIVE
+		CROWN_DEV_CONTACT_EMAIL
 	} = process.env;
 
 	const buildConfig = loadBuildConfig();
@@ -110,11 +108,7 @@ export function loadConfig() {
 		},
 		featureFlags: {
 			// by default with no feature flag set, the portal is live
-			isLive: FEATURE_FLAG_PORTAL_NOT_LIVE !== 'true',
-			// by default with no feature flag set, reps upload docs is live
-			isRepsUploadDocsLive: FEATURE_FLAG_UPLOAD_DOCS_REPS_NOT_LIVE !== 'true',
-			// by default with no feature flag set, application updates is live
-			isApplicationUpdatesLive: FEATURE_FLAG_APPLICATION_UPDATES_NOT_LIVE !== 'true'
+			isLive: FEATURE_FLAG_PORTAL_NOT_LIVE !== 'true'
 		},
 		gitSha: GIT_SHA,
 		googleAnalyticsId: GOOGLE_ANALYTICS_ID,

--- a/apps/portal/src/app/service.js
+++ b/apps/portal/src/app/service.js
@@ -89,14 +89,6 @@ export class PortalService {
 		return this.#config.featureFlags?.isLive;
 	}
 
-	get isRepsUploadDocsLive() {
-		return this.#config.featureFlags?.isRepsUploadDocsLive;
-	}
-
-	get isApplicationUpdatesLive() {
-		return this.#config.featureFlags?.isApplicationUpdatesLive;
-	}
-
 	get gitSha() {
 		return this.#config.gitSha;
 	}

--- a/apps/portal/src/app/views/applications/view/have-your-say/index.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/index.js
@@ -46,9 +46,7 @@ export function createHaveYourSayRoutes(service) {
 	const questions = getQuestions({
 		textOverrides: { appName: service.appName }
 	});
-	const getJourney = buildGetJourney((req, journeyResponse) =>
-		createJourney(questions, journeyResponse, req, service.isRepsUploadDocsLive)
-	);
+	const getJourney = buildGetJourney((req, journeyResponse) => createJourney(questions, journeyResponse, req));
 	const getJourneyResponse = buildGetJourneyResponseFromSession(JOURNEY_ID, applicationIdParam);
 	const viewHaveYourSayPage = buildHaveYourSayPage(service);
 	const redirectToHaveYourSayJourney = startHaveYourSayJourney(service);

--- a/apps/portal/src/app/views/applications/view/have-your-say/journey.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/journey.js
@@ -3,14 +3,14 @@ import { haveYourSaySections } from '@pins/crowndev-lib/forms/representations/se
 
 export const JOURNEY_ID = 'have-your-say';
 
-export function createJourney(questions, response, req, isRepsUploadDocsLive) {
+export function createJourney(questions, response, req) {
 	if (!req.baseUrl.endsWith('/' + JOURNEY_ID)) {
 		throw new Error(`not a valid request for the ${JOURNEY_ID} journey`);
 	}
 
 	return new Journey({
 		journeyId: JOURNEY_ID,
-		sections: haveYourSaySections(questions, isRepsUploadDocsLive),
+		sections: haveYourSaySections(questions),
 		taskListUrl: 'check-your-answers',
 		journeyTemplate: 'views/layouts/forms-question.njk',
 		taskListTemplate: 'views/layouts/forms-have-your-say-check-your-answers.njk',

--- a/apps/portal/src/app/views/applications/view/have-your-say/journey.test.js
+++ b/apps/portal/src/app/views/applications/view/have-your-say/journey.test.js
@@ -106,7 +106,8 @@ describe('have-your-say journey', () => {
 			myselfFirstName: 'Test Name',
 			myselfLastName: 'Surname',
 			myselfEmail: 'test@email.com',
-			myselfComment: 'some comments'
+			myselfComment: 'some comments',
+			myselfContainsAttachments: BOOLEAN_OPTIONS.NO
 		};
 
 		const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -142,7 +143,8 @@ describe('have-your-say journey', () => {
 			submitterEmail: 'test@email.com',
 			representedFirstName: 'Represented Person',
 			representedLastName: 'Rep surname',
-			submitterComment: 'some comments'
+			submitterComment: 'some comments',
+			submitterContainsAttachments: BOOLEAN_OPTIONS.NO
 		};
 
 		const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -161,7 +163,8 @@ describe('have-your-say journey', () => {
 			isAgent: BOOLEAN_OPTIONS.YES,
 			agentOrgName: 'Org Name',
 			submitterEmail: 'test@email.com',
-			submitterComment: 'some comments'
+			submitterComment: 'some comments',
+			submitterContainsAttachments: BOOLEAN_OPTIONS.NO
 		};
 
 		const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -180,7 +183,8 @@ describe('have-your-say journey', () => {
 			submitterEmail: 'test@email.com',
 			orgName: 'Org Name',
 			orgRoleName: 'Boss',
-			submitterComment: 'some comments'
+			submitterComment: 'some comments',
+			submitterContainsAttachments: BOOLEAN_OPTIONS.NO
 		};
 
 		const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -218,7 +222,8 @@ describe('have-your-say journey', () => {
 			agentOrgName: 'Test Org',
 			submitterEmail: 'test@email.com',
 			representedOrgName: 'Test Org Representing',
-			submitterComment: 'some comments'
+			submitterComment: 'some comments',
+			submitterContainsAttachments: BOOLEAN_OPTIONS.NO
 		};
 
 		const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -250,8 +255,7 @@ describe('have-your-say journey', () => {
 		const questions = getQuestions({ textOverrides: { appName: 'portal' } });
 
 		const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
-		const isRepsUploadDocsLive = true;
-		const journey = createJourney(questions, response, { baseUrl: `/some/path/${JOURNEY_ID}` }, isRepsUploadDocsLive);
+		const journey = createJourney(questions, response, { baseUrl: `/some/path/${JOURNEY_ID}` });
 		const sections = journey.sections;
 
 		assert.strictEqual(sections.length, 3);

--- a/apps/portal/src/app/views/applications/view/have-your-say/success.njk
+++ b/apps/portal/src/app/views/applications/view/have-your-say/success.njk
@@ -29,10 +29,6 @@
 
             <h3 class="govuk-heading-s">Inquiry</h3>
             <p class="govuk-body">If this procedure is chosen, we’ll contact you with details of the inquiry date and location.</p>
-            {% if not config.isRepsUploadDocsLive %}
-                <h2 class="govuk-heading-m">Providing more information</h2>
-                <p class="govuk-body">If you wish to include documents or photographs as part of your comments, you must send them to <a href="mailto:{{ config.contactEmail }}" class="govuk-link">{{ config.contactEmail }}</a> and include your name, representation reference number and application reference number in the subject line.</p>
-            {% endif %}
             {{ govukInsetText({
                 html: '<p class="govuk-body">Help us improve this service by <a class="govuk-link" href="' + config.serviceFeedbackUrl + '">sharing your feedback</a>.</p>'
             }) }}

--- a/apps/portal/src/app/views/applications/view/written-representations/read-more/controller.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/read-more/controller.js
@@ -4,13 +4,9 @@ import { fetchPublishedApplication, getApplicationStatus } from '@pins/crowndev-
 import { REPRESENTATION_STATUS_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { representationToViewModel } from '../../view-model.ts';
 import { applicationLinks } from '@pins/crowndev-lib/util/shared-view-model.ts';
-import {
-	publishedRepresentationsAttachmentsFolderPath,
-	representationAttachmentsFolderPath
-} from '@pins/crowndev-lib/util/sharepoint-path.js';
-import { getDocuments, getDocumentsById } from '@pins/crowndev-lib/documents/get.js';
+import { representationAttachmentsFolderPath } from '@pins/crowndev-lib/util/sharepoint-path.js';
+import { getDocumentsById } from '@pins/crowndev-lib/documents/get.js';
 import { mapDriveItemToViewModel } from '@pins/crowndev-lib/documents/view-model.js';
-import { wrapPrismaError } from '@pins/crowndev-lib/util/database.ts';
 import { isValidUniqueReference } from '@pins/crowndev-lib/util/random-reference.js';
 import { shouldDisplayApplicationUpdatesLink } from '../../../../util/application-util.ts';
 import { getStringParam } from '@pins/crowndev-lib/util/params.ts';
@@ -21,7 +17,7 @@ import { getStringParam } from '@pins/crowndev-lib/util/params.ts';
  * @param {import('#service').PortalService} service
  * @returns {import('express').RequestHandler}
  */
-export function buildWrittenRepresentationsReadMorePage({ db, logger, sharePointDrive, isRepsUploadDocsLive }) {
+export function buildWrittenRepresentationsReadMorePage({ db, logger, sharePointDrive }) {
 	return async (req, res) => {
 		const id = getStringParam(req.params, 'applicationId');
 		if (!isValidUuidFormat(id)) {
@@ -72,7 +68,16 @@ export function buildWrittenRepresentationsReadMorePage({ db, logger, sharePoint
 				SubmittedByContact: { select: { firstName: true, lastName: true } },
 				RepresentedContact: { select: { orgName: true, firstName: true, lastName: true } },
 				Category: { select: { displayName: true } },
-				Attachments: { select: { statusId: true } }
+				Attachments: {
+					where: { statusId: REPRESENTATION_STATUS_ID.ACCEPTED },
+					select: {
+						itemId: true,
+						fileName: true,
+						redactedItemId: true,
+						redactedFileName: true,
+						statusId: true
+					}
+				}
 			}
 		});
 
@@ -82,52 +87,19 @@ export function buildWrittenRepresentationsReadMorePage({ db, logger, sharePoint
 
 		let documents;
 		if (representation.containsAttachments === true) {
-			if (!isRepsUploadDocsLive) {
-				const folderPath = publishedRepresentationsAttachmentsFolderPath(reference, representationReference);
-				logger.info({ folderPath }, 'view documents');
-				const driveItems = await getDocuments({ sharePointDrive, folderPath, logger, id });
-				documents = driveItems.map(mapDriveItemToViewModel).filter(Boolean);
-			} else {
-				let documentsToFetch;
-				try {
-					documentsToFetch = await db.representationDocument.findMany({
-						where: {
-							representationId: representation.id,
-							statusId: REPRESENTATION_STATUS_ID.ACCEPTED
-						},
-						select: {
-							itemId: true,
-							fileName: true,
-							redactedItemId: true,
-							redactedFileName: true
-						}
-					});
-				} catch (error) {
-					logger.error({ error }, 'Error fetching documents from database');
-					wrapPrismaError({
-						error,
-						logger,
-						message: 'fetching representation documents',
-						logParams: { id }
-					});
-				}
+			const documentsToFetch = representation.Attachments;
 
-				if (!Array.isArray(documentsToFetch) || documentsToFetch.length === 0) {
-					logger.warn('No documents found for the representation, but representation contains attachments');
-					documents = [];
-				} else {
-					logger.info({ documentsToFetch }, 'Fetched accepted documents for representation');
-					const folderPath = representationAttachmentsFolderPath(reference, representationReference);
-					const ids = documentsToFetch.map((doc) => doc.redactedItemId ?? doc.itemId).filter(Boolean);
-					const driveItems = await getDocumentsById({
-						sharePointDrive,
-						folderPath,
-						logger,
-						ids
-					});
-					documents = driveItems.map(mapDriveItemToViewModel).filter(Boolean);
-					logger.info({ documents }, 'Fetched documents to display from SharePoint');
-				}
+			if (documentsToFetch.length === 0) {
+				logger.warn(
+					{ representationReference, caseReference: reference, representationId: representation.id },
+					'No documents found for the representation, but representation contains attachments'
+				);
+				documents = [];
+			} else {
+				const folderPath = representationAttachmentsFolderPath(reference, representationReference);
+				const ids = documentsToFetch.map((doc) => doc.redactedItemId ?? doc.itemId).filter(Boolean);
+				const driveItems = await getDocumentsById({ sharePointDrive, folderPath, logger, ids });
+				documents = driveItems.map(mapDriveItemToViewModel).filter(Boolean);
 			}
 		}
 

--- a/apps/portal/src/app/views/applications/view/written-representations/read-more/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/read-more/controller.test.js
@@ -5,7 +5,6 @@ import { buildWrittenRepresentationsReadMorePage } from './controller.js';
 import { mockLogger } from '@pins/crowndev-lib/testing/mock-logger.js';
 import { getDocumentsById } from '@pins/crowndev-lib/documents/get.js';
 import { mapDriveItemToViewModel } from '@pins/crowndev-lib/documents/view-model.js';
-import { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 
 describe('written representations read more', () => {
 	it('should filter out invalid or null documents', async () => {
@@ -23,55 +22,6 @@ describe('written representations read more', () => {
 		const documents = driveItems.map(mapDriveItemToViewModel).filter(Boolean);
 		assert.strictEqual(documents.length, 1);
 		assert.strictEqual(documents[0].name, 'File 1');
-	});
-	it('should handle Prisma error when fetching documents', async () => {
-		const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
-		const representationReference = 'AAAAA-BBBBB';
-		const mockReq = {
-			params: { applicationId, representationReference },
-			originalUrl: `/applications/${applicationId}/written-representations/${representationReference}`
-		};
-		const mockRes = { render: mock.fn(), status: mock.fn(), redirect: mock.fn() };
-
-		const mockDb = {
-			crownDevelopment: {
-				findUnique: mock.fn(() => ({
-					id: applicationId,
-					reference: 'CROWN/2025/0000001',
-					representationsPeriodStartDate: '2025-01-01',
-					representationsPeriodEndDate: '2025-02-01',
-					representationsPublishDate: '2025-03-01',
-					containsDistressingContent: false
-				}))
-			},
-			representation: {
-				findUnique: mock.fn(() => ({
-					id: 1,
-					reference: representationReference,
-					containsAttachments: true
-				}))
-			},
-			representationDocument: {
-				findMany: mock.fn(() => {
-					throw new Prisma.PrismaClientKnownRequestError('some error', { code: '101' });
-				})
-			}
-		};
-
-		const mockSharePoint = { getDriveItem: mock.fn() };
-		const logger = mockLogger();
-
-		const handler = buildWrittenRepresentationsReadMorePage({
-			db: mockDb,
-			logger,
-			sharePointDrive: mockSharePoint,
-			isRepsUploadDocsLive: true
-		});
-
-		await assert.rejects(() => handler(mockReq, mockRes), {
-			message: 'Error fetching representation documents (101)'
-		});
-		assert.strictEqual(mockRes.redirect.mock.callCount(), 0);
 	});
 	it('should fetch documents from database', async () => {
 		const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
@@ -122,8 +72,7 @@ describe('written representations read more', () => {
 							redactedItemId: null,
 							redactedFileName: null,
 							statusId: 'accepted'
-						},
-						{ itemId: '11111', fileName: null, redactedItemId: null, redactedFileName: null, statusId: 'rejected' }
+						}
 					]
 				}))
 			},
@@ -139,16 +88,18 @@ describe('written representations read more', () => {
 			}
 		};
 		const mockSharePoint = {
-			getDriveItem: mock.fn(() => [
-				{ id: 1, name: 'doc1.pdf', file: { mimeType: 'application/pdf' }, size: 12345 },
-				{ id: 2, name: 'doc2.pdf', file: { mimeType: 'application/pdf' }, size: 56789 }
-			])
+			getDriveItem: mock.fn((id) => {
+				const items = {
+					12345: { id: '12345', name: 'doc1.pdf', file: { mimeType: 'application/pdf' }, size: 12345 },
+					67890: { id: '67890', name: 'doc2.pdf', file: { mimeType: 'application/pdf' }, size: 56789 }
+				};
+				return items[id] ?? null;
+			})
 		};
 		const handler = buildWrittenRepresentationsReadMorePage({
 			db: mockDb,
 			logger: mockLogger(),
-			sharePointDrive: mockSharePoint,
-			isRepsUploadDocsLive: true
+			sharePointDrive: mockSharePoint
 		});
 		await handler(mockReq, mockRes);
 		assert.strictEqual(
@@ -236,27 +187,8 @@ describe('written representations read more', () => {
 					SubmittedByContact: { firstName: 'Jane', lastName: 'Smith' },
 					RepresentedContact: { firstName: 'Alice', lastName: 'Brown' },
 					Category: { displayName: 'General Representation' },
-					Attachments: [
-						{
-							itemId: '12345',
-							fileName: 'doc1.pdf',
-							redactedItemId: null,
-							redactedFileName: null,
-							statusId: 'rejected'
-						},
-						{
-							itemId: '67890',
-							fileName: 'doc2.pdf',
-							redactedItemId: null,
-							redactedFileName: null,
-							statusId: 'rejected'
-						},
-						{ itemId: '11111', fileName: null, redactedItemId: null, redactedFileName: null, statusId: 'rejected' }
-					]
+					Attachments: []
 				}))
-			},
-			representationDocument: {
-				findMany: mock.fn(() => [])
 			},
 			applicationUpdate: {
 				findFirst: mock.fn(() => undefined),
@@ -264,13 +196,18 @@ describe('written representations read more', () => {
 			}
 		};
 		const mockSharePoint = {
-			getDriveItem: mock.fn()
+			getDriveItem: mock.fn((id) => {
+				const items = {
+					12345: { id: '12345', name: 'doc1.pdf', file: { mimeType: 'application/pdf' }, size: 12345 },
+					67890: { id: '67890', name: 'doc2.pdf', file: { mimeType: 'application/pdf' }, size: 56789 }
+				};
+				return items[id] ?? null;
+			})
 		};
 		const handler = buildWrittenRepresentationsReadMorePage({
 			db: mockDb,
 			logger: mockLogger(),
-			sharePointDrive: mockSharePoint,
-			isRepsUploadDocsLive: true
+			sharePointDrive: mockSharePoint
 		});
 		await handler(mockReq, mockRes);
 		assert.strictEqual(
@@ -333,8 +270,20 @@ describe('written representations read more', () => {
 						RepresentedContact: { firstName: 'Alice', lastName: ' Brown' },
 						Category: { displayName: 'General Representation' },
 						Attachments: [
-							{ itemId: 1, fileName: 'doc1.pdf', redactedItemId: null, redactedFileName: null, statusId: 'accepted' },
-							{ itemId: 2, fileName: 'doc2.pdf', redactedItemId: null, redactedFileName: null, statusId: 'accepted' }
+							{
+								itemId: '12345',
+								fileName: 'doc1.pdf',
+								redactedItemId: null,
+								redactedFileName: null,
+								statusId: 'accepted'
+							},
+							{
+								itemId: '67890',
+								fileName: 'doc2.pdf',
+								redactedItemId: null,
+								redactedFileName: null,
+								statusId: 'accepted'
+							}
 						]
 					}))
 				},
@@ -344,7 +293,13 @@ describe('written representations read more', () => {
 				}
 			};
 			const mockSharePoint = {
-				getItemsByPath: mock.fn(() => [])
+				getDriveItem: mock.fn((id) => {
+					const items = {
+						12345: { id: '12345', name: 'doc1.pdf', file: { mimeType: 'application/pdf' }, size: 12345 },
+						67890: { id: '67890', name: 'doc2.pdf', file: { mimeType: 'application/pdf' }, size: 56789 }
+					};
+					return items[id] ?? null;
+				})
 			};
 
 			const handler = buildWrittenRepresentationsReadMorePage({
@@ -373,13 +328,32 @@ describe('written representations read more', () => {
 				distressingContent: false
 			});
 			assert.strictEqual(viewData.containsDistressingContent, false);
-			assert.deepStrictEqual(viewData.documents, []);
+			assert.deepStrictEqual(viewData.documents, [
+				{
+					category: undefined,
+					createdDate: '',
+					distressing: false,
+					id: '12345',
+					lastModified: '',
+					name: 'doc1.pdf',
+					size: '12 KB',
+					type: 'PDF'
+				},
+				{
+					category: undefined,
+					createdDate: '',
+					distressing: false,
+					id: '67890',
+					lastModified: '',
+					name: 'doc2.pdf',
+					size: '55 KB',
+					type: 'PDF'
+				}
+			]);
 
-			assert.strictEqual(mockSharePoint.getItemsByPath.mock.callCount(), 1);
-			assert.match(
-				mockSharePoint.getItemsByPath.mock.calls[0].arguments[0],
-				/^CROWN-2025-0000001\/Published\/RepresentationAttachments\/AAAAA-BBBBB$/
-			);
+			assert.strictEqual(mockSharePoint.getDriveItem.mock.callCount(), 2);
+			assert.strictEqual(mockSharePoint.getDriveItem.mock.calls[0].arguments[0], '12345');
+			assert.strictEqual(mockSharePoint.getDriveItem.mock.calls[1].arguments[0], '67890');
 		});
 
 		it('should render the view with representation (without attachments)', async () => {

--- a/apps/portal/src/util/config-middleware.js
+++ b/apps/portal/src/util/config-middleware.js
@@ -1,16 +1,9 @@
 /**
  * Add configuration values to locals.
- * @param {{isLive: boolean, isRepsUploadDocsLive: boolean, contactEmail: string, googleAnalyticsId?: string, appName: string}} params
+ * @param {{isLive: boolean, contactEmail: string, googleAnalyticsId?: string, appHostname: string, appName: string}} params
  * @returns {import('express').Handler}
  */
-export function addLocalsConfiguration({
-	isLive,
-	isRepsUploadDocsLive,
-	contactEmail,
-	googleAnalyticsId,
-	appHostname,
-	appName
-}) {
+export function addLocalsConfiguration({ isLive, contactEmail, googleAnalyticsId, appHostname, appName }) {
 	return (req, res, next) => {
 		const path = req.path;
 
@@ -59,7 +52,6 @@ export function addLocalsConfiguration({
 			}),
 			haveYourSayServiceName: 'Have your say on a Crown development application',
 			isLive,
-			isRepsUploadDocsLive,
 			contactEmail,
 			googleAnalyticsId,
 			googleAnalyticsCookieDomain: appHostname,

--- a/infrastructure/app-manage.tf
+++ b/infrastructure/app-manage.tf
@@ -91,11 +91,7 @@ module "app_manage" {
     GOV_NOTIFY_LPA_QUEST_SENT_TEMPLATE_ID      = var.apps_config.gov_notify.templates.lpa_quest_sent_template_id
 
     #feature flags
-    FEATURE_FLAG_UPLOAD_DOCS_REPS_NOT_LIVE    = var.apps_config.feature_flags.upload_docs_not_live
-    FEATURE_FLAG_NOTIFY_CALLBACK_NOT_LIVE     = var.apps_config.feature_flags.notify_callback_not_live
-    FEATURE_FLAG_APPLICATION_UPDATES_NOT_LIVE = var.apps_config.feature_flags.application_updates_not_live
-    FEATURE_FLAG_MULTIPLE_APPLICANTS_NOT_LIVE = var.apps_config.feature_flags.multiple_applicants_not_live
-    FEATURE_FLAG_S62A_MANAGE_NOT_LIVE         = var.apps_config.feature_flags.s62a_manage_not_live
+    FEATURE_FLAG_S62A_MANAGE_NOT_LIVE = var.apps_config.feature_flags.s62a_manage_not_live
 
     # Azure Language Service
     AZURE_AI_LANGUAGE_ENDPOINT = local.text_analytics_endpoint

--- a/infrastructure/app-portal.tf
+++ b/infrastructure/app-portal.tf
@@ -103,10 +103,7 @@ module "app_portal" {
     SHAREPOINT_DRIVE_ID = local.key_vault_refs["crown-sharepoint-drive-id"]
 
     #feature flags
-    FEATURE_FLAG_PORTAL_NOT_LIVE              = var.apps_config.feature_flags.portal_not_live
-    FEATURE_FLAG_UPLOAD_DOCS_REPS_NOT_LIVE    = var.apps_config.feature_flags.upload_docs_not_live
-    FEATURE_FLAG_APPLICATION_UPDATES_NOT_LIVE = var.apps_config.feature_flags.application_updates_not_live
-    FEATURE_FLAG_MULTIPLE_APPLICANTS_NOT_LIVE = var.apps_config.feature_flags.multiple_applicants_not_live
+    FEATURE_FLAG_PORTAL_NOT_LIVE = var.apps_config.feature_flags.portal_not_live
 
     # Cache Controls
     DYNAMIC_CACHE_CONTROL_ENABLED = var.apps_config.dynamic_cache_control.enabled

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -25,13 +25,9 @@ apps_config = {
   }
 
   feature_flags = {
-    portal_not_live              = false
-    upload_docs_not_live         = false
-    notify_callback_not_live     = false
-    application_updates_not_live = false
-    multiple_applicants_not_live = true
-    s62a_portal_not_live         = true
-    s62a_manage_not_live         = false
+    portal_not_live      = false
+    s62a_portal_not_live = true
+    s62a_manage_not_live = false
   }
 
   dynamic_cache_control = {

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -24,13 +24,9 @@ apps_config = {
   }
 
   feature_flags = {
-    portal_not_live              = false
-    upload_docs_not_live         = false
-    notify_callback_not_live     = false
-    application_updates_not_live = false
-    multiple_applicants_not_live = true
-    s62a_portal_not_live         = true
-    s62a_manage_not_live         = true
+    portal_not_live      = false
+    s62a_portal_not_live = true
+    s62a_manage_not_live = true
   }
 
   dynamic_cache_control = {

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -25,13 +25,9 @@ apps_config = {
   }
 
   feature_flags = {
-    portal_not_live              = false
-    upload_docs_not_live         = false
-    notify_callback_not_live     = false
-    application_updates_not_live = false
-    multiple_applicants_not_live = false
-    s62a_portal_not_live         = true
-    s62a_manage_not_live         = false
+    portal_not_live      = false
+    s62a_portal_not_live = true
+    s62a_manage_not_live = false
   }
 
   dynamic_cache_control = {

--- a/infrastructure/environments/training.tfvars
+++ b/infrastructure/environments/training.tfvars
@@ -25,13 +25,9 @@ apps_config = {
   }
 
   feature_flags = {
-    portal_not_live              = false
-    upload_docs_not_live         = false
-    notify_callback_not_live     = false
-    application_updates_not_live = false
-    multiple_applicants_not_live = true
-    s62a_portal_not_live         = true
-    s62a_manage_not_live         = true
+    portal_not_live      = false
+    s62a_portal_not_live = true
+    s62a_manage_not_live = true
   }
 
   dynamic_cache_control = {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -33,13 +33,9 @@ variable "apps_config" {
     })
 
     feature_flags = object({
-      portal_not_live              = bool
-      upload_docs_not_live         = bool
-      notify_callback_not_live     = bool
-      application_updates_not_live = bool
-      multiple_applicants_not_live = bool
-      s62a_portal_not_live         = bool
-      s62a_manage_not_live         = bool
+      portal_not_live      = bool
+      s62a_portal_not_live = bool
+      s62a_manage_not_live = bool
     })
 
     dynamic_cache_control = object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -4856,7 +4856,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5019,25 +5018,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simple-libs/stream-utils": "^1.2.0",
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-raw-commits/node_modules/meow": {

--- a/packages/lib/forms/representations/sections.js
+++ b/packages/lib/forms/representations/sections.js
@@ -18,11 +18,10 @@ import { BOOLEAN_OPTIONS } from '@planning-inspectorate/dynamic-forms/src/compon
 
 /**
  * @param {Questions} questions
- * @param {boolean} isRepsUploadDocsLive
  * @param {boolean} isViewJourney
  * @returns {Section[]}
  */
-export function haveYourSayManageSections(questions, isRepsUploadDocsLive, isViewJourney) {
+export function haveYourSayManageSections(questions, isViewJourney) {
 	/** @param {import('@planning-inspectorate/dynamic-forms/src/journey/journey-response.js').JourneyResponse} response */
 	const distressingContentCondition = (response) =>
 		isViewJourney && !questionHasAnswer(response, questions.status, REPRESENTATION_STATUS_ID.REJECTED);
@@ -38,8 +37,8 @@ export function haveYourSayManageSections(questions, isRepsUploadDocsLive, isVie
 			.addQuestion(questions.status)
 			.withCondition(() => isViewJourney),
 		new Section('Representation', 'start').addQuestion(questions.submittedFor),
-		addRepMyselfSection(questions, isRepsUploadDocsLive, isViewJourney),
-		addRepAgentSection(questions, isRepsUploadDocsLive, isViewJourney),
+		addRepMyselfSection(questions, isViewJourney),
+		addRepAgentSection(questions, isViewJourney),
 		new Section('Distressing Content', 'distressing-content')
 			.withSectionCondition(distressingContentCondition)
 			.addQuestion(questions.distressingContentInRepresentation),
@@ -54,22 +53,20 @@ export function haveYourSayManageSections(questions, isRepsUploadDocsLive, isVie
 
 /**
  * @param {Questions} questions
- * @param {boolean} isRepsUploadDocsLive
  * @returns {Section[]}
  */
-export function haveYourSaySections(questions, isRepsUploadDocsLive) {
+export function haveYourSaySections(questions) {
 	return [
 		new Section('Representation', 'start').addQuestion(questions.submittedFor),
-		myselfSection(questions, isRepsUploadDocsLive),
-		agentSection(questions, isRepsUploadDocsLive)
+		myselfSection(questions),
+		agentSection(questions)
 	];
 }
 /**
  * @param {Questions} questions
- * @param {boolean} isRepsUploadDocsLive
  * @returns {Section[]}
  */
-export function addRepresentationSection(questions, isRepsUploadDocsLive) {
+export function addRepresentationSection(questions) {
 	return [
 		new Section('Representation', 'start')
 			.addQuestion(questions.submittedDate)
@@ -77,24 +74,22 @@ export function addRepresentationSection(questions, isRepsUploadDocsLive) {
 			.addQuestion(questions.submissionMethodReason)
 			.addQuestion(questions.category)
 			.addQuestion(questions.submittedFor),
-		addRepMyselfSection(questions, isRepsUploadDocsLive, false),
-		addRepAgentSection(questions, isRepsUploadDocsLive, false)
+		addRepMyselfSection(questions, false),
+		addRepAgentSection(questions, false)
 	];
 }
 
 /**
  * @param {Questions} questions
- * @param {boolean} isRepsUploadDocsLive
  * @returns {Section}
  */
-function myselfSection(questions, isRepsUploadDocsLive) {
+function myselfSection(questions) {
 	return new Section('Myself', 'myself')
 		.withSectionCondition(whenQuestionHasAnswer(questions.submittedFor, REPRESENTATION_SUBMITTED_FOR_ID.MYSELF))
 		.addQuestion(questions.myselfFullName)
 		.addQuestion(questions.myselfEmail)
 		.addQuestion(questions.myselfTellUsAboutApplication)
 		.addQuestion(questions.myselfHasAttachments)
-		.withCondition(() => isRepsUploadDocsLive === true)
 		.addQuestion(questions.myselfSelectAttachments)
 		.withCondition(whenQuestionHasAnswer(questions.myselfHasAttachments, BOOLEAN_OPTIONS.YES));
 }
@@ -103,11 +98,10 @@ function myselfSection(questions, isRepsUploadDocsLive) {
  * Myself section for the add representation journey (contains more questions that the default section)
  *
  * @param {Questions} questions
- * @param {boolean} isRepsUploadDocsLive
  * @param {boolean} isViewJourney
  * @returns {Section}
  */
-function addRepMyselfSection(questions, isRepsUploadDocsLive, isViewJourney) {
+function addRepMyselfSection(questions, isViewJourney) {
 	return new Section('Myself', 'myself')
 		.withSectionCondition(whenQuestionHasAnswer(questions.submittedFor, REPRESENTATION_SUBMITTED_FOR_ID.MYSELF))
 		.addQuestion(questions.myselfFullName)
@@ -121,7 +115,6 @@ function addRepMyselfSection(questions, isRepsUploadDocsLive, isViewJourney) {
 		.addQuestion(questions.myselfCommentRedacted)
 		.withCondition(() => isViewJourney)
 		.addQuestion(questions.myselfHasAttachments)
-		.withCondition(() => isRepsUploadDocsLive === true)
 		.addQuestion(questions.myselfSelectAttachments)
 		.withCondition(whenQuestionHasAnswer(questions.myselfHasAttachments, BOOLEAN_OPTIONS.YES))
 		.addQuestion(questions.myselfRedactedAttachments)
@@ -137,10 +130,9 @@ function addRepMyselfSection(questions, isRepsUploadDocsLive, isViewJourney) {
 
 /**
  * @param {Questions} questions
- * @param {boolean} isRepsUploadDocsLive
  * @returns {Section}
  */
-function agentSection(questions, isRepsUploadDocsLive) {
+function agentSection(questions) {
 	const isRepresentationPerson = whenQuestionHasAnswer(questions.whoRepresenting, REPRESENTED_TYPE_ID.PERSON);
 	const isOrgWorkFor = whenQuestionHasAnswer(questions.whoRepresenting, REPRESENTED_TYPE_ID.ORGANISATION);
 	const isOrgNotWorkFor = whenQuestionHasAnswer(questions.whoRepresenting, REPRESENTED_TYPE_ID.ORG_NOT_WORK_FOR);
@@ -169,7 +161,6 @@ function agentSection(questions, isRepsUploadDocsLive) {
 		.endMultiQuestionCondition('representation-person')
 		.addQuestion(questions.submitterTellUsAboutApplication)
 		.addQuestion(questions.submitterHasAttachments)
-		.withCondition(() => isRepsUploadDocsLive === true)
 		.addQuestion(questions.submitterSelectAttachments)
 		.withCondition(whenQuestionHasAnswer(questions.submitterHasAttachments, BOOLEAN_OPTIONS.YES))
 		.addQuestion(questions.submitterRedactedAttachments)
@@ -185,11 +176,10 @@ function agentSection(questions, isRepsUploadDocsLive) {
 
 /**
  * @param {Questions} questions
- * @param {boolean} isRepsUploadDocsLive
  * @param {boolean} isViewJourney
  * @returns {Section}
  */
-function addRepAgentSection(questions, isRepsUploadDocsLive, isViewJourney) {
+function addRepAgentSection(questions, isViewJourney) {
 	const isRepresentationPerson = whenQuestionHasAnswer(questions.whoRepresenting, REPRESENTED_TYPE_ID.PERSON);
 	const isOrgWorkFor = whenQuestionHasAnswer(questions.whoRepresenting, REPRESENTED_TYPE_ID.ORGANISATION);
 	const isOrgNotWorkFor = whenQuestionHasAnswer(questions.whoRepresenting, REPRESENTED_TYPE_ID.ORG_NOT_WORK_FOR);
@@ -225,7 +215,6 @@ function addRepAgentSection(questions, isRepsUploadDocsLive, isViewJourney) {
 		.addQuestion(questions.submitterCommentRedacted)
 		.withCondition(() => isViewJourney)
 		.addQuestion(questions.submitterHasAttachments)
-		.withCondition(() => isRepsUploadDocsLive === true)
 		.addQuestion(questions.submitterSelectAttachments)
 		.withCondition(whenQuestionHasAnswer(questions.submitterHasAttachments, BOOLEAN_OPTIONS.YES));
 }

--- a/packages/lib/forms/representations/sections.test.js
+++ b/packages/lib/forms/representations/sections.test.js
@@ -21,7 +21,7 @@ describe('have-your-say', () => {
 			const createJourney = (questions, response, req) => {
 				return new Journey({
 					journeyId: JOURNEY_ID,
-					sections: haveYourSayManageSections(questions, true, true),
+					sections: haveYourSayManageSections(questions, true),
 					makeBaseUrl: () => req.baseUrl,
 					journeyTemplate: 'template.njk',
 					taskListTemplate: 'template-2.njk',
@@ -46,7 +46,7 @@ describe('have-your-say', () => {
 			const createJourney = (questions, response, req) => {
 				return new Journey({
 					journeyId: JOURNEY_ID,
-					sections: haveYourSayManageSections(questions, true, false),
+					sections: haveYourSayManageSections(questions, false),
 					makeBaseUrl: () => req.baseUrl,
 					journeyTemplate: 'template.njk',
 					taskListTemplate: 'template-2.njk',
@@ -73,7 +73,7 @@ describe('have-your-say', () => {
 			const createJourney = (questions, response, req) => {
 				return new Journey({
 					journeyId: JOURNEY_ID,
-					sections: haveYourSayManageSections(questions, true, true),
+					sections: haveYourSayManageSections(questions, true),
 					makeBaseUrl: () => req.baseUrl,
 					journeyTemplate: 'template.njk',
 					taskListTemplate: 'template-2.njk',
@@ -108,7 +108,7 @@ describe('have-your-say', () => {
 				const createJourney = (questions, response, req) => {
 					return new Journey({
 						journeyId: JOURNEY_ID,
-						sections: haveYourSayManageSections(questions, true, true),
+						sections: haveYourSayManageSections(questions, true),
 						makeBaseUrl: () => req.baseUrl,
 						journeyTemplate: 'template.njk',
 						taskListTemplate: 'template-2.njk',
@@ -144,7 +144,7 @@ describe('have-your-say', () => {
 			const createJourney = (questions, response, req) => {
 				return new Journey({
 					journeyId: JOURNEY_ID,
-					sections: haveYourSayManageSections(questions, true, false),
+					sections: haveYourSayManageSections(questions, false),
 					makeBaseUrl: () => req.baseUrl,
 					journeyTemplate: 'template.njk',
 					taskListTemplate: 'template-2.njk',
@@ -159,7 +159,7 @@ describe('have-your-say', () => {
 			});
 			const sections = journey.sections;
 
-			// Verify distressing content section exists and its condition evaluates to true
+			// Verify distressing content section exists and its condition evaluates to false
 			const distressingContentSection = sections.find((s) => s.segment === 'distressing-content');
 
 			assert.ok(distressingContentSection, 'Section should exist');
@@ -174,10 +174,10 @@ describe('have-your-say', () => {
 	});
 	describe('have-your-say section', () => {
 		const JOURNEY_ID = 'have-your-say-1';
-		const createJourney = (questions, response, req, isRepsUploadDocsLive = true) => {
+		const createJourney = (questions, response, req) => {
 			return new Journey({
 				journeyId: JOURNEY_ID,
-				sections: haveYourSaySections(questions, isRepsUploadDocsLive),
+				sections: haveYourSaySections(questions),
 				makeBaseUrl: () => req.baseUrl,
 				journeyTemplate: 'template.njk',
 				taskListTemplate: 'template-2.njk',
@@ -366,7 +366,7 @@ describe('have-your-say', () => {
 			assert.strictEqual(journey.isComplete(), true);
 		});
 
-		it('isComplete should false true if on behalf of org work for journey incomplete', () => {
+		it('isComplete should return false if on behalf of org work for journey incomplete', () => {
 			const questions = getQuestions();
 			const answers = {
 				submittedForId: REPRESENTATION_SUBMITTED_FOR_ID.ON_BEHALF_OF,
@@ -495,7 +495,8 @@ describe('have-your-say', () => {
 				'myselfContactPreference',
 				'myselfFullName',
 				'myselfComment',
-				'myselfHearingPreference'
+				'myselfHearingPreference',
+				'myselfContainsAttachments'
 			];
 			it('should include all default questions', () => {
 				const answers = defaultAnswers();
@@ -529,7 +530,8 @@ describe('have-your-say', () => {
 					myselfContactPreference: 'email',
 					myselfEmail: 'test@test.com',
 					myselfComment: 'some comments',
-					myselfHearingPreference: BOOLEAN_OPTIONS.YES
+					myselfHearingPreference: BOOLEAN_OPTIONS.YES,
+					myselfContainsAttachments: BOOLEAN_OPTIONS.NO
 				};
 
 				const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -569,7 +571,8 @@ describe('have-your-say', () => {
 					'representedFullName',
 					'submitterComment',
 					'submitterContactPreference',
-					'submitterHearingPreference'
+					'submitterHearingPreference',
+					'submitterContainsAttachments'
 				];
 				it('should include all default questions', () => {
 					const answers = defaultAnswers();
@@ -623,7 +626,8 @@ describe('have-your-say', () => {
 						representedFirstName: 'Represented Person',
 						representedLastName: 'Represented Surname',
 						submitterComment: 'some comments',
-						submitterHearingPreference: BOOLEAN_OPTIONS.YES
+						submitterHearingPreference: BOOLEAN_OPTIONS.YES,
+						submitterContainsAttachments: BOOLEAN_OPTIONS.NO
 					};
 
 					const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -666,6 +670,7 @@ describe('have-your-say', () => {
 					'submitterComment',
 					'submitterContactPreference',
 					'submitterHearingPreference',
+					'submitterContainsAttachments',
 					'representedOrgName'
 				];
 				it('should include all default questions', () => {
@@ -719,7 +724,8 @@ describe('have-your-say', () => {
 						},
 						representedOrgName: 'Org Name Representing',
 						submitterComment: 'some comments',
-						submitterHearingPreference: BOOLEAN_OPTIONS.YES
+						submitterHearingPreference: BOOLEAN_OPTIONS.YES,
+						submitterContainsAttachments: BOOLEAN_OPTIONS.NO
 					};
 
 					const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);
@@ -765,7 +771,8 @@ describe('have-your-say', () => {
 					'submitterContactPreference',
 					'submitterHearingPreference',
 					'orgName',
-					'orgRoleName'
+					'orgRoleName',
+					'submitterContainsAttachments'
 				];
 				it('should include all default questions', () => {
 					const answers = defaultAnswers();
@@ -800,7 +807,8 @@ describe('have-your-say', () => {
 						orgName: 'some org',
 						orgRoleName: 'some job',
 						submitterComment: 'some comments',
-						submitterHearingPreference: BOOLEAN_OPTIONS.YES
+						submitterHearingPreference: BOOLEAN_OPTIONS.YES,
+						submitterContainsAttachments: BOOLEAN_OPTIONS.NO
 					};
 
 					const response = new JourneyResponse(JOURNEY_ID, 'sess-id', answers);

--- a/packages/lib/util/sharepoint-path.js
+++ b/packages/lib/util/sharepoint-path.js
@@ -33,17 +33,6 @@ export function publishedRepresentationsAttachmentsRootFolderPath(caseReference)
 }
 
 /**
- * Returns the published reps attachments folder path for the given case reference and representation reference
- *
- * @param {string} caseReference
- * @param {string} repReference
- * @returns {string}
- */
-export function publishedRepresentationsAttachmentsFolderPath(caseReference, repReference) {
-	return buildPath(publishedFolderPath(caseReference), APPLICATION_FOLDERS.REPRESENTATION_ATTACHMENTS, repReference);
-}
-
-/**
  * Return the representation attachments folder path for the given case reference and representation reference
  * @param {string} caseReference
  * @param {string} repReference


### PR DESCRIPTION
## Describe your changes
This pull request removes the "Reps Upload Docs" and "Application Updates" feature flags from both the Manage and Portal applications. As a result, related code paths and conditional logic based on these flags have been deleted or simplified. Additionally, the journeys for representations have been updated to always assume these features are live, and tests have been adjusted accordingly.

**Feature flag removal and code simplification:**

- Removed all references to `FEATURE_FLAG_UPLOAD_DOCS_REPS_NOT_LIVE` and `FEATURE_FLAG_APPLICATION_UPDATES_NOT_LIVE` from configuration and service files in both `apps/manage` and `apps/portal`, including their use in `loadConfig`, `ManageService`, and `PortalService` (`apps/manage/src/app/config.js`, `apps/portal/src/app/config.js`, `apps/manage/src/app/service.js`, `apps/portal/src/app/service.js`) [[1]](diffhunk://#diff-1ba8d76e3831e7acc4caff696530762f5836807d7a412854eb69a46b3009f0a0L69-L71) [[2]](diffhunk://#diff-1ba8d76e3831e7acc4caff696530762f5836807d7a412854eb69a46b3009f0a0L209-L211) [[3]](diffhunk://#diff-2ef67412f63f3b7bd975b40f20a590d6de4126a5cb535a18d40eb11f07c3fc12L155-L162) [[4]](diffhunk://#diff-3fe65e52bb2506f990269e5369b45b5694e8ca24610ec72825998c7d4f55ea57L33) [[5]](diffhunk://#diff-3fe65e52bb2506f990269e5369b45b5694e8ca24610ec72825998c7d4f55ea57L49-R48) [[6]](diffhunk://#diff-3fe65e52bb2506f990269e5369b45b5694e8ca24610ec72825998c7d4f55ea57L113-R111) [[7]](diffhunk://#diff-22d748fd1e199910dbafd6de747273a2eaf13de7920de8a38e01fa802bf995feL92-L99).
- Removed feature flag parameters from controllers, route definitions, and utility functions, including `addLocalsConfiguration`, and updated their signatures and usages to no longer depend on these flags (`apps/manage/src/util/config-middleware.js`, `apps/manage/src/app/views/cases/view/controller.ts`, `apps/manage/src/app/views/cases/view/index.js`) [[1]](diffhunk://#diff-5d43bc121109aef7d07e6b0842ac6adc112e50c7209e842b8dcb8e4c627ae425L3-L9) [[2]](diffhunk://#diff-f8df097ea116aea6bde7351fa0715c816366779f631d652927f97441d2551bd3L174-R174) [[3]](diffhunk://#diff-f8df097ea116aea6bde7351fa0715c816366779f631d652927f97441d2551bd3L211) [[4]](diffhunk://#diff-bcccef2fe59e14d01209a4d9ceefb4238d57fc3dba5ee18d2b501afeb4fb1cb8L45-L50).

**Representation journeys always live:**

- Updated all `createJourney` functions and their usages in the "manage representations" and "have your say" flows to remove the `isRepsUploadDocsLive` parameter, and simplified the logic in journey section creation accordingly (`apps/manage/src/app/views/cases/view/manage-reps/add/journey.js`, `apps/manage/src/app/views/cases/view/manage-reps/view/journey.js`, `apps/manage/src/app/views/cases/view/manage-reps/withdraw/journey.js`, `apps/portal/src/app/views/applications/view/have-your-say/journey.js`) [[1]](diffhunk://#diff-37925ae86a04372597ebcf8c7f8180dd5fb5e90ec42a1c28f9cc0c8dfe4ef46cL6-R13) [[2]](diffhunk://#diff-a4826966751fb70c86803aaab0f4fc2ce7e85d0e04ca54c82e60ac7b691fada9L12-R14) [[3]](diffhunk://#diff-a4826966751fb70c86803aaab0f4fc2ce7e85d0e04ca54c82e60ac7b691fada9L24-R23) [[4]](diffhunk://#diff-20a33ea86e38b4c98324fb4a67af01830feb3b5d63df9cb10964205242cc377aL6-R6) [[5]](diffhunk://#diff-20a33ea86e38b4c98324fb4a67af01830feb3b5d63df9cb10964205242cc377aL18) [[6]](diffhunk://#diff-5ad574f4a6d72f1f522c956dff9ad96b2329c35d067d318ecad6cc99c8b17a16L6-R13).

**Route and view cleanup:**

- Removed conditional routing and template logic based on the removed feature flags, making routes and UI elements for application updates and document uploads always available (`apps/manage/src/app/views/cases/view/index.js`, `apps/manage/src/app/views/cases/view/view.njk`) [[1]](diffhunk://#diff-bcccef2fe59e14d01209a4d9ceefb4238d57fc3dba5ee18d2b501afeb4fb1cb8L45-L50) [[2]](diffhunk://#diff-8e00175704c357e01fcbec675c519b0af3754c21c34727da1bdddd81aa02c482L67-L73).

**Test updates:**

- Updated tests for all journeys to remove the feature flag parameter and ensure test data includes new required fields, such as `*_containsAttachments` (`apps/manage/src/app/views/cases/view/manage-reps/withdraw/journey.test.js`, `apps/portal/src/app/views/applications/view/have-your-say/journey.test.js`) [[1]](diffhunk://#diff-ab337be07f53bdc43cc66357a0110461e83763106562b203f4eb59aa5ec31978L18-R18) [[2]](diffhunk://#diff-d0d19975a2255e76745b84d2e4b424be37a07eae7c79ee7b3ec045f596a4b757L109-R110) [[3]](diffhunk://#diff-d0d19975a2255e76745b84d2e4b424be37a07eae7c79ee7b3ec045f596a4b757L145-R147) [[4]](diffhunk://#diff-d0d19975a2255e76745b84d2e4b424be37a07eae7c79ee7b3ec045f596a4b757L164-R167) [[5]](diffhunk://#diff-d0d19975a2255e76745b84d2e4b424be37a07eae7c79ee7b3ec045f596a4b757L183-R187) [[6]](diffhunk://#diff-d0d19975a2255e76745b84d2e4b424be37a07eae7c79ee7b3ec045f596a4b757L221-R226).

**Logging improvement:**

- Added a warning log when a representation claims to contain attachments but none are found, improving diagnostics for edge cases in the review flow (`apps/manage/src/app/views/cases/view/manage-reps/review/controller.js`).
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1687