### PR TITLE
Feat/peas 365 folder page no table

### DIFF
--- a/apps/manage/src/app/sass/accordion.scss
+++ b/apps/manage/src/app/sass/accordion.scss
@@ -1,0 +1,14 @@
+// Used to have an accordion with no parent controller above it
+.govuk-accordion.hide-controls {
+	.govuk-accordion__controls {
+		display: none;
+	}
+
+	.govuk-accordion__section-button {
+		border: none;
+	}
+
+	.govuk-table__cell {
+		border-bottom-style: none;
+	}
+}

--- a/apps/manage/src/app/sass/style.scss
+++ b/apps/manage/src/app/sass/style.scss
@@ -9,6 +9,7 @@ $font-family: arial, helvetica, sans-serif;
 @use 'node_modules/govuk-frontend/dist/govuk/index' as govuk;
 @use './header';
 @use './sub-navigation';
+@use './accordion';
 
 @use 'packages/lib/views/header/pins-header.scss';
 

--- a/apps/manage/src/app/views/layouts/main.njk
+++ b/apps/manage/src/app/views/layouts/main.njk
@@ -32,7 +32,11 @@
 		document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 	</script>
 	{% block backLink %}
-		{% if backLinkUrl and backLinkText %}
+		{% if breadcrumbItems %}
+		    {{ govukBreadcrumbs({
+				items: breadcrumbItems
+			}) }}
+		{% elseif backLinkUrl and backLinkText %}
 			{{ govukBackLink({ text: backLinkText, href: backLinkUrl }) }}
 		{% elseif backLinkUrl %}
 			{{ govukBackLink({ href: backLinkUrl }) }}

--- a/apps/manage/src/app/views/s62a/cases/util/folders.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/util/folders.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
-import { addCaseIdToFolders, createFolders, findFolders, FOLDERS_MAP } from './folders.ts';
+import {
+	addCaseIdToFolders,
+	createFolders,
+	findFolders,
+	buildBreadcrumbItems,
+	FOLDERS_MAP,
+	getFolderPath
+} from './folders.ts';
 import type { Prisma } from '@pins/crowndev-database/src/client/client.ts';
 import { PRE_APPLICATION_OR_APPLICATION_ID } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
 
@@ -67,6 +74,36 @@ describe('Folder creation utils', () => {
 			assert.strictEqual(children[1].s62aCaseId, caseId);
 		});
 
