### PR TITLE
fix(portal): add error summary for documents page

### DIFF
--- a/apps/portal/src/app/views/applications/view/documents/controller.test.ts
+++ b/apps/portal/src/app/views/applications/view/documents/controller.test.ts
@@ -857,4 +857,82 @@ describe('Date Published Filter', () => {
 		assert.strictEqual((viewData.queryParams as Record<string, string>)['publishedDateFrom-month'], '1');
 		assert.strictEqual((viewData.queryParams as Record<string, string>)['publishedDateFrom-year'], '2026');
 	});
+
+	it('should build error summary when incomplete date published from date', async () => {
+		const documents = [
+			{
+				id: '1',
+				name: 'doc.pdf',
+				file: { mimeType: 'application/pdf' },
+				createdDateTime: '2025-02-05T10:00:00Z',
+				lastModifiedDateTime: '2025-02-05T10:00:00Z',
+				size: 1000
+			}
+		];
+
+		const mockDb = createMockDb();
+		const mockSharePoint = createMockSharePoint(documents);
+		const handler = buildApplicationDocumentsPage({
+			db: mockDb,
+			logger: mockLogger(),
+			sharePointDrive: mockSharePoint
+		} as any);
+
+		const req = createMockRequest({
+			query: {
+				'publishedDateFrom-day': '',
+				'publishedDateFrom-month': '02',
+				'publishedDateFrom-year': '2025'
+			}
+		});
+
+		const res = createMockResponse();
+
+		await handler(req, res, createMockNext());
+
+		const viewData = getRenderArgs(res);
+		assert.ok(Array.isArray(viewData.errorSummary));
+		const errorSummary = viewData.errorSummary as Array<{ text: string; href: string }>;
+		assert.strictEqual(errorSummary.length, 1);
+		assert.strictEqual(errorSummary[0].href, '#publishedDateFrom-day');
+	});
+
+	it('should build error summary when invalid date published to date', async () => {
+		const documents = [
+			{
+				id: '1',
+				name: 'doc.pdf',
+				file: { mimeType: 'application/pdf' },
+				createdDateTime: '2025-02-05T10:00:00Z',
+				lastModifiedDateTime: '2025-02-05T10:00:00Z',
+				size: 1000
+			}
+		];
+
+		const mockDb = createMockDb();
+		const mockSharePoint = createMockSharePoint(documents);
+		const handler = buildApplicationDocumentsPage({
+			db: mockDb,
+			logger: mockLogger(),
+			sharePointDrive: mockSharePoint
+		} as any);
+
+		const req = createMockRequest({
+			query: {
+				'publishedDateTo-day': '32',
+				'publishedDateTo-month': '13',
+				'publishedDateTo-year': '20256'
+			}
+		});
+
+		const res = createMockResponse();
+
+		await handler(req, res, createMockNext());
+
+		const viewData = getRenderArgs(res);
+		assert.ok(Array.isArray(viewData.errorSummary));
+		const errorSummary = viewData.errorSummary as Array<{ text: string; href: string }>;
+		assert.strictEqual(errorSummary.length, 1);
+		assert.strictEqual(errorSummary[0].href, '#publishedDateTo-day');
+	});
 });

--- a/apps/portal/src/app/views/applications/view/documents/controller.ts
+++ b/apps/portal/src/app/views/applications/view/documents/controller.ts
@@ -24,6 +24,7 @@ import {
 	type FilterSection,
 	type QueryFilters
 } from './filters/filters.ts';
+import { mapDateFilterErrorSummary } from '../utils/filter-error-summary.ts';
 import type { PortalService } from '#service';
 import type { RequestHandler } from 'express';
 
@@ -138,6 +139,12 @@ export function buildApplicationDocumentsPage(service: PortalService): RequestHa
 		const queryParams = req.query;
 		const filterQueryParams = (req.query || {}) as QueryFilters;
 		const filters: FilterSection[] = buildDocumentFilters(filterQueryParams, categoryCounts);
+		const errorSummaryArray = mapDateFilterErrorSummary({
+			filters,
+			formType: 'desktop',
+			sectionTitle: 'Date published'
+		});
+		const errorSummary = errorSummaryArray.length > 0 ? errorSummaryArray : null;
 		const filterQueryItems = getFilterQueryItems(filters);
 
 		const baseUrl = `${req.baseUrl}/documents`;
@@ -180,7 +187,8 @@ export function buildApplicationDocumentsPage(service: PortalService): RequestHa
 			filters,
 			hasQueries: hasQueries(filterQueryParams),
 			filterQueries: filterQueryItems,
