### PR TITLE
fix(manage): peas 371 s62a case list fixes to search order with case urls and sort

### DIFF
--- a/apps/manage/src/app/views/s62a/cases/list/controller.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.test.ts
@@ -190,8 +190,8 @@ describe('case list', () => {
 			assert.deepStrictEqual(mockResData.render.mock.calls[0].arguments[1], {
 				pageTitle: 'Manage Section 62A applications',
 				s62aCasesViewModels: [],
+				searchValue: '',
 				baseUrl: '/s62a/cases',
-				containerClasses: 'pins-container-wide',
 				currentUrl: undefined,
 				queryParams: undefined,
 				paginationParams: {
@@ -274,8 +274,8 @@ describe('case list', () => {
 				assert.deepStrictEqual(onlyRelevantKeys, {
 					pageTitle: 'Manage Section 62A applications',
 					baseUrl: '/s62a/cases',
+					searchValue: '',
 					currentUrl: undefined,
-					containerClasses: 'pins-container-wide',
 					queryParams: {
 						itemsPerPage: itemsPerPage,
 						page: requestedPage

--- a/apps/manage/src/app/views/s62a/cases/list/controller.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.ts
@@ -52,10 +52,10 @@ export function buildCaseListPage(service: ManageService): AsyncRequestHandler {
 		return res.render('./views/s62a/cases/list/view.njk', {
 			pageTitle: 'Manage Section 62A applications',
 			s62aCasesViewModels,
-			containerClasses: 'pins-container-wide',
 			currentUrl: req.originalUrl,
 			paginationParams,
 			baseUrl: '/s62a/cases',
+			searchValue: req.query?.searchCriteria || '',
 			queryParams: req.query && Object.keys(req.query).length > 0 ? req.query : undefined
 		});
 	};

--- a/apps/manage/src/app/views/s62a/cases/list/view-model.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/view-model.test.ts
@@ -82,7 +82,7 @@ describe('Case list view model', () => {
 			assert.deepStrictEqual(result, {
 				id: 'id-1',
 				reference: 'REF/2025/001',
-				referenceLink: '<a class="govuk-link" href="/cases/id-1">REF/<wbr>2025/<wbr>001</a>',
+				referenceLink: '<a class="govuk-link" href="/s62a/cases/id-1">REF/<wbr>2025/<wbr>001</a>',
 				lpaName: 'Test LPA',
 				status: undefined,
 				type: 'Planning permission',

--- a/apps/manage/src/app/views/s62a/cases/list/view-model.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/view-model.ts
@@ -47,7 +47,8 @@ export function s62aToViewModel(s62aCases: S62ACasePayload) {
 					relation.roleId === ORGANISATION_ROLES_ID.APPLICANT && typeof relation.Organisation?.name === 'string'
 			).map((item) => item.Organisation!.name) ?? [],
 		location: '',
-		referenceLink: '<a class="govuk-link" href="/cases/' + s62aCases.id + '">' + insertWbr(s62aCases.reference) + '</a>'
+		referenceLink:
+			'<a class="govuk-link" href="/s62a/cases/' + s62aCases.id + '">' + insertWbr(s62aCases.reference) + '</a>'
 	};
 	if (s62aCases.SiteAddress) {
 		const address = addressToViewModel(s62aCases.SiteAddress);

--- a/apps/manage/src/app/views/s62a/cases/list/view.njk
+++ b/apps/manage/src/app/views/s62a/cases/list/view.njk
@@ -10,7 +10,6 @@
 {% endblock %}
 
 {% block pageContent %}
-
 	<div class="govuk-grid-row row-inline">
 		<div class="govuk-grid-column-two-thirds pins-dashboard-box">
 			<form id="search-bar-form" method="GET" action="{{ buildUrlWithParams(baseUrl, queryParams, { page: 1 }) }}">


### PR DESCRIPTION
## Describe your changes
Fixes to address issues raised by PEAS-101 and PEAS-201 merges, and small formatting issue based on prototype:

- Fixes search term disappearing after search
- Fixes navigation urls for individual case links in the case list
- Fixes table sorting order
- Re-formats table to remove the pins-container-wide element to match prototype formatting

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PEAS-371