### PR TITLE
fix(portal): align error summary in written representations

### DIFF
--- a/apps/portal/src/app/views/applications/view/written-representations/view.njk
+++ b/apps/portal/src/app/views/applications/view/written-representations/view.njk
@@ -11,7 +11,7 @@
 {% from "distressing-content/distressing-content-banner.njk" import distressingContentBanner %}
 
 {% block pageHeading %}{% endblock %}
-
+{% block error_summary %}{% endblock %}
 {% block pageContent %}
 	<div class="govuk-grid-row">
 		<div class="govuk-grid-column-one-third">
@@ -37,6 +37,12 @@
 		</div>
 
 		<div class="govuk-grid-column-two-thirds">
+			{% if errorSummary %}
+				{{ govukErrorSummary({
+					titleText: "There is a problem",
+					errorList: errorSummary
+				}) }}
+			{% endif %}
 			{{ distressingContentBanner(containsDistressingContent) }}
 			<div class="govuk-grid-row">
 				<div class="govuk-grid-column-full">


### PR DESCRIPTION
## Describe your changes

This pull request updates the `view.njk` template for written representations to support error summary display. The main changes add an error summary block and conditionally render a GOV.UK error summary component when errors are present.

**Error handling improvements:**

* Added an `{% block error_summary %}` block to the template to allow for error summary content injection.
* Conditionally render the GOV.UK `govukErrorSummary` component with the `errorSummary` data if errors exist, improving user feedback on form validation issues.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1555

Before 
<img width="1159" height="1067" alt="image" src="https://github.com/user-attachments/assets/f84db7fe-e1b3-4b2f-8f54-1485f730e4cf" />

After
<img width="1785" height="1071" alt="image" src="https://github.com/user-attachments/assets/87e6d9ed-0749-4041-9f4f-d06abd3acdd7" />