-			containsDistressingContent: crownDevelopment.containsDistressingContent ?? false
+			containsDistressingContent: crownDevelopment.containsDistressingContent ?? false,
+			errorSummary
 		});
 	};
 }

--- a/apps/portal/src/app/views/applications/view/documents/view.njk
+++ b/apps/portal/src/app/views/applications/view/documents/view.njk
@@ -1,6 +1,7 @@
 {% extends "views/layouts/main.njk" %}
 
 {% from "views/applications/view/links.njk" import applicationLinks %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% import "pagination/pagination.njk" as pagination %}
 {% import "pagination/pagination-options.njk" as paginationOptions %}
 {% from "search-bar/search-bar.njk" import searchBar %}
@@ -9,7 +10,7 @@
 {% from "distressing-content/distressing-content-banner.njk" import distressingContentBanner %}
 
 {% block pageHeading %}{% endblock %}
-
+{% block error_summary %}{% endblock %}
 {% block pageContent %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
@@ -25,6 +26,16 @@
         </div>
 
         <div class="govuk-grid-column-two-thirds">
+            {% if errorSummary %}
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        {{ govukErrorSummary({
+                            titleText: "There is a problem",
+                            errorList: errorSummary
+                        }) }}
+                    </div>
+                </div>
+            {% endif %}
             {{ distressingContentBanner(containsDistressingContent) }}
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">

--- a/apps/portal/src/app/views/applications/view/utils/filter-error-summary.test.ts
+++ b/apps/portal/src/app/views/applications/view/utils/filter-error-summary.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { mapDateFilterErrorSummary } from './filter-error-summary.ts';
+import type { DateFilterInput } from '@pins/crowndev-lib/filters/date-filter.ts';
+
+const createDateInput = (idPrefix: string, errorText?: string): DateFilterInput =>
+	({
+		idPrefix,
+		...(errorText && { errorMessage: { text: errorText } })
+	}) as DateFilterInput;
+
+describe('mapDateFilterErrorSummary', () => {
+	it('should extract a single date error with default desktop href format', () => {
+		const filters = [
+			{
+				title: 'Date published',
+				dateInputs: [createDateInput('publishedDateFrom', 'From date must include a day')]
+			}
+		];
+		const result = mapDateFilterErrorSummary({ filters, sectionTitle: 'Date published' });
+		assert.deepStrictEqual(result, [{ text: 'From date must include a day', href: '#publishedDateFrom-day' }]);
+	});
+
+	it('should generate mobile href format when formType is mobile', () => {
+		const filters = [
+			{
+				title: 'Date submitted',
+				dateInputs: [createDateInput('submittedDateFrom', 'From date must include a day')]
+			}
+		];
+		const result = mapDateFilterErrorSummary({
+			filters,
+			formType: 'mobile',
+			sectionTitle: 'Date submitted'
+		});
+		assert.deepStrictEqual(result, [{ text: 'From date must include a day', href: '#submittedDateFrom-mobile-day' }]);
+	});
+
+	it('should generate desktop href format when formType is desktop', () => {
+		const filters = [
+			{
+				title: 'Date submitted',
+				dateInputs: [createDateInput('submittedDateFrom', 'From date must include a day')]
+			}
+		];
+		const result = mapDateFilterErrorSummary({
+			filters,
+			formType: 'desktop',
+			sectionTitle: 'Date submitted'
+		});
+		assert.deepStrictEqual(result, [{ text: 'From date must include a day', href: '#submittedDateFrom-day' }]);
+	});
+
+	it('should extract errors from both From and To date inputs', () => {
+		const filters = [
+			{
+				title: 'Date submitted',
+				dateInputs: [
+					createDateInput('submittedDateFrom', 'From date is invalid'),
+					createDateInput('submittedDateTo', 'To date must be after From date')
+				]
+			}
+		];
+		const result = mapDateFilterErrorSummary({ filters, sectionTitle: 'Date submitted' });
+		assert.strictEqual(result.length, 2);
+		assert.strictEqual(result[0].text, 'From date is invalid');
+		assert.strictEqual(result[0].href, '#submittedDateFrom-day');
+		assert.strictEqual(result[1].text, 'To date must be after From date');
+		assert.strictEqual(result[1].href, '#submittedDateTo-day');
+	});
+
+	it('should only extract errors from the specified section title', () => {
+		const filters = [
+			{
+				title: 'Date submitted',
+				dateInputs: [createDateInput('submittedDate', 'Submitted date error')]
+			},
+			{
+				title: 'Date decided',
+				dateInputs: [createDateInput('decidedDate', 'Decided date error')]
+			}
+		];
+		const result = mapDateFilterErrorSummary({ filters, sectionTitle: 'Date submitted' });
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].text, 'Submitted date error');
+	});
+
+	it('should skip dateInputs that have no error', () => {
+		const filters = [
+			{
+				title: 'Date submitted',
+				dateInputs: [createDateInput('submittedDateFrom'), createDateInput('submittedDateTo', 'To date is required')]
+			}
+		];
+		const result = mapDateFilterErrorSummary({ filters, sectionTitle: 'Date submitted' });
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].text, 'To date is required');
+	});
+
+	it('should return empty array when dateInputs have no errors', () => {
+		const filters = [
+			{
+				title: 'Date submitted',
+				dateInputs: [createDateInput('submittedDateFrom'), createDateInput('submittedDateTo')]
+			}
+		];
+		const result = mapDateFilterErrorSummary({ filters, sectionTitle: 'Date submitted' });
+		assert.deepStrictEqual(result, []);
+	});
+});

