### PR TITLE
chore(deps): update cookie parsing method to use parseCookie

### DIFF
--- a/apps/portal/src/util/cookies.js
+++ b/apps/portal/src/util/cookies.js
@@ -1,5 +1,5 @@
-import cookie from 'cookie';
 import { addSessionData, clearSessionData, readSessionData } from '@pins/crowndev-lib/util/session.ts';
+import { parseCookie } from 'cookie';
 
 export const COOKIE_NAME_ANALYTICS_ENABLED = 'CrownDevAnalyticsEnabled';
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
@@ -74,7 +74,7 @@ export function parseCookies(req) {
 	if (!cookieHeader) {
 		return {};
 	}
-	return cookie.parse(cookieHeader);
+	return parseCookie(cookieHeader);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "body-parser": "^2.3.0",
         "cfb": "^1.2.2",
         "connect-redis": "^10.0.0",
-        "cookie": "^1.1.1",
+        "cookie": "^2.0.1",
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
         "escape-html": "^1.0.3",
@@ -3588,12 +3588,12 @@
       }
     },
     "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "body-parser": "^2.3.0",
     "cfb": "^1.2.2",
     "connect-redis": "^10.0.0",
-    "cookie": "^1.1.1",
+    "cookie": "^2.0.1",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
     "escape-html": "^1.0.3",


### PR DESCRIPTION
## Describe your changes
This pull request updates how cookies are parsed in the `apps/portal/src/util/cookies.js` utility and bumps the `cookie` package version in `package.json`. The main changes focus on using the named `parseCookie` import from the updated `cookie` library, ensuring compatibility and clarity.

**Dependency update:**
* Upgraded the `cookie` package from version `^1.1.1` to `^2.0.1` in `package.json` to use the latest features and maintain security.

**Code updates for cookie parsing:**
* Replaced the default import of `cookie` with a named import of `parseCookie` in `apps/portal/src/util/cookies.js` to match the new API in version 2.x.
* Updated the `parseCookies` function to use `parseCookie` instead of `cookie.parse` for parsing cookies from the request header.
## Issue ticket number and link