+		it('should recursively inject caseId into deeply nested (3+ levels) arrays', () => {
+			const inputFolders = [
+				{
+					displayName: 'Level 1',
+					displayOrder: 1,
+					ChildFolders: {
+						create: [
+							{
+								displayName: 'Level 2',
+								displayOrder: 1,
+								ChildFolders: {
+									create: [{ displayName: 'Level 3', displayOrder: 1 }]
+								}
+							}
+						]
+					}
+				}
+			];
+
+			const result = addCaseIdToFolders(inputFolders, caseId);
+
+			const level1 = result[0];
+			const level2 = level1.ChildFolders?.create[0] as any;
+			const level3 = level2.ChildFolders?.create[0] as any;
+
+			assert.strictEqual(level1.s62aCaseId, caseId);
+			assert.strictEqual(level2.s62aCaseId, caseId);
+			assert.strictEqual(level3.s62aCaseId, caseId);
+		});
+
 		it('should not mutate the original objects', () => {
 			const inputFolders = [{ displayName: 'F1', displayOrder: 1 }];
 			const result = addCaseIdToFolders(inputFolders, caseId);
@@ -124,6 +161,80 @@ describe('Folder creation utils', () => {
 
 			assert.strictEqual(callData.s62aCaseId, caseId);
 			assert.strictEqual(callData.ChildFolders.create[0].s62aCaseId, caseId);
+		});
+	});
+
+	describe('buildBreadcrumbItems', () => {
+		const caseId = 'case-123';
+		const baseFoldersUrl = `/s62a/cases/${caseId}/case-folders`;
+
+		it('should return only the base breadcrumb when folderPath is empty', () => {
+			const result = buildBreadcrumbItems(caseId, []);
+
+			assert.deepStrictEqual(result, [{ text: 'Manage case files', href: baseFoldersUrl }]);
+		});
+
+		it('should return base and one unlinked item when folderPath has one folder', () => {
+			const folderPath = [{ id: 'folder-1', displayName: 'Root Folder', parentFolderId: null }];
+			const result = buildBreadcrumbItems(caseId, folderPath);
+
+			assert.deepStrictEqual(result, [
+				{ text: 'Manage case files', href: baseFoldersUrl },
+				{ text: 'Root Folder', href: undefined }
+			]);
+		});
+
+		it('should generate linked intermediate breadcrumbs and unlinked last item for deep paths', () => {
+			const folderPath = [
+				{ id: 'folder-1', displayName: 'Representations', parentFolderId: null },
+				{ id: 'folder-2', displayName: 'Original versions', parentFolderId: 'folder-1' },
+				{ id: 'folder-3', displayName: 'Interested Parties', parentFolderId: 'folder-2' }
+			];
+			const result = buildBreadcrumbItems(caseId, folderPath);
+
+			assert.deepStrictEqual(result, [
+				{ text: 'Manage case files', href: baseFoldersUrl },
+				{ text: 'Representations', href: `${baseFoldersUrl}/folder-1/representations` },
+				{ text: 'Original versions', href: `${baseFoldersUrl}/folder-2/original-versions` },
+				{ text: 'Interested Parties', href: undefined }
+			]);
+		});
+	});
+
+	describe('getFolderPath', () => {
+		const mockFolders = [
+			{ id: 'folder-1', displayName: 'Root', parentFolderId: null },
+			{ id: 'folder-2', displayName: 'Child', parentFolderId: 'folder-1' },
+			{ id: 'folder-3', displayName: 'Grandchild', parentFolderId: 'folder-2' },
+			{ id: 'folder-4', displayName: 'Orphan', parentFolderId: 'missing-parent-id' }
+		];
+
+		it('should return a path with only the target folder when it has no parent', () => {
+			const result = getFolderPath(mockFolders, 'folder-1');
+
+			assert.deepStrictEqual(result, [{ id: 'folder-1', displayName: 'Root', parentFolderId: null }]);
+		});
+
+		it('should return the full ancestry chain from root to target folder in the correct order', () => {
+			const result = getFolderPath(mockFolders, 'folder-3');
+
+			assert.deepStrictEqual(result, [
+				{ id: 'folder-1', displayName: 'Root', parentFolderId: null },
+				{ id: 'folder-2', displayName: 'Child', parentFolderId: 'folder-1' },
+				{ id: 'folder-3', displayName: 'Grandchild', parentFolderId: 'folder-2' }
+			]);
+		});
+
+		it('should return an empty array if the target folderId is not in the list', () => {
+			const result = getFolderPath(mockFolders, 'non-existent-id');
+
+			assert.deepStrictEqual(result, []);
+		});
+
+		it('should gracefully stop walking up the tree if a parent is missing from the list', () => {
+			const result = getFolderPath(mockFolders, 'folder-4');
+
+			assert.deepStrictEqual(result, [{ id: 'folder-4', displayName: 'Orphan', parentFolderId: 'missing-parent-id' }]);
 		});
 	});
 });

--- a/apps/manage/src/app/views/s62a/cases/util/folders.ts
+++ b/apps/manage/src/app/views/s62a/cases/util/folders.ts
@@ -4,6 +4,7 @@ import {
 	PRE_APPLICATION_FOLDERS,
 	PRE_APPLICATION_OR_APPLICATION_ID
 } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