--- a/apps/portal/src/app/views/applications/view/utils/filter-error-summary.ts
+++ b/apps/portal/src/app/views/applications/view/utils/filter-error-summary.ts
@@ -1,0 +1,57 @@
+import type { DateFilterInput } from '@pins/crowndev-lib/filters/date-filter.ts';
+
+type FilterSectionLike = {
+	title?: string;
+	type?: string;
+	dateInputs?: DateFilterInput[];
+};
+
+type ErrorSummaryItem = {
+	text: string;
+	href: string;
+};
+
+type FormType = 'desktop' | 'mobile';
+
+type MapDateFilterErrorSummaryOptions = {
+	sectionTitle: string;
+	getHref?: (dateInput: DateFilterInput, formType: FormType) => string;
+	requireDateInputType?: boolean;
+};
+
+type MapDateFilterErrorSummaryArgs = {
+	filters?: FilterSectionLike[];
+	formType?: FormType;
+} & MapDateFilterErrorSummaryOptions;
+
+export function mapDateFilterErrorSummary({
+	filters = [],
+	formType = 'desktop',
+	sectionTitle,
+	getHref = (dateInput, ft) => {
+		const suffix = ft === 'mobile' ? '-mobile' : '';
+		return `#${dateInput.idPrefix}${suffix}-day`;
+	},
+	requireDateInputType = false
+}: MapDateFilterErrorSummaryArgs): ErrorSummaryItem[] {
+	const errorSummary: ErrorSummaryItem[] = [];
+
+	filters.forEach((section) => {
+		const isMatchingTitle = section?.title === sectionTitle;
+		const isMatchingType = !requireDateInputType || section?.type === 'date-input';
+
+		if (isMatchingTitle && isMatchingType && Array.isArray(section.dateInputs)) {
+			section.dateInputs.forEach((dateInput) => {
+				const errText = dateInput?.errorMessage?.text;
+				if (errText) {
+					errorSummary.push({
+						text: errText,
+						href: getHref(dateInput, formType)
+					});
+				}
+			});
+		}
+	});
+
+	return errorSummary;
+}

--- a/apps/portal/src/app/views/applications/view/written-representations/controller.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/controller.js
@@ -14,6 +14,7 @@ import { parseDateFromParts } from '@pins/crowndev-lib/validators/date-filter-va
 import { endOfDay, startOfDay } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { getStringParam } from '@pins/crowndev-lib/util/params.ts';
