### PR TITLE
fix(portal): add missing focus to pagination element

### DIFF
--- a/packages/lib/views/pagination/pagination-options.njk
+++ b/packages/lib/views/pagination/pagination-options.njk
@@ -8,7 +8,7 @@
             {% if size == selectedItemsPerPage %}
                 <span class="govuk-body">{{ size }}</span>
             {% else %}
-                <a class="govuk-link--no-visited-state" href="{{ buildItemsPerPageUrl(baseUrl, queryParams, size, true) }}" data-pagination="{{ size }}">{{ size }}</a>
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ buildItemsPerPageUrl(baseUrl, queryParams, size, true) }}" data-pagination="{{ size }}">{{ size }}</a>
             {% endif %}
 
             {% if not loop.last %}&nbsp;&nbsp;|&nbsp;&nbsp;{% endif %}


### PR DESCRIPTION
## Describe your changes
This ticket fixes the focus on the pagination in the portal app for written reps and documents. 

The results per page 25, 50 and 100 links now show a yellow focus matching the same behaviour as other links

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1538
<img width="1742" height="637" alt="image" src="https://github.com/user-attachments/assets/d8993d66-a8af-499a-b196-d519e09520f4" />