+import { stringToKebab } from '@pins/crowndev-lib/util/string.ts';
 
 export const FOLDERS_MAP = {
 	[PRE_APPLICATION_OR_APPLICATION_ID.PRE_APPLICATION]: PRE_APPLICATION_FOLDERS,
@@ -14,6 +15,23 @@ type Folder = {
 	displayName: string;
 	displayOrder: number;
 	ChildFolders?: { create: Folder[] };
+};
+
+/**
+ * Breadcrumb item structure for breadcrumbs component
+ */
+export type BreadcrumbItem = {
+	text: string;
+	href?: string;
+};
+
+/**
+ * Minimal folder info needed for breadcrumbs
+ */
+export type FolderBreadcrumb = {
+	id: string;
+	displayName: string;
+	parentFolderId: string | null;
 };
 
 /**
@@ -59,4 +77,56 @@ export function findFolders(
 	lookupMap: typeof FOLDERS_MAP
 ) {
 	return lookupMap[typeId] || [];
+}
+
+/**
+ * Builds breadcrumb items for the breadcrumbs component.
+ * Structure: Manage case files > Folder > Subfolder > Subfolder
+ */
+export function buildBreadcrumbItems(caseId: string, folderPath: FolderBreadcrumb[]): BreadcrumbItem[] {
+	const baseFoldersUrl = `/s62a/cases/${caseId}/case-folders`;
+
+	// Start with "Manage case files" which links to the root folders page
+	const breadcrumbItems: BreadcrumbItem[] = [
+		{
+			text: 'Manage case files',
+			href: baseFoldersUrl
+		}
+	];
+
+	// Add each folder in the path
+	// All folders except the last one get links
+	folderPath.forEach((folder, index) => {
+		const isLastItem = index === folderPath.length - 1;
+
+		breadcrumbItems.push({
+			text: folder.displayName,
+			// Last item (current page) shouldn't have a link per guidelines
+			href: isLastItem ? undefined : `${baseFoldersUrl}/${folder.id}/${stringToKebab(folder.displayName)}`
+		});
+	});
+
+	return breadcrumbItems;
+}
+
+/**
+ * Takes a flat array of folders and builds the ancestry chain up to the root.
+ * Returns folders in order from root to current folder.
+ */
+export function getFolderPath(allFolders: FolderBreadcrumb[], folderId: string): FolderBreadcrumb[] {
+	const folderMap = new Map(allFolders.map((folder) => [folder.id, folder]));
+
+	// Walk up the tree in memory
+	const folderPath: FolderBreadcrumb[] = [];
+	let currentId: string | null = folderId;
+
+	while (currentId) {
+		const folder = folderMap.get(currentId);
+		if (!folder) break;
+
+		folderPath.push(folder);
+		currentId = folder.parentFolderId;
+	}
+
+	return folderPath.reverse();
 }

--- a/apps/manage/src/app/views/s62a/cases/view/folders/folder/controller.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/folders/folder/controller.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import { buildViewCaseFolder } from './controller.ts';
+import type { ManageService } from '../../../../../../service.js';
+import type { Request, Response, NextFunction } from 'express';
+
+type TemplatePayload = {
+	reference: string;
+	folderName: string;
+	backLinkUrl: string;
+	baseFoldersUrl: string;
+	currentPath: string;
+	breadcrumbItems: Array<{ text: string; href?: string }>;
+};
+
+describe('buildViewCaseFolder controller', () => {
+	it('should render the folder view with the correct template variables', async () => {
+		const mockFindUnique = mock.fn(async () => ({
+			id: 'folder-456',
+			displayName: 'Original versions',
+			s62aCaseId: 'case-123',
+			S62aCase: { reference: 'REF-001' },
+			ChildFolders: [{ id: 'child-1', displayName: 'Consultees', displayOrder: 1 }],
+			ParentFolder: { id: 'parent-789', displayName: 'Representations' }
+		}));
+
+		const mockFindMany = mock.fn(async () => [
+			{ id: 'parent-789', displayName: 'Representations', parentFolderId: null },
+			{ id: 'folder-456', displayName: 'Original versions', parentFolderId: 'parent-789' }
+		]);
+
+		const mockService = {
+			db: {
+				folder: {
+					findUnique: mockFindUnique,
+					findMany: mockFindMany
+				}
+			},
+			logger: {
+				info: mock.fn(),
+				error: mock.fn()
+			}
+		} as unknown as ManageService;
+
+		const handler = buildViewCaseFolder(mockService);
+
+		const mockRender = mock.fn();
+		const mockReq = {
+			params: { id: 'case-123', folderId: 'folder-456' },
+			originalUrl: '/s62a/cases/case-123/case-folders/folder-456?tab=1'
+		} as unknown as Request;
+
+		const mockRes = {
+			render: mockRender,
+			status: mock.fn(() => mockRes),
+			send: mock.fn()
+		} as unknown as Response;
+
+		const mockNext = mock.fn() as unknown as NextFunction;
+
+		await handler(mockReq, mockRes, mockNext);
+
+		assert.strictEqual(mockRender.mock.callCount(), 1);
+
+		const callArgs = mockRender.mock.calls[0].arguments as [string, TemplatePayload];
+		const viewName = callArgs[0];
+		const payload = callArgs[1];
+
+		assert.strictEqual(viewName, 'views/s62a/cases/view/folders/folder/view.njk');
+		assert.strictEqual(payload.reference, 'REF-001');
+		assert.strictEqual(payload.folderName, 'Original versions');
+		assert.strictEqual(payload.backLinkUrl, '/s62a/cases/case-123/case-folders/parent-789/representations');
+		assert.strictEqual(payload.currentPath, '/s62a/cases/case-123/case-folders/folder-456');
+
+		assert.strictEqual(payload.breadcrumbItems.length, 3);
+		assert.strictEqual(payload.breadcrumbItems[2].text, 'Original versions');
+	});
+
+	it('should set backLinkUrl to the base folder page when the folder is at the root', async () => {
+		const mockFindUnique = mock.fn(async () => ({
+			id: 'folder-456',
+			displayName: 'Root Folder',
+			s62aCaseId: 'case-123',
+			S62aCase: { reference: 'REF-001' },
+			ChildFolders: [],
+			ParentFolder: null
+		}));
+
+		const mockFindMany = mock.fn(async () => [{ id: 'folder-456', displayName: 'Root Folder', parentFolderId: null }]);
+
+		const mockService = {
+			db: {
+				folder: {
+					findUnique: mockFindUnique,
+					findMany: mockFindMany
+				}
+			},
+			logger: { info: mock.fn(), error: mock.fn() }
+		} as unknown as ManageService;
+
+		const mockRender = mock.fn();
+		const mockReq = {
+			params: { id: 'case-123', folderId: 'folder-456' },
+			originalUrl: '/s62a/cases/case-123/case-folders/folder-456'
+		} as unknown as Request;
+		const mockRes = { render: mockRender, status: mock.fn(), send: mock.fn() } as unknown as Response;
+
+		await buildViewCaseFolder(mockService)(mockReq, mockRes, mock.fn() as unknown as NextFunction);
+
+		const callArgs = mockRender.mock.calls[0].arguments as [string, TemplatePayload];
+		const payload = callArgs[1];
+
+		assert.strictEqual(payload.backLinkUrl, '/s62a/cases/case-123/case-folders');
+	});
+
+	it('should handle missing folders by not rendering the main view', async () => {
+		const mockFindUnique = mock.fn(async () => null);
+		const mockFindMany = mock.fn(async () => []);
+
+		const mockService = {
+			db: { folder: { findUnique: mockFindUnique, findMany: mockFindMany } },
+			logger: { info: mock.fn(), error: mock.fn() }
+		} as unknown as ManageService;
+
+		const mockRender = mock.fn();
+		const mockReq = {
+			params: { id: 'case-123', folderId: 'invalid-id' },
+			originalUrl: '/test'
+		} as unknown as Request;
+		const mockRes = {
+			render: mockRender,
+			status: mock.fn(() => mockRes),
+			send: mock.fn()
+		} as unknown as Response;
+
+		await buildViewCaseFolder(mockService)(mockReq, mockRes, mock.fn() as unknown as NextFunction);
+
+		const successRenders = mockRender.mock.calls.filter(
+			(call) => (call.arguments as string[])[0] === 'views/s62a/cases/view/folders/folder/view.njk'
+		);
+
+		assert.strictEqual(successRenders.length, 0);
+	});
+});

--- a/apps/manage/src/app/views/s62a/cases/view/folders/folder/controller.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/folders/folder/controller.test.ts
@@ -112,33 +112,4 @@ describe('buildViewCaseFolder controller', () => {
 
 		assert.strictEqual(payload.backLinkUrl, '/s62a/cases/case-123/case-folders');
 	});
-
-	it('should handle missing folders by not rendering the main view', async () => {
-		const mockFindUnique = mock.fn(async () => null);
-		const mockFindMany = mock.fn(async () => []);
-
-		const mockService = {
-			db: { folder: { findUnique: mockFindUnique, findMany: mockFindMany } },
-			logger: { info: mock.fn(), error: mock.fn() }
-		} as unknown as ManageService;
-
-		const mockRender = mock.fn();
-		const mockReq = {
-			params: { id: 'case-123', folderId: 'invalid-id' },
-			originalUrl: '/test'
-		} as unknown as Request;
-		const mockRes = {
-			render: mockRender,
-			status: mock.fn(() => mockRes),
-			send: mock.fn()
-		} as unknown as Response;
-
-		await buildViewCaseFolder(mockService)(mockReq, mockRes, mock.fn() as unknown as NextFunction);
-
-		const successRenders = mockRender.mock.calls.filter(
-			(call) => (call.arguments as string[])[0] === 'views/s62a/cases/view/folders/folder/view.njk'
-		);
-
-		assert.strictEqual(successRenders.length, 0);
-	});
 });

