### PR TITLE
Feat/peas 242 update s62a header

### DIFF
--- a/apps/manage/src/app/app.js
+++ b/apps/manage/src/app/app.js
@@ -68,6 +68,12 @@ export function getApp(service) {
 		}
 	});
 
+	// S62A header variable, to trigger header on S62A pages
+	app.use((req, res, next) => {
+		res.locals.isS62A = req.path.includes('/s62a/');
+		next();
+	});
+
 	app.use(addLocalsConfiguration(service));
 
 	// Generate the nonce for each request

--- a/apps/manage/src/app/sass/style.scss
+++ b/apps/manage/src/app/sass/style.scss
@@ -10,6 +10,8 @@ $font-family: arial, helvetica, sans-serif;
 @use './header';
 @use './sub-navigation';
 
+@use 'packages/lib/views/header/pins-header.scss';
+
 // set font-family for any autocomplete menu items
 .autocomplete__menu {
 	font-family: $font-family;

--- a/apps/manage/src/app/views/layouts/components/core/banner.njk
+++ b/apps/manage/src/app/views/layouts/components/core/banner.njk
@@ -1,0 +1,8 @@
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{{ govukPhaseBanner({
+  tag: {
+    text: "Beta"
+  },
+  html: 'This is a new service. Help us improve it and <a class="govuk-link" href="' + config.serviceFeedbackUrl + '" target="_blank" rel="noreferrer">give your feedback (opens in new tab)</a>'
+}) }}

--- a/apps/manage/src/app/views/layouts/main.njk
+++ b/apps/manage/src/app/views/layouts/main.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "views/layouts/components/header.njk" import header %}
+{% from "header/pins-header.njk" import pinsHeader %}
 
 {% block head %}
 	{# setup the header tags, to link to the styles #}
@@ -19,7 +20,11 @@
 {% endblock %}
 
 {% block header %}
-	{{ header('Manage a Crown Development Application', '/cases') }}
+	{% if isS62A %}	
+		{{ pinsHeader({ isExternal: false }, config) }}
+	{% else %}
+		{{ header('Manage a Crown Development Application', '/cases') }}
+	{% endif %}
 {% endblock %}
 
 {% block containerStart %}

--- a/apps/manage/src/app/views/s62a/cases/list/view.njk
+++ b/apps/manage/src/app/views/s62a/cases/list/view.njk
@@ -2,16 +2,11 @@
 
 {% import "pagination/pagination.njk" as pagination %}
 {% import "pagination/pagination-options.njk" as paginationOptions %}
-{% from "views/layouts/components/header.njk" import header %}
 {% from "search-bar/search-bar.njk" import searchBar %}
 {% from "tables/tables.njk" import baseCaseListTable, baseManageHeaders, baseManageColumns %}
 
 {% block pageTitle %}
 	Case list - All Cases - Manage a Section 62A Development Application
-{% endblock %}
-
-{% block header %}
-	{{ header('Manage a Section 62A Application', baseUrl ) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/apps/manage/src/util/config-middleware.js
+++ b/apps/manage/src/util/config-middleware.js
@@ -5,9 +5,51 @@
  */
 export function addLocalsConfiguration({ appName }) {
 	return (req, res, next) => {
+		const path = req.path;
+
+		const s62aLinks = [
+			{
+				text: 'Home',
+				href: '/s62a/cases'
+			},
+			{
+				text: 'Create new case',
+				href: '/s62a/cases/create-a-case/pre-application-or-application'
+			},
+			{
+				text: 'Sign out',
+				href: '/s62a/auth/signout'
+			}
+		];
+
+		const crownLinks = [
+			{
+				text: 'All Cases',
+				href: '/crown/cases'
+			},
+			{
+				text: 'Sign out',
+				href: '/auth/signout'
+			}
+		];
+
+		const links = res.locals.isS62A ? s62aLinks : crownLinks;
+
+		const headerTitle = res.locals.isS62A
+			? 'Manage Section 62A applications'
+			: 'Manage a Crown Development Application';
+
 		res.locals.config = {
-			appName
+			appName,
+			headerTitle: headerTitle,
+			isLive: true,
+			inBeta: false,
+			primaryNavigationLinks: links.map((link) => ({
+				...link,
+				current: link.href === path
+			}))
 		};
+
 		next();
 	};
 }

--- a/packages/lib/views/header/pins-header.njk
+++ b/packages/lib/views/header/pins-header.njk
@@ -1,29 +1,29 @@
 {% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 
 {% macro pinsHeader(settings, config) %}
-	<header class="govuk-header pins-header {% if settings.isExternal %}pins-header__external{% endif %}"
+    <header class="govuk-header pins-header {% if settings.isExternal %}pins-header__external{% endif %}"
 					data-module="govuk-header">
-		<div class="govuk-header__container govuk-width-container">
-			{% if settings.isExternal %}
-				<a href="https://www.gov.uk/government/organisations/planning-inspectorate">
-					{% include "./pins-landscape-logo.njk" %}
-				</a>
-			{% else %}
-				{% include "./pins-landscape-logo.njk" %}
-			{% endif %}
-		</div>
-	</header>
-	{% if config.isLive %}
-		{{ govukServiceNavigation({
-			classes: 'pins-navigation',
-			serviceName: config.headerTitle,
-			serviceUrl: config.headerUrl,
-			navigation: config.primaryNavigationLinks
-		}) }}
-
-		<div class="govuk-width-container">
-			{% include "views/layouts/components/core/banner.njk" %}
-		</div>
-
-	{% endif %}
+        <div class="govuk-header__container govuk-width-container">
+            {% if settings.isExternal %}
+                <a href="https://www.gov.uk/government/organisations/planning-inspectorate">
+                    {% include "./pins-landscape-logo.njk" %}
+                </a>
+            {% else %}
+                {% include "./pins-landscape-logo.njk" %}
+            {% endif %}
+        </div>
+    </header>
+    {% if config.isLive %}
+        {{ govukServiceNavigation({
+            classes: 'pins-navigation',
+            serviceName: config.headerTitle,
+            serviceUrl: config.headerUrl,
+            navigation: config.primaryNavigationLinks
+        }) }}
+    {% endif %}
+    {% if config.isBeta %}
+        <div class="govuk-width-container">
+            {% include "views/layouts/components/core/banner.njk" %}
+        </div>
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Describe your changes
Update the Section 62A service header so it matches the current prototype

- Change only applies to pages under the /s62a route- Crown Development pages outside that path keep their existing header and are not affected. 
- Header on S62A pages are renamed from Manage a Crown Development Application to Manage Section 62A applications. - The layout, banding and navigation should also be brought in line with the prototype. 

Depends on PEAS-111 (Back office case list)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PEAS-242