+import { mapDateFilterErrorSummary } from '../utils/filter-error-summary.ts';
 
 /**
  * Processes filters and error summaries for written representations.
@@ -30,7 +31,11 @@ function getFiltersAndErrors({ db, logger }, id, query) {
 	return Promise.resolve(filters).then((filters) => {
 		const filterQueryItems = getFilterQueryItems(filters);
 		const formType = getFormType(query);
-		const errorSummary = mapErrorSummary(filters, formType);
+		const errorSummary = mapDateFilterErrorSummary({
+			filters,
+			formType,
+			sectionTitle: 'Date submitted'
+		});
 		const dateErrors = errorSummary
 			.filter((e) => e.href && e.href.startsWith('#submittedDate'))
 			.map((e) => ({ text: e.text, href: e.href }));
@@ -52,28 +57,6 @@ function getFiltersAndErrors({ db, logger }, id, query) {
  */
 function getFormType(query) {
 	return query?.formType === 'mobile' ? 'mobile' : 'desktop';
-}
-
-/**
- * Maps error summary from filters.
- * @param {any[]} filters
- * @param {'desktop'|'mobile'} formType
- * @returns {Array<{ text: string, href: string }>}
- */
-function mapErrorSummary(filters, formType) {
-	const errorSummary = [];
-	(filters || []).forEach((section) => {
-		if (section?.title === 'Date submitted' && Array.isArray(section.dateInputs)) {
-			section.dateInputs.forEach((dateInput) => {
-				const errText = dateInput?.errorMessage?.text;
-				if (errText) {
-					const prefix = formType === 'mobile' ? `${dateInput.idPrefix}-mobile` : dateInput.idPrefix;
-					errorSummary.push({ text: errText, href: `#${prefix}-day` });
-				}
-			});
-		}
-	});
-	return errorSummary;
 }
 
 /**

--- a/apps/portal/src/app/views/applications/view/written-representations/controller.test.js
+++ b/apps/portal/src/app/views/applications/view/written-representations/controller.test.js
@@ -865,6 +865,46 @@ describe('written representations', () => {
 			assert.match(viewData.dateErrors[0].href, /submittedDateFrom-day/, 'error href should point to From day input');
 		});
 
+		it('should build error summary when invalid submitted date to date', async (context) => {
+			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
+
+			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';
+			const mockReq = {
+				params: { applicationId },
+				query: {
+					'submittedDateTo-day': '32',
+					'submittedDateTo-month': '13',
+					'submittedDateTo-year': '20256'
+				},
+				originalUrl: `/applications/${applicationId}/written-representations`
+			};
+			const mockRes = { render: mock.fn(), status: mock.fn() };
+
+			const mockDb = {
+				crownDevelopment: {
+					findUnique: mock.fn(() => ({
+						id: applicationId,
+						reference: 'CROWN/2025/0000001',
+						representationsPeriodStartDate: new Date('2025-01-01'),
+						representationsPeriodEndDate: new Date('2025-02-01'),
+						representationsPublishDate: new Date('2025-03-01'),
+						applicationStatus: 'active'
+					}))
+				},
+				representation: { findMany: mock.fn(() => []), count: mock.fn(() => 0) },
+				applicationUpdate: { findFirst: mock.fn(() => undefined), count: mock.fn(() => 0) }
+			};
+
+			const handler = buildWrittenRepresentationsListPage({ db: mockDb });
+			await handler(mockReq, mockRes);
+
+			const viewData = mockRes.render.mock.calls[0].arguments[1];
+			assert.ok(Array.isArray(viewData.dateErrors));
+			const errorSummary = viewData.dateErrors;
+			assert.strictEqual(errorSummary.length, 1);
+			assert.strictEqual(errorSummary[0].href, '#submittedDateTo-day');
+		});
+
 		it('should not apply submittedDate filter when all From parts are empty', async (context) => {
 			context.mock.timers.enable({ apis: ['Date'], now: new Date('2025-03-15T03:24:00.000Z') });
 			const applicationId = 'cfe3dc29-1f63-45e6-81dd-da8183842bf8';

--- a/apps/portal/src/app/views/applications/view/written-representations/view.njk
+++ b/apps/portal/src/app/views/applications/view/written-representations/view.njk
@@ -11,7 +11,7 @@
 {% from "distressing-content/distressing-content-banner.njk" import distressingContentBanner %}
 
 {% block pageHeading %}{% endblock %}
-
+{% block error_summary %}{% endblock %}
 {% block pageContent %}
 	<div class="govuk-grid-row">
 		<div class="govuk-grid-column-one-third">
@@ -37,6 +37,12 @@
 		</div>
 
 		<div class="govuk-grid-column-two-thirds">
+			{% if errorSummary %}
+				{{ govukErrorSummary({
+					titleText: "There is a problem",
+					errorList: errorSummary
+				}) }}
+			{% endif %}
 			{{ distressingContentBanner(containsDistressingContent) }}
 			<div class="govuk-grid-row">
 				<div class="govuk-grid-column-full">


### PR DESCRIPTION
## Describe your changes

Bug fix on documents page in the portal app where the filters were displaying an inline error in the filter section but not a errorSummary. This ticket fixes the error summary so it now appears at the top when a error occurs

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1689

before
<img width="1182" height="1195" alt="image" src="https://github.com/user-attachments/assets/a0a2ac88-6574-4400-9abe-91dde61a00eb" />

after
<img width="1181" height="1021" alt="image" src="https://github.com/user-attachments/assets/e4565b98-25fb-476e-8a36-9d6d2e9b6aab" />