--- a/apps/manage/src/app/views/s62a/cases/view/folders/folder/controller.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/folders/folder/controller.ts
@@ -1,0 +1,77 @@
+import type { ManageService } from '#service';
+import { notFoundHandler } from '@pins/crowndev-lib/middleware/errors.ts';
+import type { AsyncRequestHandler } from '@pins/crowndev-lib/util/async-handler.ts';
+import { wrapPrismaError } from '@pins/crowndev-lib/util/database.ts';
+import { getStringParams } from '@pins/crowndev-lib/util/params.ts';
+import { createFoldersViewModel } from '../view-model.ts';
+import { stringToKebab } from '@pins/crowndev-lib/util/string.ts';
+import { buildBreadcrumbItems, getFolderPath } from '../../../util/folders.ts';
+
+export function buildViewCaseFolder(service: ManageService): AsyncRequestHandler {
+	const { db, logger } = service;
+	return async (req, res) => {
+		const { id, folderId } = getStringParams(req.params, ['id', 'folderId']);
+
+		let caseRow, currentFolder, subFolders, parentFolder, allFolders;
+		try {
+			const [folderData, allFoldersData] = await Promise.all([
+				db.folder.findUnique({
+					where: { id: folderId },
+					include: {
+						S62aCase: { select: { reference: true } },
+						ChildFolders: { where: { s62aCaseId: id, deletedAt: null } },
+						ParentFolder: { select: { id: true, displayName: true } }
+					}
+				}),
+				db.folder.findMany({
+					where: { s62aCaseId: id, deletedAt: null },
+					select: {
+						id: true,
+						displayName: true,
+						parentFolderId: true
+					}
+				})
+			]);
+
+			if (!folderData) throw new Error('Folder not found');
+
+			const { S62aCase, ChildFolders, ParentFolder, ...restOfFolder } = folderData;
+
+			caseRow = S62aCase;
+			currentFolder = restOfFolder;
+			subFolders = ChildFolders;
+			parentFolder = ParentFolder;
+			allFolders = allFoldersData;
+		} catch (error) {
+			wrapPrismaError({
+				error,
+				logger,
+				message: 'fetching folders',
+				logParams: {}
+			});
+		}
+
+		if (!caseRow || !currentFolder) {
+			return notFoundHandler(req, res);
+		}
+
+		const folderPath = getFolderPath(allFolders || [], folderId);
+		const breadcrumbItems = buildBreadcrumbItems(id, folderPath);
+
+		const subFoldersViewModel = subFolders ? createFoldersViewModel(subFolders) : [];
+		const baseFoldersUrl = `/s62a/cases/${id}/case-folders`;
+
+		return res.render('views/s62a/cases/view/folders/folder/view.njk', {
+			reference: caseRow?.reference,
+			folderName: currentFolder?.displayName,
+			backLinkUrl: parentFolder
+				? baseFoldersUrl + `/${parentFolder.id}/${stringToKebab(parentFolder.displayName)}`
+				: baseFoldersUrl,
+			baseFoldersUrl: baseFoldersUrl,
+			subFolders: subFoldersViewModel,
+			currentUrl: req.originalUrl,
+			currentPath: req.originalUrl.split('?')[0],
+			breadcrumbItems
+		});
+	};
+}

