### PR TITLE
Feat/crown 1635 audit logging for static data lookup

### DIFF
--- a/apps/manage/src/app/audit/resolvers/field-resolver.test.ts
+++ b/apps/manage/src/app/audit/resolvers/field-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
+import { resolveFieldValues } from './field-resolver.ts';
 
 describe('Field Resolver', () => {
 	// Set environment before importing modules that depend on it
@@ -22,91 +23,195 @@ describe('Field Resolver', () => {
 	});
 
 	describe('resolveFieldValues', () => {
-		it('should resolve simple scalar field values', async () => {
-			const { resolveFieldValues } = await import('./field-resolver.ts');
-			const previousCase = { siteArea: 10.5 };
-			const newAnswer = 15.0;
+		describe('simple scalar values', () => {
+			it('should resolve simple scalar field values', async () => {
+				const previousCase = { siteArea: 10.5 };
+				const newAnswer = 15.0;
 
-			const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
+				const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
 
-			assert.strictEqual(oldValue, '10.5');
-			assert.strictEqual(newValue, '15');
+				assert.strictEqual(oldValue, '10.5');
+				assert.strictEqual(newValue, '15');
+			});
+
+			it('should return "-" for null previous value', async () => {
+				const previousCase = { siteArea: null };
+				const newAnswer = 12.5;
+
+				const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '-');
+				assert.strictEqual(newValue, '12.5');
+			});
+
+			it('should return "-" for null new value', async () => {
+				const previousCase = { siteArea: 10.5 };
+				const newAnswer = null;
+
+				const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '10.5');
+				assert.strictEqual(newValue, '-');
+			});
+
+			it('should return "-" for undefined previous value', async () => {
+				const previousCase = {};
+				const newAnswer = 'New Value';
+
+				const { oldValue, newValue } = resolveFieldValues('lpaReference', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '-');
+				assert.strictEqual(newValue, 'New Value');
+			});
+
+			it('should handle string values', async () => {
+				const previousCase = { lpaReference: 'ABC/123' };
+				const newAnswer = 'XYZ/456';
+
+				const { oldValue, newValue } = resolveFieldValues('lpaReference', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, 'ABC/123');
+				assert.strictEqual(newValue, 'XYZ/456');
+			});
 		});
 
-		it('should return "-" for null previous value', async () => {
-			const { resolveFieldValues } = await import('./field-resolver.ts');
-			const previousCase = { siteArea: null };
-			const newAnswer = 12.5;
+		describe('composite values', () => {
+			it('should use siteAddress resolver for address fields', async () => {
+				const previousCase = {
+					SiteAddress: {
+						line1: '123 Old Street',
+						townCity: 'London',
+						postcode: 'SW1A 1AA'
+					}
+				};
+				const newAnswer = {
+					addressLine1: '456 New Road',
+					townCity: 'Manchester',
+					postcode: 'M1 1AA'
+				};
 
-			const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
+				const { oldValue, newValue } = resolveFieldValues('siteAddress', previousCase, newAnswer);
 
-			assert.strictEqual(oldValue, '-');
-			assert.strictEqual(newValue, '12.5');
+				assert.strictEqual(oldValue, '123 Old Street, London, SW1A 1AA');
+				assert.strictEqual(newValue, '456 New Road, Manchester, M1 1AA');
+			});
+
+			it('should return "-" for null address', async () => {
+				const previousCase = { SiteAddress: null };
+				const newAnswer = null;
+
+				const { oldValue, newValue } = resolveFieldValues('siteAddress', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '-');
+				assert.strictEqual(newValue, '-');
+			});
 		});
 
-		it('should return "-" for null new value', async () => {
-			const { resolveFieldValues } = await import('./field-resolver.ts');
-			const previousCase = { siteArea: 10.5 };
-			const newAnswer = null;
+		describe('ID field resolvers', () => {
+			it('should resolve typeId to application type display names', async () => {
+				const previousCase = { typeId: 'planning-permission' };
+				const newAnswer = 'outline-planning-permission-some-reserved';
 
-			const { oldValue, newValue } = resolveFieldValues('siteArea', previousCase, newAnswer);
+				const { oldValue, newValue } = resolveFieldValues('typeId', previousCase, newAnswer);
 
-			assert.strictEqual(oldValue, '10.5');
-			assert.strictEqual(newValue, '-');
-		});
+				assert.strictEqual(oldValue, 'Planning permission');
+				assert.strictEqual(newValue, 'Outline planning permission with some matters reserved');
+			});
 
-		it('should return "-" for undefined previous value', async () => {
-			const { resolveFieldValues } = await import('./field-resolver.ts');
-			const previousCase = {};
-			const newAnswer = 'New Value';
+			it('should resolve statusId to application status display names', async () => {
+				const previousCase = { statusId: 'new' };
+				const newAnswer = 'acceptance';
 
-			const { oldValue, newValue } = resolveFieldValues('lpaReference', previousCase, newAnswer);
+				const { oldValue, newValue } = resolveFieldValues('statusId', previousCase, newAnswer);
 
-			assert.strictEqual(oldValue, '-');
-			assert.strictEqual(newValue, 'New Value');
-		});
+				assert.strictEqual(oldValue, 'New');
+				assert.strictEqual(newValue, 'Accepted');
+			});
 
-		it('should handle string values', async () => {
-			const { resolveFieldValues } = await import('./field-resolver.ts');
-			const previousCase = { lpaReference: 'ABC/123' };
-			const newAnswer = 'XYZ/456';
+			it('should resolve stageId to application stage display names', async () => {
+				const previousCase = { stageId: 'acceptance' };
+				const newAnswer = 'consultation';
 
-			const { oldValue, newValue } = resolveFieldValues('lpaReference', previousCase, newAnswer);
+				const { oldValue, newValue } = resolveFieldValues('stageId', previousCase, newAnswer);
 
-			assert.strictEqual(oldValue, 'ABC/123');
-			assert.strictEqual(newValue, 'XYZ/456');
-		});
+				assert.strictEqual(oldValue, 'Accepted');
+				assert.strictEqual(newValue, 'Consultation');
+			});
 
-		it('should use siteAddress resolver for address fields', async () => {
-			const { resolveFieldValues } = await import('./field-resolver.ts');
-			const previousCase = {
-				SiteAddress: {
-					line1: '123 Old Street',
-					townCity: 'London',
-					postcode: 'SW1A 1AA'
-				}
-			};
-			const newAnswer = {
-				addressLine1: '456 New Road',
-				townCity: 'Manchester',
-				postcode: 'M1 1AA'
-			};
+			it('should resolve procedureId to procedure display names', async () => {
+				const previousCase = { procedureId: 'written-reps' };
+				const newAnswer = 'inquiry';
 
-			const { oldValue, newValue } = resolveFieldValues('siteAddress', previousCase, newAnswer);
+				const { oldValue, newValue } = resolveFieldValues('procedureId', previousCase, newAnswer);
 
-			assert.strictEqual(oldValue, '123 Old Street, London, SW1A 1AA');
-			assert.strictEqual(newValue, '456 New Road, Manchester, M1 1AA');
-		});
+				assert.strictEqual(oldValue, 'Written representations');
+				assert.strictEqual(newValue, 'Inquiry');
+			});
 
-		it('should return "-" for null address', async () => {
-			const { resolveFieldValues } = await import('./field-resolver.ts');
-			const previousCase = { SiteAddress: null };
-			const newAnswer = null;
+			it('should resolve decisionOutcomeId to decision outcome display names', async () => {
+				const previousCase = { decisionOutcomeId: null };
+				const newAnswer = 'approved';
 
-			const { oldValue, newValue } = resolveFieldValues('siteAddress', previousCase, newAnswer);
+				const { oldValue, newValue } = resolveFieldValues('decisionOutcomeId', previousCase, newAnswer);
 
-			assert.strictEqual(oldValue, '-');
-			assert.strictEqual(newValue, '-');
+				assert.strictEqual(oldValue, '-');
+				assert.strictEqual(newValue, 'Approved');
+			});
+
+			it('should resolve subCategoryId to category display names', async () => {
+				const previousCase = { subCategoryId: 'major-minerals' };
+				const newAnswer = 'non-major-buildings-under-1000-sqm';
+
+				const { oldValue, newValue } = resolveFieldValues('subCategoryId', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, 'Major Development > Minerals');
+				assert.strictEqual(newValue, 'Non-Major Development > Buildings less than 1000 square metres');
+			});
+
+			it('should display "[Unknown value]" for unknown reference values', async () => {
+				const previousCase = { typeId: 'unknown-type-id' };
+				const newAnswer = 'another-unknown-type';
+
+				const { oldValue, newValue } = resolveFieldValues('typeId', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '[Unknown value]');
+				assert.strictEqual(newValue, '[Unknown value]');
+			});
+
+			it('should resolve lpaId using static LPA data lookup', async () => {
+				// Both old and new values are looked up from static LPA data using the ID
+				const previousCase = {
+					lpaId: '4515ebac-65e2-4bcd-bc0b-a6fee69ae25a' // System Test Borough Council
+				};
+				const newAnswer = '1a76f67e-5828-4532-bd6f-aa7ef40a13ca'; // Another System Test Borough Council
+
+				const { oldValue, newValue } = resolveFieldValues('lpaId', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, 'System Test Borough Council');
+				assert.strictEqual(newValue, 'Another System Test Borough Council');
+			});
+
+			it('should return "-" for null lpaId values', async () => {
+				const previousCase = { lpaId: null };
+				const newAnswer = null;
+
+				const { oldValue, newValue } = resolveFieldValues('lpaId', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '-');
+				assert.strictEqual(newValue, '-');
+			});
+
+			it('should resolve secondaryLpaId using static LPA data lookup', async () => {
+				const previousCase = {
+					secondaryLpaId: '4515ebac-65e2-4bcd-bc0b-a6fee69ae25a' // System Test Borough Council
+				};
+				const newAnswer = null; // Removing secondary LPA
+
+				const { oldValue, newValue } = resolveFieldValues('secondaryLpaId', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, 'System Test Borough Council');
+				assert.strictEqual(newValue, '-');
+			});
 		});
 	});
 });

--- a/apps/manage/src/app/audit/resolvers/field-resolver.ts
+++ b/apps/manage/src/app/audit/resolvers/field-resolver.ts
@@ -1,10 +1,89 @@
 import { formatAddress, formatValue } from '@pins/crowndev-lib/util/audit-formatters.ts';
 import { camelCaseToSentenceCase } from '@pins/crowndev-lib/util/string.ts';
 import { FIELD_DISPLAY_NAMES } from '../../views/cases/view/questions.js';
+import {
+	APPLICATION_TYPES,
+	APPLICATION_STATUS,
+	APPLICATION_STAGE,
+	APPLICATION_PROCEDURE,
+	APPLICATION_DECISION_OUTCOME,
+	CATEGORIES
+} from '@pins/crowndev-database/src/seed/data-static.ts';
+import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_DEV } from '@pins/crowndev-database/src/seed/data-lpa-dev.ts';
+import { LOCAL_PLANNING_AUTHORITIES as LOCAL_PLANNING_AUTHORITIES_PROD } from '@pins/crowndev-database/src/seed/data-lpa-prod.ts';
+import { loadEnvironmentConfig, ENVIRONMENT_NAME } from '../../config.js';
 
 interface ResolverContext {
 	userDisplayNameMap?: Map<string, string>;
 }
+
+/**
+ * Creates a lookup map from id to displayName for reference data arrays.
+ */
+function createDisplayNameMap(
+	items: ReadonlyArray<{ readonly id: string; readonly displayName: string }>
+): Map<string, string> {
+	return new Map(items.map((item) => [item.id, item.displayName]));
+}
+
+/**
+ * Category type with optional parent connection (matches Prisma seed data structure).
+ */
+interface CategoryWithParent {
+	readonly id: string;
+	readonly displayName: string;
+	readonly ParentCategory?: { readonly connect?: { readonly id?: string } };
+}
+
+/**
+ * Creates a lookup map from category id to hierarchical display name.
+ * For child categories, formats as "Parent name > Child name".
+ * For parent categories, returns just the display name.
+ */
+function createCategoryDisplayNameMap(categories: ReadonlyArray<CategoryWithParent>): Map<string, string> {
+	// First, build a simple id → displayName map for parent lookups
+	const simpleMap = new Map(categories.map((cat) => [cat.id, cat.displayName]));
+
+	// Then build the hierarchical map
+	return new Map(
+		categories.map((category) => {
+			const parentId = category.ParentCategory?.connect?.id;
+			if (parentId) {
+				const parentName = simpleMap.get(parentId) ?? '-';
+				return [category.id, `${parentName} > ${category.displayName}`];
+			}
+			return [category.id, category.displayName];
+		})
+	);
+}
+
+/**
+ * Creates a lookup map from id to name for LPA data.
+ * Handles both dev and prod environments.
+ */
+function createLpaDisplayNameMap(): Map<string, string> {
+	let lpas;
+	try {
+		const env = loadEnvironmentConfig();
+		lpas = env === ENVIRONMENT_NAME.PROD ? LOCAL_PLANNING_AUTHORITIES_PROD : LOCAL_PLANNING_AUTHORITIES_DEV;
+	} catch {
+		lpas = LOCAL_PLANNING_AUTHORITIES_DEV;
+	}
+	return new Map(
+		lpas
+			.filter((lpa): lpa is typeof lpa & { id: string; name: string } => Boolean(lpa.id && lpa.name))
+			.map((lpa) => [lpa.id, lpa.name])
+	);
+}
+
+// Lookup maps for reference data
+const APPLICATION_TYPE_DISPLAY_NAMES = createDisplayNameMap(APPLICATION_TYPES);
+const APPLICATION_STATUS_DISPLAY_NAMES = createDisplayNameMap(APPLICATION_STATUS);
+const APPLICATION_STAGE_DISPLAY_NAMES = createDisplayNameMap(APPLICATION_STAGE);
+const APPLICATION_PROCEDURE_DISPLAY_NAMES = createDisplayNameMap(APPLICATION_PROCEDURE);
+const APPLICATION_DECISION_OUTCOME_DISPLAY_NAMES = createDisplayNameMap(APPLICATION_DECISION_OUTCOME);
+const CATEGORY_DISPLAY_NAMES = createCategoryDisplayNameMap(CATEGORIES);
+const LPA_DISPLAY_NAMES = createLpaDisplayNameMap();
 
 /**
  * Returns a human-readable display name for a field.
@@ -42,6 +121,24 @@ function defaultResolver(fieldName: string): FieldResolver {
 }
 
 /**
+ * Creates a resolver for ID fields that map to display names via a lookup table.
+ * Falls back to '[Unknown value]' if no display name is found.
+ */
+function createLookupResolver(fieldName: string, displayNameMap: Map<string, string>): FieldResolver {
+	return {
+		resolve(previousCase, newAnswer) {
+			const oldId = previousCase[fieldName] as string | null | undefined;
+			const newId = newAnswer as string | null | undefined;
+
+			const oldValue = oldId ? (displayNameMap.get(oldId) ?? '[Unknown value]') : '-';
+			const newValue = newId ? (displayNameMap.get(newId) ?? '[Unknown value]') : '-';
+
+			return { oldValue, newValue };
+		}
+	};
+}
+
+/**
  * Registry of field-specific resolvers.
  *
  * Add an entry here whenever a field needs special handling — e.g. the
@@ -66,7 +163,34 @@ const FIELD_RESOLVERS: Record<string, FieldResolver> = {
 				newValue: formatAddress(newAddress)
 			};
 		}
-	}
+	},
+
+	// ── Reference table ID fields ────────────────────────────────────────
+	// These fields store IDs that map to display names in static reference data.
+
+	/** Application type (e.g. 'planning-permission' → 'Planning permission') */
+	typeId: createLookupResolver('typeId', APPLICATION_TYPE_DISPLAY_NAMES),
+
+	/** Application status (e.g. 'new' → 'New') */
+	statusId: createLookupResolver('statusId', APPLICATION_STATUS_DISPLAY_NAMES),
+
+	/** Application stage (e.g. 'acceptance' → 'Accepted') */
+	stageId: createLookupResolver('stageId', APPLICATION_STAGE_DISPLAY_NAMES),
+
+	/** Procedure type (e.g. 'inquiry' → 'Inquiry') */
+	procedureId: createLookupResolver('procedureId', APPLICATION_PROCEDURE_DISPLAY_NAMES),
+
+	/** Decision outcome (e.g. 'approved' → 'Approved') */
+	decisionOutcomeId: createLookupResolver('decisionOutcomeId', APPLICATION_DECISION_OUTCOME_DISPLAY_NAMES),
+
+	/** Category/sub-category (e.g. 'major-minerals' → 'Major Development > Minerals') */
+	subCategoryId: createLookupResolver('subCategoryId', CATEGORY_DISPLAY_NAMES),
+
+	/** Local planning authority */
+	lpaId: createLookupResolver('lpaId', LPA_DISPLAY_NAMES),
+
+	/** Secondary local planning authority */
+	secondaryLpaId: createLookupResolver('secondaryLpaId', LPA_DISPLAY_NAMES)
 };
 
 /**

--- a/apps/manage/src/app/views/cases/view/update-case.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.ts
@@ -71,11 +71,22 @@ function isClearableSaveKey(key: keyof CrownDevelopmentSaveModel): key is CrownD
  * Only these fields will produce audit entries in recordAuditEntries.
  */
 const AUDITABLE_SCALAR_FIELDS = new Set([
+	// Directly editable scalar fields
 	'siteArea',
 	'lpaReference',
 	'agentOrganisationName',
 	'hearingVenue',
-	'inquiryVenue'
+	'inquiryVenue',
+
+	// Reference table fields (IDs that map to display names)
+	'typeId',
+	'lpaId',
+	'secondaryLpaId',
+	'decisionOutcomeId',
+	'subCategoryId',
+	'procedureId',
+	'statusId',
+	'stageId'
 ]);
 
 type ErrorWithSummary = Error & { errorSummary: ErrorSummaryItem[] };

--- a/packages/database/src/seed/data-static.ts
+++ b/packages/database/src/seed/data-static.ts
@@ -8,7 +8,7 @@ import {
 	SPECIALISMS
 } from './s62a/data-static.ts';
 
-export const APPLICATION_DECISION_OUTCOME: Prisma.ApplicationDecisionOutcomeCreateInput[] = [
+export const APPLICATION_DECISION_OUTCOME = [
 	{
 		id: 'approved',
 		displayName: 'Approved'
@@ -25,7 +25,7 @@ export const APPLICATION_DECISION_OUTCOME: Prisma.ApplicationDecisionOutcomeCrea
 		id: 'withdrawn',
 		displayName: 'Withdrawn'
 	}
-];
+] as const satisfies readonly Prisma.ApplicationDecisionOutcomeCreateInput[];
 
 export const APPLICATION_TYPE_ID = Object.freeze({
 	PLANNING_PERMISSION: 'planning-permission',
@@ -35,7 +35,7 @@ export const APPLICATION_TYPE_ID = Object.freeze({
 	PLANNING_AND_LISTED_BUILDING_CONSENT: 'planning-permission-and-listed-building-consent'
 } as const);
 
-export const APPLICATION_TYPES: Prisma.ApplicationTypeCreateInput[] = [
+export const APPLICATION_TYPES = [
 	{
 		id: APPLICATION_TYPE_ID.PLANNING_PERMISSION,
 		displayName: 'Planning permission'
@@ -57,14 +57,14 @@ export const APPLICATION_TYPES: Prisma.ApplicationTypeCreateInput[] = [
 		displayName:
 			'Planning permission and listed building consent (LBC) for alterations, extension or demolition of a listed building'
 	}
-];
+] as const satisfies readonly Prisma.ApplicationTypeCreateInput[];
 
 export const APPLICATION_SUB_TYPE_ID = Object.freeze({
 	PLANNING_PERMISSION: 'planning-permission',
 	LISTED_BUILDING_CONSENT: 'listed-building-consent'
 } as const);
 
-export const APPLICATION_SUB_TYPES: Prisma.ApplicationSubTypeCreateInput[] = [
+export const APPLICATION_SUB_TYPES = [
 	{
 		id: APPLICATION_SUB_TYPE_ID.PLANNING_PERMISSION,
 		displayName: 'Planning permission'
@@ -73,13 +73,13 @@ export const APPLICATION_SUB_TYPES: Prisma.ApplicationSubTypeCreateInput[] = [
 		id: APPLICATION_SUB_TYPE_ID.LISTED_BUILDING_CONSENT,
 		displayName: 'Listed building consent (LBC)'
 	}
-];
+] as const satisfies readonly Prisma.ApplicationSubTypeCreateInput[];
 export const ORGANISATION_ROLES_ID = Object.freeze({
 	APPLICANT: 'applicant',
 	AGENT: 'agent'
 } as const);
 
-export const ORGANISATION_ROLES: Prisma.CrownDevelopmentToOrganisationRoleCreateInput[] = [
+export const ORGANISATION_ROLES = [
 	{
 		id: ORGANISATION_ROLES_ID.APPLICANT,
 		displayName: 'Applicant'
@@ -88,7 +88,7 @@ export const ORGANISATION_ROLES: Prisma.CrownDevelopmentToOrganisationRoleCreate
 		id: ORGANISATION_ROLES_ID.AGENT,
 		displayName: 'Agent'
 	}
-];
+] as const satisfies readonly Prisma.CrownDevelopmentToOrganisationRoleCreateInput[];
 
 export const APPLICATION_STATUS_ID = Object.freeze({
 	NEW: 'new',
@@ -107,7 +107,7 @@ export const APPLICATION_STATUS_ID = Object.freeze({
 	CLOSED_OPEN_IN_ERROR: 'closed-open-in-error'
 } as const);
 
-export const APPLICATION_STATUS: Prisma.ApplicationStatusCreateInput[] = [
+export const APPLICATION_STATUS = [
 	{
 		id: APPLICATION_STATUS_ID.NEW,
 		displayName: 'New'
@@ -165,7 +165,7 @@ export const APPLICATION_STATUS: Prisma.ApplicationStatusCreateInput[] = [
 		id: APPLICATION_STATUS_ID.CLOSED_OPEN_IN_ERROR,
 		displayName: 'Closed - opened in error'
 	}
-];
+] as const satisfies readonly Prisma.ApplicationStatusCreateInput[];
 
 export const APPLICATION_STAGE_ID = Object.freeze({
 	ACCEPTANCE: 'acceptance',
@@ -177,7 +177,7 @@ export const APPLICATION_STAGE_ID = Object.freeze({
 	DECISION: 'decision'
 } as const);
 
-export const APPLICATION_STAGE: Prisma.ApplicationStageCreateInput[] = [
+export const APPLICATION_STAGE = [
 	{
 		id: APPLICATION_STAGE_ID.ACCEPTANCE,
 		// called complete to match the terminology in the draft order
@@ -207,7 +207,7 @@ export const APPLICATION_STAGE: Prisma.ApplicationStageCreateInput[] = [
 		id: APPLICATION_STAGE_ID.DECISION,
 		displayName: 'Final decision'
 	}
-];
+] as const satisfies readonly Prisma.ApplicationStageCreateInput[];
 
 export const APPLICATION_PROCEDURE_ID = Object.freeze({
 	WRITTEN_REPS: 'written-reps',
@@ -215,7 +215,7 @@ export const APPLICATION_PROCEDURE_ID = Object.freeze({
 	INQUIRY: 'inquiry'
 } as const);
 
-export const APPLICATION_PROCEDURE: Prisma.ApplicationProcedureCreateInput[] = [
+export const APPLICATION_PROCEDURE = [
 	{
 		id: APPLICATION_PROCEDURE_ID.WRITTEN_REPS,
 		displayName: 'Written representations'
@@ -228,7 +228,7 @@ export const APPLICATION_PROCEDURE: Prisma.ApplicationProcedureCreateInput[] = [
 		id: APPLICATION_PROCEDURE_ID.INQUIRY,
 		displayName: 'Inquiry'
 	}
-];
+] as const satisfies readonly Prisma.ApplicationProcedureCreateInput[];
 
 export const APPLICATION_UPDATE_STATUS_ID = Object.freeze({
 	DRAFT: 'draft',
@@ -236,7 +236,7 @@ export const APPLICATION_UPDATE_STATUS_ID = Object.freeze({
 	UNPUBLISHED: 'unpublished'
 } as const);
 
-export const APPLICATION_UPDATE_STATUS: Prisma.ApplicationUpdateStatusCreateInput[] = [
+export const APPLICATION_UPDATE_STATUS = [
 	{
 		id: APPLICATION_UPDATE_STATUS_ID.DRAFT,
 		displayName: 'Draft'
@@ -249,7 +249,7 @@ export const APPLICATION_UPDATE_STATUS: Prisma.ApplicationUpdateStatusCreateInpu
 		id: APPLICATION_UPDATE_STATUS_ID.UNPUBLISHED,
 		displayName: 'Unpublished'
 	}
-];
+] as const satisfies readonly Prisma.ApplicationUpdateStatusCreateInput[];
 
 export const NOTIFY_STATUS_ID = Object.freeze({
 	SENDING: 'sending',
@@ -259,7 +259,7 @@ export const NOTIFY_STATUS_ID = Object.freeze({
 	TECHNICAL_FAILURE: 'technical-failure'
 } as const);
 
-export const NOTIFY_STATUS: Prisma.NotifyStatusCreateInput[] = [
+export const NOTIFY_STATUS = [
 	{
 		id: NOTIFY_STATUS_ID.SENDING,
 		displayName: 'Sending'
@@ -280,7 +280,7 @@ export const NOTIFY_STATUS: Prisma.NotifyStatusCreateInput[] = [
 		id: NOTIFY_STATUS_ID.TECHNICAL_FAILURE,
 		displayName: 'Technical failure'
 	}
-];
+] as const satisfies readonly Prisma.NotifyStatusCreateInput[];
 
 export const NOTIFICATION_SOURCE = Object.freeze({
 	REPRESENTATION: 'representation',
@@ -295,20 +295,20 @@ export const RECEIVED_METHOD_ID = Object.freeze({
 	IN_PERSON: 'in-person'
 } as const);
 
-export const RECEIVED_METHOD: Prisma.RepresentationReceivedMethodCreateInput[] = [
+export const RECEIVED_METHOD = [
 	{ id: RECEIVED_METHOD_ID.ONLINE, displayName: 'Online' },
 	{ id: RECEIVED_METHOD_ID.PHONE, displayName: 'Phone' },
 	{ id: RECEIVED_METHOD_ID.EMAIL, displayName: 'Email' },
 	{ id: RECEIVED_METHOD_ID.POST, displayName: 'Post' },
 	{ id: RECEIVED_METHOD_ID.IN_PERSON, displayName: 'In person' }
-];
+] as const satisfies readonly Prisma.RepresentationReceivedMethodCreateInput[];
 
 export const REPRESENTATION_CATEGORY_ID = Object.freeze({
 	CONSULTEES: 'consultees',
 	INTERESTED_PARTIES: 'interested-parties'
 } as const);
 
-export const REPRESENTATION_CATEGORY: Prisma.RepresentationCategoryCreateInput[] = [
+export const REPRESENTATION_CATEGORY = [
 	{
 		id: 'consultees',
 		displayName: 'Consultees'
@@ -317,14 +317,14 @@ export const REPRESENTATION_CATEGORY: Prisma.RepresentationCategoryCreateInput[]
 		id: 'interested-parties',
 		displayName: 'Interested party'
 	}
-];
+] as const satisfies readonly Prisma.RepresentationCategoryCreateInput[];
 
 export const CONTACT_PREFERENCE_ID = Object.freeze({
 	EMAIL: 'email',
 	POST: 'post'
 } as const);
 
-export const CONTACT_PREFERENCE: Prisma.ContactPreferenceCreateInput[] = [
+export const CONTACT_PREFERENCE = [
 	{
 		id: CONTACT_PREFERENCE_ID.EMAIL,
 		displayName: 'Email'
@@ -333,14 +333,14 @@ export const CONTACT_PREFERENCE: Prisma.ContactPreferenceCreateInput[] = [
 		id: CONTACT_PREFERENCE_ID.POST,
 		displayName: 'Post'
 	}
-];
+] as const satisfies readonly Prisma.ContactPreferenceCreateInput[];
 
 export const REPRESENTATION_SUBMITTED_FOR_ID = Object.freeze({
 	MYSELF: 'myself',
 	ON_BEHALF_OF: 'on-behalf-of'
 } as const);
 
-export const REPRESENTATION_SUBMITTED_FOR: Prisma.RepresentationSubmittedForCreateInput[] = [
+export const REPRESENTATION_SUBMITTED_FOR = [
 	{
 		id: REPRESENTATION_SUBMITTED_FOR_ID.MYSELF,
 		displayName: 'Myself'
@@ -349,7 +349,7 @@ export const REPRESENTATION_SUBMITTED_FOR: Prisma.RepresentationSubmittedForCrea
 		id: REPRESENTATION_SUBMITTED_FOR_ID.ON_BEHALF_OF,
 		displayName: 'On behalf of another person or an organisation'
 	}
-];
+] as const satisfies readonly Prisma.RepresentationSubmittedForCreateInput[];
 
 export const REPRESENTATION_STATUS_ID = Object.freeze({
 	AWAITING_REVIEW: 'awaiting-review',
@@ -358,7 +358,7 @@ export const REPRESENTATION_STATUS_ID = Object.freeze({
 	WITHDRAWN: 'withdrawn'
 } as const);
 
-export const REPRESENTATION_STATUS: Prisma.RepresentationStatusCreateInput[] = [
+export const REPRESENTATION_STATUS = [
 	{
 		id: REPRESENTATION_STATUS_ID.AWAITING_REVIEW,
 		displayName: 'Awaiting review'
@@ -375,7 +375,7 @@ export const REPRESENTATION_STATUS: Prisma.RepresentationStatusCreateInput[] = [
 		id: REPRESENTATION_STATUS_ID.WITHDRAWN,
 		displayName: 'Withdrawn'
 	}
-];
+] as const satisfies readonly Prisma.RepresentationStatusCreateInput[];
 
 export const REPRESENTED_TYPE_ID = Object.freeze({
 	PERSON: 'person',
@@ -383,7 +383,7 @@ export const REPRESENTED_TYPE_ID = Object.freeze({
 	ORG_NOT_WORK_FOR: 'household'
 } as const);
 
-export const REPRESENTED_TYPE: Prisma.RepresentedTypeCreateInput[] = [
+export const REPRESENTED_TYPE = [
 	{
 		id: REPRESENTED_TYPE_ID.PERSON,
 		displayName: 'A person'
@@ -396,7 +396,7 @@ export const REPRESENTED_TYPE: Prisma.RepresentedTypeCreateInput[] = [
 		id: REPRESENTED_TYPE_ID.ORG_NOT_WORK_FOR,
 		displayName: 'An organisation or charity I do not work or volunteer for'
 	}
-];
+] as const satisfies readonly Prisma.RepresentedTypeCreateInput[];
 
 export const WITHDRAWAL_REASON_ID = Object.freeze({
 	CHANGE_OF_OPINION: 'change-of-opinion',
@@ -405,7 +405,7 @@ export const WITHDRAWAL_REASON_ID = Object.freeze({
 	PERSONAL_REASONS: 'personal-reasons'
 } as const);
 
-export const WITHDRAWAL_REASON: Prisma.WithdrawalReasonCreateInput[] = [
+export const WITHDRAWAL_REASON = [
 	{
 		id: WITHDRAWAL_REASON_ID.CHANGE_OF_OPINION,
 		displayName: 'Change of opinion',
@@ -426,7 +426,7 @@ export const WITHDRAWAL_REASON: Prisma.WithdrawalReasonCreateInput[] = [
 		displayName: 'Personal Reasons',
 		hintText: 'Such as privacy or a change in circumstances'
 	}
-];
+] as const satisfies readonly Prisma.WithdrawalReasonCreateInput[];
 
 // this only works if the main categories are created first
 const majorParentConnection: NonNullable<Prisma.CategoryCreateInput['ParentCategory']> = {
@@ -436,7 +436,7 @@ const nonMajorParentConnection: NonNullable<Prisma.CategoryCreateInput['ParentCa
 	connect: { id: 'non-major' }
 };
 
-export const CATEGORIES: Prisma.CategoryCreateInput[] = [
+export const CATEGORIES = [
 	{
 		id: 'major',
 		displayName: 'Major Development'
@@ -527,7 +527,7 @@ export const CATEGORIES: Prisma.CategoryCreateInput[] = [
 		displayName: 'Listed building consent to demolish',
 		ParentCategory: nonMajorParentConnection
 	}
-];
+] as const satisfies readonly Prisma.CategoryCreateInput[];
 
 type UpsertReferenceDataArgs =
 	| {
@@ -709,8 +709,8 @@ export async function seedCrownStaticData(dbClient: PrismaClient) {
 		)
 	);
 
-	const categories = CATEGORIES.filter((c) => !c.ParentCategory);
-	const subCategories = CATEGORIES.filter((c) => c.ParentCategory);
+	const categories = CATEGORIES.filter((c) => !('ParentCategory' in c));
+	const subCategories = CATEGORIES.filter((c) => 'ParentCategory' in c);
 	// order is important here - parent categories first
 	await Promise.all(categories.map((input) => upsertReferenceData({ delegate: dbClient.category, input })));
 	await Promise.all(subCategories.map((input) => upsertReferenceData({ delegate: dbClient.category, input })));


### PR DESCRIPTION
## Describe your changes
Add audit logging for fields that reference static data, including environment-dependent LPAs.
Also includes update to narrow static data types to `const satisfies readonly...` so they are easier to work with.


## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1635
<img width="1023" height="621" alt="Screenshot 2026-07-22 113406" src="https://github.com/user-attachments/assets/3f8123fa-1578-4554-964b-8dc43094b2ff" />
