### PR TITLE
fix(macros): peas 371 shared list table fix to allow sort by ref not url

### DIFF
--- a/apps/manage/src/app/views/s62a/cases/list/controller.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.ts
@@ -49,6 +49,8 @@ export function buildCaseListPage(service: ManageService): AsyncRequestHandler {
 
 		const paginationParams = createPaginationParams(req, totalItems);
 
+		console.log(s62aCasesViewModels);
+
 		return res.render('./views/s62a/cases/list/view.njk', {
 			pageTitle: 'Manage Section 62A applications',
 			s62aCasesViewModels,

--- a/apps/manage/src/app/views/s62a/cases/list/controller.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/controller.ts
@@ -49,8 +49,6 @@ export function buildCaseListPage(service: ManageService): AsyncRequestHandler {
 
 		const paginationParams = createPaginationParams(req, totalItems);
 
-		console.log(s62aCasesViewModels);
-
 		return res.render('./views/s62a/cases/list/view.njk', {
 			pageTitle: 'Manage Section 62A applications',
 			s62aCasesViewModels,

--- a/apps/manage/src/app/views/s62a/cases/list/view-model.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/view-model.test.ts
@@ -8,7 +8,8 @@ describe('Case list view model', () => {
 	describe('genericDevelopmentToViewModel', () => {
 		const input = {
 			id: 'id-1',
-			reference: 'REF/2025/001',
+			reference: 'REF/2025/000001',
+			createdDate: '2025-10-11T23:00:00.000Z',
 			Type: {
 				displayName: 'Planning permission'
 			},
@@ -81,13 +82,15 @@ describe('Case list view model', () => {
 			const result = s62aToViewModel(input as unknown as S62ACasePayload) as S62ACaseView;
 			assert.deepStrictEqual(result, {
 				id: 'id-1',
-				reference: 'REF/2025/001',
-				referenceLink: '<a class="govuk-link" href="/s62a/cases/id-1">REF/<wbr>2025/<wbr>001</a>',
+				createdDate: '2025-10-11T23:00:00.000Z',
+				reference: 'REF/2025/000001',
+				referenceLink: '<a class="govuk-link" href="/s62a/cases/id-1">REF/<wbr>2025/<wbr>000001</a>',
 				lpaName: 'Test LPA',
 				status: undefined,
 				type: 'Planning permission',
 				applicantOrganisations: ['Applicant organisation 1', 'Applicant organisation 2'],
-				location: 'Site Street, Site Town, Site ONE'
+				location: 'Site Street, Site Town, Site ONE',
+				sortByReferenceThenDate: '000001-2025-10-11T23:00:00.000Z'
 			});
 		});
 		it('should map applicantOrganisations if present', () => {

--- a/apps/manage/src/app/views/s62a/cases/list/view-model.ts
+++ b/apps/manage/src/app/views/s62a/cases/list/view-model.ts
@@ -5,6 +5,7 @@ import { insertWbr, formatStatusTag } from '@pins/crowndev-lib/util/string.ts';
 
 export interface S62ACaseView {
 	id: string;
+	createdDate: Date;
 	reference: string;
 	lpaName: string | undefined;
 	applicationType?: string;
@@ -18,6 +19,7 @@ export interface S62ACaseView {
 
 export const s62aCaseSelect = {
 	id: true,
+	createdDate: true,
 	reference: true,
 	Lpa: { select: { name: true } },
 	description: true,
@@ -34,9 +36,27 @@ export type S62ACasePayload = Prisma.S62aCaseGetPayload<{
 	select: typeof s62aCaseSelect;
 }>;
 
+function getSortByReferenceThenDate(s62aCases: S62ACasePayload): string | undefined {
+	if (!s62aCases?.reference) return undefined;
+
+	const parts = s62aCases.reference.split('/');
+	const refVal = parts.length >= 3 ? parts.slice(-1).join('/') : s62aCases.reference;
+
+	let refTime = '';
+	if (s62aCases.createdDate) {
+		const dateObj = new Date(s62aCases.createdDate);
+		if (!isNaN(dateObj.getTime())) {
+			refTime = dateObj.toISOString();
+		}
+	}
+
+	return refTime ? `${refVal}-${refTime}` : refVal;
+}
+
 export function s62aToViewModel(s62aCases: S62ACasePayload) {
 	const fields = {
 		id: s62aCases.id,
+		createdDate: s62aCases.createdDate,
 		reference: s62aCases.reference,
 		lpaName: s62aCases.Lpa?.name,
 		status: formatStatusTag(s62aCases.S62aStatus?.displayName),
@@ -48,7 +68,8 @@ export function s62aToViewModel(s62aCases: S62ACasePayload) {
 			).map((item) => item.Organisation!.name) ?? [],
 		location: '',
 		referenceLink:
-			'<a class="govuk-link" href="/s62a/cases/' + s62aCases.id + '">' + insertWbr(s62aCases.reference) + '</a>'
+			'<a class="govuk-link" href="/s62a/cases/' + s62aCases.id + '">' + insertWbr(s62aCases.reference) + '</a>',
+		sortByReferenceThenDate: getSortByReferenceThenDate(s62aCases) ?? s62aCases.reference ?? ''
 	};
 	if (s62aCases.SiteAddress) {
 		const address = addressToViewModel(s62aCases.SiteAddress);

--- a/apps/manage/src/app/views/s62a/cases/list/view.njk
+++ b/apps/manage/src/app/views/s62a/cases/list/view.njk
@@ -3,7 +3,7 @@
 {% import "pagination/pagination.njk" as pagination %}
 {% import "pagination/pagination-options.njk" as paginationOptions %}
 {% from "search-bar/search-bar.njk" import searchBar %}
-{% from "tables/tables.njk" import baseCaseListTable, baseManageHeaders, baseManageColumns %}
+{% from "tables/tables.njk" import baseCaseListTable, baseManageHeaders %}
 
 {% block pageTitle %}
 	Case list - All Cases - Manage a Section 62A Development Application
@@ -46,7 +46,7 @@
 				</p>
 				{{ paginationOptions.renderPagination(paginationParams.selectedItemsPerPage, paginationParams.totalItems, baseUrl, queryParams) }}
 				<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-				{{ baseCaseListTable(s62aCasesViewModels,baseManageHeaders,baseManageColumns,true) }}
+				{{ baseCaseListTable(s62aCasesViewModels,baseManageHeaders,s62aManageColumns,true) }}
 			{% endif %}
 		</div>
 	</div>
@@ -55,3 +55,23 @@
 	{{ pagination.renderPagination(paginationParams.pageNumber, paginationParams.totalPages, baseUrl, queryParams) }}
 
 {% endblock %}
+
+{% set s62aManageColumns = [
+	{
+		field: "referenceLink",
+		sortField: "sortByReferenceThenDate"
+	},
+	{
+		field: "location",
+		classes: "pins-white-space-pre-wrap"
+	},
+	{
+		field: "lpaName"
+	},
+	{
+		field: "type"
+	},
+	{
+		field: "status"
+	}
+] %}

--- a/packages/lib/views/tables/tables.njk
+++ b/packages/lib/views/tables/tables.njk
@@ -8,9 +8,16 @@
 		{% set rowData = [] %}
 
 		{% for column in columns %}
+			{# Check if a sortField is specified for this column #}
+			{% set cellAttributes = {} %}
+			{% if column.sortField and development[column.sortField] %}
+				{% set cellAttributes = { "data-sort-value": development[column.sortField] } %}
+			{% endif %}
+
 			{% set rowData = (rowData.push({
 				html: development[column.field],
-				classes: column.classes
+				classes: column.classes,
+				attributes: cellAttributes
 			}), rowData) %}
 		{% endfor %}
 
@@ -80,7 +87,8 @@
 
 {% set baseManageColumns = [
 	{
-		field: "referenceLink"
+		field: "referenceLink",
+		sortField: "reference"
 	},
 	{
 		field: "location",

--- a/packages/lib/views/tables/tables.njk
+++ b/packages/lib/views/tables/tables.njk
@@ -19,6 +19,7 @@
 				classes: column.classes,
 				attributes: cellAttributes
 			}), rowData) %}
+			
 		{% endfor %}
 
 		{% set rows = (rows.push(rowData), rows) %}
@@ -47,7 +48,8 @@
 
 {% set basePortalColumns = [
 	{
-		field: "referenceLink"
+		field: "referenceLink",
+		sortField: "reference"
 	},
 	{
 		field: "applicantOrganisations"


### PR DESCRIPTION
## Describe your changes
Fix to shared nunjucks case list table component to allow sorting by specific field. Fixes issue where table was sorting on passed url fields instead of reference strings.

Changes also made to view model, and test file, to support requested reference sorting.

Fixes failed acceptance criteria for PEAS-111: Table does not sort in descending order 

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PEAS-371

Relates to:
https://pins-ds.atlassian.net/browse/PEAS-145