--- a/apps/manage/src/app/views/s62a/cases/view/folders/folder/index.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/folders/folder/index.ts
@@ -1,0 +1,16 @@
+import { Router as createRouter } from 'express';
+import type { ManageService } from '#service';
+import { buildViewCaseFolder } from './controller.ts';
+import { validateIdFormat } from '../../controller.ts';
+import { asyncHandler } from '@pins/crowndev-lib/util/async-handler.ts';
+
+export function createRoutes(service: ManageService) {
+	const router = createRouter({ mergeParams: true });
+
+	const viewCaseFolder = buildViewCaseFolder(service);
+
+	// Gets the "individual folder page"
+	router.get('/', validateIdFormat, asyncHandler(viewCaseFolder));
+
+	return router;
+}

--- a/apps/manage/src/app/views/s62a/cases/view/folders/folder/view.njk
+++ b/apps/manage/src/app/views/s62a/cases/view/folders/folder/view.njk
@@ -1,0 +1,69 @@
+{% extends "views/layouts/main.njk" %}
+{% from "govuk/components/accordion/macro.njk" import govukAccordion %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{% set title = reference + " - Case Folder" %}
+
+{% block pageTitle %}
+    {{ title }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+            <h2 class="govuk-caption-l" data-cy="case-reference">
+                {{ reference }}
+            </h2>
+            <h1 class="govuk-heading-l" data-cy="folder-name-heading">
+                {{ folderName }} folder
+            </h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {% if subFolders|length !== 0 %}
+                {% set subFoldersHtml %}
+                    <div class="pins-link-menu">
+                        {% for folder in subFolders %}
+                            <a class="govuk-link govuk-heading-s" href="{{ baseFoldersUrl }}/{{ folder.id }}/{{ folder.encodedDisplayName }}" data-cy="subfolder-link-{{ folder.id }}">
+                                {{ folder.displayName }}
+                            </a>
+                        {% endfor %}
+                    </div>
+                {% endset %}
+
+                {{ govukAccordion({
+                    id: "sub-folders-accordion",
+                    classes: "hide-controls",
+                    hideAllSections: true,
+                    showSectionText: "Show subfolders list",
+                    hideSectionText: "Hide subfolders list",
+                    items: [
+                        {
+                            content: {
+                                html: subFoldersHtml
+                            }
+                        }
+                    ],
+                    attributes: { "data-cy": "subfolders-accordion" }
+                }) }}
+            {% endif %}
+        </div>
+    </div>
+    <div class="govuk-grid-row">        
+        <div class="case-folder-table-column govuk-grid-column-full">
+            <div id="pagination" class="govuk-body">
+                <p class="govuk-body govuk-!-font-weight-bold">File actions</p>
+                    <div class="govuk-button-group govuk-!-margin-bottom-4">
+                        {{ govukButton({
+                            text: "Upload files",
+                            href: currentPath + "/upload",
+                            classes: "govuk-button--secondary",
+                            attributes: { "data-cy": "upload-files-btn" }
+                        }) }}
+                    </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/apps/manage/src/app/views/s62a/cases/view/folders/index.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/folders/index.ts
@@ -3,14 +3,20 @@ import { buildViewCaseFolders } from './controller.ts';
 import type { ManageService } from '#service';
 import { validateIdFormat } from '../controller.ts';
 import { asyncHandler } from '@pins/crowndev-lib/util/async-handler.ts';
+import { createRoutes as createSingleFolderRoutes } from './folder/index.ts';
 
 export function createRoutes(service: ManageService) {
 	const router = createRouter({ mergeParams: true });
+
+	const singleFolderRoutes = createSingleFolderRoutes(service);
 
 	const viewCaseFolders = buildViewCaseFolders(service);
 
 	// Gets "all folders" page
 	router.get('/', validateIdFormat, asyncHandler(viewCaseFolders));
+
+	// Mounts "individual folder" routes
+	router.use('/:folderId/:folderName', singleFolderRoutes);
 
 	return router;
 }


### PR DESCRIPTION
## Describe your changes
- Adds a half completed folder page that doesn't reference documents, so we have a place to put the uploading functionality.
- Branched from main folder branch which must be merged first.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PEAS-365

## Implementation
<img width="1084" height="680" alt="Screenshot 2026-07-29 at 12 26 11" src="https://github.com/user-attachments/assets/5b53125e-196b-46cf-80b1-e7c8ced23042" />
<img width="1076" height="782" alt="Screenshot 2026-07-29 at 12 26 16" src="https://github.com/user-attachments/assets/8de6caaa-aff8-41ce-9f86-26d408fb2fee" />
<img width="983" height="601" alt="Screenshot 2026-07-29 at 12 26 25" src="https://github.com/user-attachments/assets/476c0464-1db6-4aaf-8465-11cb9dfabb1d" />

