### PR TITLE
Feat/peas 231 add waste tab

### DIFF
--- a/apps/manage/src/app/views/s62a/cases/view/constants.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/constants.ts
@@ -79,6 +79,9 @@ export const S62A_VIEW_SELECT_INCLUDE = {
 		include: { User: true },
 		orderBy: { allocatedDate: 'asc' }
 	},
+	WasteTypes: {
+		include: { WasteType: true, VoidCapacityUnit: true, MaxAnnualThroughputUnit: true }
+	},
 	AssessorInspector: true,
 	CaseOfficer: true,
 	PlanningOfficer: true,

--- a/apps/manage/src/app/views/s62a/cases/view/delete.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/delete.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, mock, beforeEach, afterEach, type Mock } from 'node:test';
 import assert from 'node:assert';
-import { buildDeleteS62aManageListItemOnConfirmRemove } from './delete.ts';
+import { buildDeleteS62aManageListItemOnConfirmRemove, questionConfig } from './delete.ts';
 import { S62aManageListDeleter } from './s62a-manage-list-deleter.ts';
 import type { Request, Response, NextFunction } from 'express';
 import type { ManageService } from '../../../../service.js';
@@ -19,6 +19,7 @@ describe('buildDeleteS62aManageListItemOnConfirmRemove', () => {
 	let agentContactSpy: Mock<Function>;
 	let additionalContactSpy: Mock<Function>;
 	let inspectorSpy: Mock<Function>;
+	let wasteTypeSpy: Mock<Function>;
 
 	beforeEach(() => {
 		req = { params: {} };
@@ -41,6 +42,7 @@ describe('buildDeleteS62aManageListItemOnConfirmRemove', () => {
 		agentContactSpy = mock.method(S62aManageListDeleter.prototype, 'deleteAgentContactDetails', async () => {});
 		additionalContactSpy = mock.method(S62aManageListDeleter.prototype, 'deleteAdditionalContact', async () => {});
 		inspectorSpy = mock.method(S62aManageListDeleter.prototype, 'deleteCaseTeamInspector', async () => {});
+		wasteTypeSpy = mock.method(S62aManageListDeleter.prototype, 'deleteWasteType', async () => {});
 	});
 
 	afterEach(() => {
@@ -175,6 +177,65 @@ describe('buildDeleteS62aManageListItemOnConfirmRemove', () => {
 			assert.strictEqual(additionalContactSpy.mock.callCount(), 1);
 			assert.deepStrictEqual(additionalContactSpy.mock.calls[0].arguments, ['case-1', 'additional-1']);
 			assert.strictEqual(next.mock.callCount(), 1);
+		});
+
+		it('routes "check-case-team-inspectors" to deleteCaseTeamInspector', async () => {
+			req.params = {
+				manageListAction: 'remove',
+				manageListQuestion: 'confirm',
+				manageListItemId: 'inspector-row-1',
+				id: 'case-1',
+				question: 'check-case-team-inspectors'
+			};
+
+			const middleware = buildDeleteS62aManageListItemOnConfirmRemove(mockService);
+			await middleware(req as Request, res as Response, next as unknown as NextFunction);
+
+			assert.strictEqual(inspectorSpy.mock.callCount(), 1);
+			assert.deepStrictEqual(inspectorSpy.mock.calls[0].arguments, ['case-1', 'inspector-row-1']);
+			assert.strictEqual(next.mock.callCount(), 1);
+		});
+
+		it('routes "check-waste-types" to deleteWasteType', async () => {
+			req.params = {
+				manageListAction: 'remove',
+				manageListQuestion: 'confirm',
+				manageListItemId: 'waste-row-1',
+				id: 'case-1',
+				question: 'check-waste-types'
+			};
+
+			const middleware = buildDeleteS62aManageListItemOnConfirmRemove(mockService);
+			await middleware(req as Request, res as Response, next as unknown as NextFunction);
+
+			assert.strictEqual(wasteTypeSpy.mock.callCount(), 1);
+			assert.deepStrictEqual(wasteTypeSpy.mock.calls[0].arguments, ['case-1', 'waste-row-1']);
+			assert.strictEqual(next.mock.callCount(), 1);
+		});
+	});
+
+	describe('questionConfig', () => {
+		it('has a delete handler for every configured question', async () => {
+			const middleware = buildDeleteS62aManageListItemOnConfirmRemove(mockService);
+
+			for (const question of Object.keys(questionConfig)) {
+				const localNext = mock.fn();
+				await middleware(
+					{
+						params: {
+							manageListAction: 'remove',
+							manageListQuestion: 'confirm',
+							manageListItemId: 'item-1',
+							id: 'case-1',
+							question
+						}
+					} as unknown as Request,
+					res as Response,
+					localNext as unknown as NextFunction
+				);
+
+				assert.strictEqual(localNext.mock.calls[0].arguments.length, 0, `${question} has no delete handler`);
+			}
 		});
 	});
 

--- a/apps/manage/src/app/views/s62a/cases/view/delete.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/delete.ts
@@ -8,7 +8,8 @@ export const questionConfig: Record<string, { fieldName: string; successMessage:
 	'check-applicant-contact-details': { fieldName: 'manageApplicantContactDetails', successMessage: 'Contact removed' },
 	'check-applicant-details': { fieldName: 'manageApplicantOrganisations', successMessage: 'Organisation removed' },
 	'check-additional-contact-details': { fieldName: 'manageAdditionalContacts', successMessage: 'Contact removed' },
-	'check-case-team-inspectors': { fieldName: 'manageCaseTeamInspectors', successMessage: 'Inspector removed' }
+	'check-case-team-inspectors': { fieldName: 'manageCaseTeamInspectors', successMessage: 'Inspector removed' },
+	'check-waste-types': { fieldName: 'manageWasteTypes', successMessage: 'Waste type removed' }
 };
 
 /**
@@ -55,6 +56,9 @@ export function buildDeleteS62aManageListItemOnConfirmRemove(service: ManageServ
 					break;
 				case 'manageCaseTeamInspectors':
 					await deleter.deleteCaseTeamInspector(id, manageListItemId);
+					break;
+				case 'manageWasteTypes':
+					await deleter.deleteWasteType(id, manageListItemId);
 					break;
 				default:
 					service.logger.warn(

--- a/apps/manage/src/app/views/s62a/cases/view/journey.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/journey.test.ts
@@ -211,6 +211,11 @@ describe('s62a case details journey', () => {
 					'preApplicationAdviceIssuedDate',
 					'preApplicationReference'
 				]
+			},
+			{
+				title: '',
+				segment: 'waste',
+				questions: ['wasteActivitiesDescription', 'wasteManagementDevelopment', 'manageWasteTypes']
 			}
 		];
 

--- a/apps/manage/src/app/views/s62a/cases/view/journey.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/journey.ts
@@ -15,7 +15,8 @@ import {
 	OUTCOME_TYPE_ID,
 	PRE_APPLICATION_ADVICE_ID,
 	PRE_APPLICATION_OR_APPLICATION_ID,
-	VIEW_TAB_ID
+	VIEW_TAB_ID,
+	WASTE_TYPES_WITHOUT_VOID_CAPACITY
 } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
 import { APPLICATION_TYPE_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 
@@ -51,6 +52,11 @@ export function createJourney(questions: Record<string, Question>, response: Jou
 
 	const showAdviceIssuedDate = (response: JourneyResponse) =>
 		isPreApplicationCase(response) || isApplicationAdviceGiven(response);
+
+	const needsVoidCapacity = (response: JourneyResponse) => {
+		const wasteTypeId = response.answers?.wasteTypeId as string | undefined;
+		return !!wasteTypeId && !WASTE_TYPES_WITHOUT_VOID_CAPACITY.includes(wasteTypeId);
+	};
 
 	return new Journey({
 		journeyId: JOURNEY_ID,
@@ -299,7 +305,19 @@ export function createJourney(questions: Record<string, Question>, response: Jou
 				.addQuestion(questions.preApplicationAdviceIssuedDate)
 				.withCondition(showAdviceIssuedDate)
 				.addQuestion(questions.preApplicationReference)
-				.withCondition(isApplicationAdviceGiven)
+				.withCondition(isApplicationAdviceGiven),
+			new Section('', 'waste')
+				.withSectionCondition(() => currentTab === VIEW_TAB_ID.WASTE && isApplicationCase(response))
+				.addQuestion(questions.wasteActivitiesDescription)
+				.addQuestion(questions.wasteManagementDevelopment)
+				.addQuestion(
+					questions.manageWasteTypes,
+					new ManageListSection()
+						.addQuestion(questions.wasteType)
+						.addQuestion(questions.voidCapacity)
+						.withCondition(needsVoidCapacity)
+						.addQuestion(questions.maxAnnualThroughput)
+				)
 		],
 		taskListUrl: '',
 		journeyTemplate: 'views/layouts/forms-question.njk',

--- a/apps/manage/src/app/views/s62a/cases/view/questions.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/questions.ts
@@ -22,7 +22,10 @@ import {
 	S62A_PRE_APPLICATION_STATUSES,
 	S62A_STAGES,
 	SITE_VISIT_TYPES,
-	SPECIALISMS
+	SPECIALISMS,
+	WASTE_TYPES,
+	WASTE_UNIT_ID,
+	WASTE_UNITS
 } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
 import {
 	AddressValidator,
@@ -54,6 +57,8 @@ import CILAmountLengthValidator from '@pins/crowndev-lib/forms/custom-components
 import { multiContactQuestions, createLpaContactQuestion } from '../util/question-factories.ts';
 import { getApplicantOrganisationOptions } from '../../../../views/cases/util/applicant-organisation-options.js';
 import TelephoneNumberValidator from '@pins/crowndev-lib/validators/telephone-number-validator.ts';
+import MultiConditionalNumericValidator from '@pins/crowndev-lib/forms/custom-components/multi-conditional-radio/multi-conditional-numeric-validator.ts';
+import UniqueListFieldValidator from '@pins/crowndev-lib/validators/unique-list-field-validator.ts';
 import type { EntraGroupMembers } from '#util/entra-groups.ts';
 
 type ApplicantOrg = {
@@ -107,6 +112,8 @@ export function getQuestions(
 	const hasAgent = answers?.hasAgent === BOOLEAN_OPTIONS.YES;
 
 	const applicantContactsValidator = getApplicantContactsValidator(hasAgent, isIndividual);
+
+	const throughputUnits = WASTE_UNITS.filter((u) => u.id !== WASTE_UNIT_ID.CUBIC_METRES);
 
 	const questions = {
 		reference: {
@@ -1884,6 +1891,155 @@ export function getQuestions(
 			url: 'site-visit-type',
 			validators: [new RequiredValidator('Select the type of site visit')],
 			options: SITE_VISIT_TYPES.map((t) => ({ text: t.displayName, value: t.id }))
+		},
+		wasteActivitiesDescription: {
+			type: COMPONENT_TYPES.TEXT_ENTRY,
+			title: 'Description of the activities and processes',
+			question: 'Provide a description of the activities and processes which would be carried out on the site',
+			fieldName: 'wasteActivitiesDescription',
+			url: 'activities',
+			validators: [
+				new RequiredValidator(
+					'Enter description of the activities and processes which would be carried out on the site'
+				),
+				new StringValidator({
+					maxLength: {
+						maxLength: 1000,
+						maxLengthMessage: 'Description of activities and processes must be 1000 characters or less'
+					}
+				})
+			],
+			viewData: {
+				extraActionButtons: [{ text: 'Remove and save', type: 'submit', formaction: 'activities/remove' }]
+			}
+		},
+		wasteManagementDevelopment: {
+			type: COMPONENT_TYPES.BOOLEAN,
+			title: 'Waste management development',
+			question: 'Is the proposal a waste management development?',
+			fieldName: 'isWasteManagementDevelopment',
+			url: 'waste-management-development',
+			validators: [new RequiredValidator('Select yes if the proposal is a waste management development')],
+			viewData: {
+				extraActionButtons: [
+					{ text: 'Remove and save', type: 'submit', formaction: 'waste-management-development/remove' }
+				]
+			}
+		},
+		manageWasteTypes: {
+			type: CUSTOM_COMPONENTS.DEFINED_COLUMNS_TABLE,
+			title: isQuestionView ? 'Check types of waste details' : 'Type of waste',
+			question: 'Check types of waste details',
+			url: 'check-waste-types',
+			fieldName: 'manageWasteTypes',
+			titleSingular: 'Waste type',
+			emptyName: 'waste type',
+			emptyNamePlural: 'waste types',
+			showAnswersInSummary: true,
+			summaryLimit: 3,
+			hideCancel: true,
+			columns: [
+				{
+					header: 'Type',
+					fieldName: 'wasteTypeId'
+				},
+				{
+					header: 'Capacity',
+					fieldName: 'voidCapacityUnitId',
+					sortType: 'number'
+				},
+				{
+					header: 'Throughput',
+					fieldName: 'maxAnnualThroughputUnitId',
+					sortType: 'number'
+				}
+			]
+		},
+		wasteType: {
+			// TODO: Retire MultiConditionalRadioQuestion once RadioQuestion
+			// supports summary labels, unit suffixes and bolding directly.
+			type: CUSTOM_COMPONENTS.MULTI_CONDITIONAL_RADIO,
+			title: 'Type of waste',
+			question: 'Which types of waste are applicable to this development?',
+			fieldName: 'wasteTypeId',
+			url: 'waste-types',
+			boldSummaryValue: true,
+			validators: [
+				new RequiredValidator('Select type of waste'),
+				new UniqueListFieldValidator({
+					listFieldName: 'manageWasteTypes',
+					displayNameFor: (id) => WASTE_TYPES.find((t) => t.id === id)?.displayName ?? 'this waste type',
+					buildErrorMessage: (name) =>
+						`You have already added ${name}. Select a different waste type or change the existing entry`
+				})
+			],
+			options: WASTE_TYPES.map((t) => ({ text: t.displayName, value: t.id }))
+		},
+		voidCapacity: {
+			// TODO: Retire MultiConditionalRadioQuestion once RadioQuestion
+			// supports summary labels, unit suffixes and bolding directly.
+			type: CUSTOM_COMPONENTS.MULTI_CONDITIONAL_RADIO,
+			title: 'Total capacity of void',
+			question: 'What is the total capacity of the void?',
+			hint: 'This includes engineering surcharge and making no allowance for cover or restoration material in cubic metres. For solid waste use tonnes or litres for liquid waste.',
+			fieldName: 'voidCapacityUnitId',
+			url: 'total-void-capacity',
+			summaryLabel: 'Capacity',
+			summarySuffixes: {
+				[WASTE_UNIT_ID.CUBIC_METRES]: 'm³',
+				[WASTE_UNIT_ID.TONNES]: 't',
+				[WASTE_UNIT_ID.LITRES]: 'l'
+			},
+			options: WASTE_UNITS.map((unit) => ({
+				text: unit.displayName,
+				value: unit.id,
+				conditional: {
+					type: 'text',
+					fieldName: unit.id,
+					label: unit.displayName,
+					classes: 'govuk-input--width-10',
+					inputmode: 'numeric'
+				}
+			})),
+			validators: [
+				new RequiredValidator('Select the unit of measurement'),
+				new ConditionalRequiredValidator('Enter the total capacity of the void'),
+				new MultiConditionalNumericValidator({
+					regexMessage: 'Total capacity of the void must be a number'
+				})
+			]
+		},
+		maxAnnualThroughput: {
+			// TODO: Retire MultiConditionalRadioQuestion once RadioQuestion
+			// supports summary labels, unit suffixes and bolding directly.
+			type: CUSTOM_COMPONENTS.MULTI_CONDITIONAL_RADIO,
+			title: 'Maximum annual throughput',
+			question: 'What is the maximum annual operational throughput in tonnes (or litres if liquid waste)?',
+			fieldName: 'maxAnnualThroughputUnitId',
+			url: 'max-annual-throughput',
+			summaryLabel: 'Throughput',
+			summarySuffixes: {
+				[WASTE_UNIT_ID.TONNES]: 't',
+				[WASTE_UNIT_ID.LITRES]: 'l'
+			},
+			options: throughputUnits.map((unit) => ({
+				text: unit.displayName,
+				value: unit.id,
+				conditional: {
+					type: 'text',
+					fieldName: unit.id,
+					label: unit.displayName,
+					classes: 'govuk-input--width-10',
+					inputmode: 'numeric'
+				}
+			})),
+			validators: [
+				new RequiredValidator('Select the unit of measurement'),
+				new ConditionalRequiredValidator('Enter the maximum annual operational throughput'),
+				new MultiConditionalNumericValidator({
+					regexMessage: 'Maximum annual operational throughput must be a number'
+				})
+			]
 		}
 	};
 

--- a/apps/manage/src/app/views/s62a/cases/view/s62a-manage-list-deleter.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/s62a-manage-list-deleter.test.ts
@@ -38,6 +38,17 @@ describe('S62aManageListDeleter', () => {
 				delete: mock.fn(async () => {}),
 				deleteMany: mock.fn(async () => {})
 			},
+			s62aCaseWasteType: {
+				deleteMany: mock.fn(async () => {})
+			},
+			s62aWasteType: {
+				delete: mock.fn(async () => {}),
+				deleteMany: mock.fn(async () => {})
+			},
+			s62aWasteUnit: {
+				delete: mock.fn(async () => {}),
+				deleteMany: mock.fn(async () => {})
+			},
 			$transaction: mock.fn(async (ops: any[]) => Promise.all(ops))
 		};
 
@@ -251,6 +262,31 @@ describe('S62aManageListDeleter', () => {
 
 			assert.strictEqual(mockDb.s62aToApplicant.deleteMany.mock.callCount(), 0);
 			assert.strictEqual(mockDb.contact.delete.mock.callCount(), 0);
+		});
+	});
+
+	describe('deleteWasteType', () => {
+		it('deletes the join row scoped to the case', async () => {
+			await deleter.deleteWasteType('case-1', 'waste-row-1');
+
+			assert.strictEqual(mockDb.s62aCaseWasteType.deleteMany.mock.callCount(), 1);
+			assert.deepStrictEqual(mockDb.s62aCaseWasteType.deleteMany.mock.calls[0].arguments[0], {
+				where: { id: 'waste-row-1', s62aCaseId: 'case-1' }
+			});
+		});
+
+		it('leaves the waste type and unit lookups alone, as they are reference data', async () => {
+			await deleter.deleteWasteType('case-1', 'waste-row-1');
+
+			assert.strictEqual(mockDb.s62aWasteType?.delete?.mock.callCount() ?? 0, 0);
+			assert.strictEqual(mockDb.s62aWasteUnit?.delete?.mock.callCount() ?? 0, 0);
+		});
+
+		it('does not touch the inspector or applicant join tables', async () => {
+			await deleter.deleteWasteType('case-1', 'waste-row-1');
+
+			assert.strictEqual(mockDb.s62aCaseInspector.deleteMany.mock.callCount(), 0);
+			assert.strictEqual(mockDb.s62aToApplicant.deleteMany.mock.callCount(), 0);
 		});
 	});
 });

--- a/apps/manage/src/app/views/s62a/cases/view/s62a-manage-list-deleter.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/s62a-manage-list-deleter.ts
@@ -165,4 +165,14 @@ export class S62aManageListDeleter {
 			where: { id: manageListItemId, s62aCaseId: id }
 		});
 	}
+
+	/**
+	 * Deletes a single waste type entry. The waste type and unit lookups are
+	 * reference data and must survive.
+	 */
+	public async deleteWasteType(id: string, manageListItemId: string): Promise<void> {
+		await this.db.s62aCaseWasteType.deleteMany({
+			where: { id: manageListItemId, s62aCaseId: id }
+		});
+	}
 }

--- a/apps/manage/src/app/views/s62a/cases/view/s62a-update-case-mapper.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/s62a-update-case-mapper.test.ts
@@ -7,7 +7,9 @@ import {
 	PRE_APPLICATION_ADVICE_ID,
 	OUTCOME_TYPE_ID,
 	DECISION_OUTCOME_ID,
-	SITE_VISIT_TYPE_ID
+	SITE_VISIT_TYPE_ID,
+	WASTE_TYPE_ID,
+	WASTE_UNIT_ID
 } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
 import { ORGANISATION_ROLES_ID } from '@pins/crowndev-database/src/seed/data-static.ts';
 import { viewModelToAddressUpdateInput } from '@pins/crowndev-lib/util/address.ts';
@@ -1245,6 +1247,144 @@ describe('S62aCaseUpdateMapper', () => {
 
 			assert.strictEqual((result as any).hearingDate, undefined);
 			assert.strictEqual(result.S62aDates, undefined);
+		});
+	});
+
+	describe('Waste Tab', () => {
+		it('maps the description, clearing to null when empty', () => {
+			assert.strictEqual(
+				new S62aCaseUpdateMapper({ wasteActivitiesDescription: 'Sorting and baling' }).generateUpdateInput()
+					.wasteActivitiesDescription,
+				'Sorting and baling'
+			);
+			assert.strictEqual(
+				new S62aCaseUpdateMapper({ wasteActivitiesDescription: '' }).generateUpdateInput().wasteActivitiesDescription,
+				null
+			);
+		});
+
+		it('maps the waste management boolean', () => {
+			const answers = { isWasteManagementDevelopment: true } as unknown as UpdateCaseAnswers;
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+
+			assert.strictEqual(result.isWasteManagementDevelopment, true);
+		});
+
+		it('maps a false boolean rather than treating it as cleared', () => {
+			const answers = { isWasteManagementDevelopment: false } as unknown as UpdateCaseAnswers;
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+
+			assert.strictEqual(result.isWasteManagementDevelopment, false);
+		});
+
+		it('nullifies the boolean when cleared', () => {
+			const answers = { isWasteManagementDevelopment: null } as unknown as UpdateCaseAnswers;
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+
+			assert.strictEqual(result.isWasteManagementDevelopment, null);
+		});
+
+		it('replaces the waste type rows wholesale, collapsing the conditional amounts', () => {
+			const answers = {
+				manageWasteTypes: [
+					{
+						id: 'row-1',
+						wasteTypeId: WASTE_TYPE_ID.INERT_LANDFILL,
+						voidCapacityUnitId: WASTE_UNIT_ID.CUBIC_METRES,
+						[`voidCapacityUnitId_${WASTE_UNIT_ID.CUBIC_METRES}`]: '34',
+						maxAnnualThroughputUnitId: WASTE_UNIT_ID.TONNES,
+						[`maxAnnualThroughputUnitId_${WASTE_UNIT_ID.TONNES}`]: '55'
+					}
+				]
+			} as unknown as UpdateCaseAnswers;
+
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+
+			assert.deepStrictEqual(result.WasteTypes, {
+				deleteMany: {},
+				create: [
+					{
+						WasteType: { connect: { id: WASTE_TYPE_ID.INERT_LANDFILL } },
+						voidCapacity: new Prisma.Decimal(34),
+						VoidCapacityUnit: { connect: { id: WASTE_UNIT_ID.CUBIC_METRES } },
+						maxAnnualThroughput: new Prisma.Decimal(55),
+						MaxAnnualThroughputUnit: { connect: { id: WASTE_UNIT_ID.TONNES } }
+					}
+				]
+			});
+		});
+
+		it('ignores the amounts for units that were not selected', () => {
+			const answers = {
+				manageWasteTypes: [
+					{
+						id: 'row-1',
+						wasteTypeId: WASTE_TYPE_ID.INERT_LANDFILL,
+						voidCapacityUnitId: WASTE_UNIT_ID.TONNES,
+						// the hidden reveals still submit their inputs, so both arrive
+						[`voidCapacityUnitId_${WASTE_UNIT_ID.CUBIC_METRES}`]: '999',
+						[`voidCapacityUnitId_${WASTE_UNIT_ID.TONNES}`]: '12'
+					}
+				]
+			} as unknown as UpdateCaseAnswers;
+
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+			const [created] = (result.WasteTypes as any).create;
+
+			assert.deepStrictEqual(created.voidCapacity, new Prisma.Decimal(12));
+		});
+
+		it('writes a null amount when the selected unit has no value', () => {
+			const answers = {
+				manageWasteTypes: [
+					{
+						id: 'row-1',
+						wasteTypeId: WASTE_TYPE_ID.MUNICIPAL,
+						maxAnnualThroughputUnitId: WASTE_UNIT_ID.LITRES,
+						[`maxAnnualThroughputUnitId_${WASTE_UNIT_ID.LITRES}`]: ''
+					}
+				]
+			} as unknown as UpdateCaseAnswers;
+
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+			const [created] = (result.WasteTypes as any).create;
+
+			assert.strictEqual(created.maxAnnualThroughput, null);
+			assert.strictEqual(created.voidCapacity, null);
+			assert.strictEqual(created.VoidCapacityUnit, undefined);
+		});
+
+		it('skips rows with no waste type selected', () => {
+			const answers = {
+				manageWasteTypes: [
+					{ id: 'row-1', wasteTypeId: WASTE_TYPE_ID.INERT_LANDFILL },
+					{ id: 'row-2', voidCapacityUnitId: WASTE_UNIT_ID.TONNES }
+				]
+			} as unknown as UpdateCaseAnswers;
+
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+
+			assert.strictEqual((result.WasteTypes as any).create.length, 1);
+		});
+
+		it('clears every waste type row when the list is empty', () => {
+			const answers = { manageWasteTypes: [] } as unknown as UpdateCaseAnswers;
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+
+			assert.deepStrictEqual(result.WasteTypes, { deleteMany: {}, create: [] });
+		});
+
+		it('clears every waste type row when the list is null', () => {
+			const answers = { manageWasteTypes: null } as unknown as UpdateCaseAnswers;
+			const result = new S62aCaseUpdateMapper(answers).generateUpdateInput();
+
+			assert.deepStrictEqual(result.WasteTypes, { deleteMany: {}, create: [] });
+		});
+
+		it('does not touch the waste type rows when the list is absent from the payload', () => {
+			const result = new S62aCaseUpdateMapper({ likelyIssues: 'Traffic' }).generateUpdateInput();
+
+			assert.strictEqual(result.WasteTypes, undefined);
 		});
 	});
 });

--- a/apps/manage/src/app/views/s62a/cases/view/s62a-update-case-mapper.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/s62a-update-case-mapper.ts
@@ -19,7 +19,8 @@ import {
 	type S62aCaseViewModel,
 	EVENT_DATE_FIELDS,
 	EVENT_NUMBER_FIELDS,
-	EVENT_STRING_FIELDS
+	EVENT_STRING_FIELDS,
+	type WasteTypeItem
 } from './view-model.ts';
 import {
 	type AgentContactAnswer,
@@ -173,6 +174,11 @@ export interface UpdateCaseAnswers {
 	issuesReportingPublishedDate?: Date | null;
 	siteVisitDate?: Date | null;
 	siteVisitTypeId?: string | null;
+
+	// Waste tab
+	wasteActivitiesDescription?: string;
+	isWasteManagementDevelopment?: YesNo;
+	manageWasteTypes?: WasteTypeItem[] | null;
 }
 
 /**
@@ -207,6 +213,7 @@ export class S62aCaseUpdateMapper {
 		this.mapEiaScalars(input);
 		this.mapCaseTeam(input);
 		this.mapEvent(input);
+		this.mapWaste(input);
 
 		return input;
 	}
@@ -515,6 +522,48 @@ export class S62aCaseUpdateMapper {
 				}
 			};
 		}
+	}
+
+	/**
+	 * Maps the Waste tab.
+	 *
+	 * TODO: PEAS-399 — the waste type list is replaced wholesale on every save,
+	 * so a minor edit deletes and recreates every row. Should be a diff instead
+	 * (match by id, update/create/delete only what changed) before case history
+	 * lands, or the history will show mass deletes and inserts for small changes.
+	 */
+	private mapWaste(input: Prisma.S62aCaseUpdateInput): void {
+		const ans = this.answers;
+
+		if (this.hasAnswer('wasteActivitiesDescription')) {
+			input.wasteActivitiesDescription = ans.wasteActivitiesDescription || null;
+		}
+
+		if (this.hasAnswer('isWasteManagementDevelopment')) {
+			input.isWasteManagementDevelopment =
+				typeof ans.isWasteManagementDevelopment === 'boolean' ? yesNoToBoolean(ans.isWasteManagementDevelopment) : null;
+		}
+
+		// Deliberately not hasAnswer(): it returns false for an empty array, so
+		// removing the last waste type would be skipped and the row would survive.
+		if (ans.manageWasteTypes === undefined) return;
+
+		const items = ans.manageWasteTypes ?? [];
+
+		input.WasteTypes = {
+			deleteMany: {},
+			create: items
+				.filter((item) => item.wasteTypeId)
+				.map((item) => ({
+					WasteType: { connect: { id: item.wasteTypeId! } },
+					voidCapacity: this.selectedConditionalAmount(item, 'voidCapacityUnitId'),
+					VoidCapacityUnit: item.voidCapacityUnitId ? { connect: { id: item.voidCapacityUnitId } } : undefined,
+					maxAnnualThroughput: this.selectedConditionalAmount(item, 'maxAnnualThroughputUnitId'),
+					MaxAnnualThroughputUnit: item.maxAnnualThroughputUnitId
+						? { connect: { id: item.maxAnnualThroughputUnitId } }
+						: undefined
+				}))
+		};
 	}
 
 	/**
@@ -966,6 +1015,9 @@ export class S62aCaseUpdateMapper {
 	 * Replaces the inspector rows wholesale. Prisma runs deleteMany before
 	 * create, so re-adding the same user in one save does not trip the
 	 * (s62aCaseId, userId) unique constraint.
+	 *
+	 * TODO: PEAS-399 — see the note on mapWaste. Should be a diff rather than a
+	 * full replace.
 	 */
 	private mapCaseTeamInspectors(input: Prisma.S62aCaseUpdateInput): void {
 		// Deliberately didn't use hasAnswer() as it returns false for an empty array, so
@@ -1028,5 +1080,22 @@ export class S62aCaseUpdateMapper {
 			return value.length > 0;
 		}
 		return value !== undefined;
+	}
+
+	/**
+	 * The conditional radio posts one input per unit option. Pull the amount
+	 * belonging to the selected unit and discard the rest.
+	 */
+	private selectedConditionalAmount(
+		item: WasteTypeItem,
+		unitFieldName: 'voidCapacityUnitId' | 'maxAnnualThroughputUnitId'
+	): Prisma.Decimal | null {
+		const unitId = item[unitFieldName];
+		if (!unitId) return null;
+
+		const raw = item[`${unitFieldName}_${unitId}`];
+		if (raw === undefined || raw === null || raw === '') return null;
+
+		return new Prisma.Decimal(raw as string | number);
 	}
 }

--- a/apps/manage/src/app/views/s62a/cases/view/view-model.test.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/view-model.test.ts
@@ -7,7 +7,9 @@ import {
 	PRE_APPLICATION_ADVICE_ID,
 	OUTCOME_TYPE_ID,
 	DECISION_OUTCOME_ID,
-	SITE_VISIT_TYPE_ID
+	SITE_VISIT_TYPE_ID,
+	WASTE_TYPE_ID,
+	WASTE_UNIT_ID
 } from '@pins/crowndev-database/src/seed/s62a/data-static.ts';
 import { s62aCaseToViewModel, type S62aCaseDbModel } from './view-model.ts';
 
@@ -1264,6 +1266,120 @@ describe('s62aCaseToViewModel', () => {
 
 			assert.strictEqual(result.notificationReceivedDate, notificationReceivedDate);
 			assert.strictEqual(result.notificationDate, notificationDate);
+		});
+	});
+
+	describe('Waste Mapping', () => {
+		it('maps the description and the boolean', () => {
+			const mockDbCase = {
+				id: 'case-waste-1',
+				reference: 'S62A/2026/0044',
+				expectedSubmissionDate: mockDate,
+				wasteActivitiesDescription: 'Sorting and baling',
+				isWasteManagementDevelopment: true
+			} as unknown as S62aCaseDbModel;
+
+			const result = s62aCaseToViewModel(mockDbCase);
+
+			assert.strictEqual(result.wasteActivitiesDescription, 'Sorting and baling');
+			assert.strictEqual(result.isWasteManagementDevelopment, 'yes');
+		});
+
+		it('maps "No" distinctly from unanswered', () => {
+			const withNo = {
+				id: 'case-waste-2',
+				reference: 'S62A/2026/0045',
+				expectedSubmissionDate: mockDate,
+				isWasteManagementDevelopment: false
+			} as unknown as S62aCaseDbModel;
+
+			const withNull = {
+				id: 'case-waste-3',
+				reference: 'S62A/2026/0046',
+				expectedSubmissionDate: mockDate,
+				isWasteManagementDevelopment: null
+			} as unknown as S62aCaseDbModel;
+
+			assert.strictEqual(s62aCaseToViewModel(withNo).isWasteManagementDevelopment, 'no');
+			assert.strictEqual(s62aCaseToViewModel(withNull).isWasteManagementDevelopment, undefined);
+		});
+
+		it('maps waste types, converting the decimals and expanding the conditional keys', () => {
+			const mockDbCase = {
+				id: 'case-waste-4',
+				reference: 'S62A/2026/0047',
+				expectedSubmissionDate: mockDate,
+				WasteTypes: [
+					{
+						id: 'row-1',
+						wasteTypeId: WASTE_TYPE_ID.INERT_LANDFILL,
+						voidCapacity: createMockDecimal(34),
+						voidCapacityUnitId: WASTE_UNIT_ID.CUBIC_METRES,
+						maxAnnualThroughput: createMockDecimal(55),
+						maxAnnualThroughputUnitId: WASTE_UNIT_ID.TONNES
+					}
+				]
+			} as unknown as S62aCaseDbModel;
+
+			const result = s62aCaseToViewModel(mockDbCase);
+
+			assert.deepStrictEqual(result.manageWasteTypes, [
+				{
+					id: 'row-1',
+					wasteTypeId: WASTE_TYPE_ID.INERT_LANDFILL,
+					voidCapacity: 34,
+					voidCapacityUnitId: WASTE_UNIT_ID.CUBIC_METRES,
+					maxAnnualThroughput: 55,
+					maxAnnualThroughputUnitId: WASTE_UNIT_ID.TONNES,
+					// the conditional radio reads the amount from this key, so the
+					// right input pre-fills on edit and the table can find the value
+					[`voidCapacityUnitId_${WASTE_UNIT_ID.CUBIC_METRES}`]: '34',
+					[`maxAnnualThroughputUnitId_${WASTE_UNIT_ID.TONNES}`]: '55'
+				}
+			]);
+		});
+
+		it('omits the conditional keys when there is no amount', () => {
+			const mockDbCase = {
+				id: 'case-waste-5',
+				reference: 'S62A/2026/0048',
+				expectedSubmissionDate: mockDate,
+				WasteTypes: [
+					{
+						id: 'row-1',
+						wasteTypeId: WASTE_TYPE_ID.MUNICIPAL,
+						voidCapacity: null,
+						voidCapacityUnitId: null,
+						maxAnnualThroughput: createMockDecimal(43),
+						maxAnnualThroughputUnitId: WASTE_UNIT_ID.LITRES
+					}
+				]
+			} as unknown as S62aCaseDbModel;
+
+			const result = s62aCaseToViewModel(mockDbCase);
+			const [item] = result.manageWasteTypes!;
+
+			assert.strictEqual(item.voidCapacity, undefined);
+			assert.strictEqual(item.voidCapacityUnitId, undefined);
+			assert.strictEqual(item[`maxAnnualThroughputUnitId_${WASTE_UNIT_ID.LITRES}`], '43');
+		});
+
+		it('returns an empty array when there are no waste types', () => {
+			const withEmpty = {
+				id: 'case-waste-6',
+				reference: 'S62A/2026/0049',
+				expectedSubmissionDate: mockDate,
+				WasteTypes: []
+			} as unknown as S62aCaseDbModel;
+
+			const withNone = {
+				id: 'case-waste-7',
+				reference: 'S62A/2026/0050',
+				expectedSubmissionDate: mockDate
+			} as unknown as S62aCaseDbModel;
+
+			assert.deepStrictEqual(s62aCaseToViewModel(withEmpty).manageWasteTypes, []);
+			assert.deepStrictEqual(s62aCaseToViewModel(withNone).manageWasteTypes, []);
 		});
 	});
 });

--- a/apps/manage/src/app/views/s62a/cases/view/view-model.ts
+++ b/apps/manage/src/app/views/s62a/cases/view/view-model.ts
@@ -98,6 +98,17 @@ export type S62aCaseDbModel = Prisma.S62aCaseGetPayload<{
 	include: typeof S62A_VIEW_SELECT_INCLUDE;
 }>;
 
+export interface WasteTypeItem {
+	id: string;
+	wasteTypeId?: string;
+	voidCapacity?: number;
+	voidCapacityUnitId?: string;
+	maxAnnualThroughput?: number;
+	maxAnnualThroughputUnitId?: string;
+	/// Conditional radio amounts, keyed as `<unitFieldName>_<unitId>`
+	[key: string]: unknown;
+}
+
 export interface S62aCaseViewModel {
 	id: string;
 	reference: string;
@@ -246,6 +257,11 @@ export interface S62aCaseViewModel {
 	issuesReportingPublishedDate?: Date;
 	siteVisitDate?: Date;
 	siteVisitTypeId?: string;
+
+	// Waste tab
+	wasteActivitiesDescription?: string | null;
+	isWasteManagementDevelopment?: YesNo;
+	manageWasteTypes?: WasteTypeItem[];
 }
 
 /**
@@ -258,7 +274,8 @@ const BOOLEAN_FIELDS = Object.freeze([
 	'bngExempt',
 	'hasAgent',
 	'eiaScreening',
-	'eiaScreeningOutcome'
+	'eiaScreeningOutcome',
+	'isWasteManagementDevelopment'
 ] as const);
 
 /**
@@ -276,7 +293,8 @@ const DIRECT_UNMAPPED_FIELDS = Object.freeze([
 	'lpaReference',
 	'listedBuildingReference',
 	'healthAndSafetyIssue',
-	'preApplicationReference'
+	'preApplicationReference',
+	'wasteActivitiesDescription'
 ] as const);
 
 /**
@@ -594,6 +612,23 @@ export function s62aCaseToViewModel(dbCase: S62aCaseDbModel): S62aCaseViewModel 
 		id: inspector.id,
 		inspectorId: inspector.User.idpUserId ?? undefined,
 		inspectorAllocatedDate: inspector.allocatedDate ?? undefined
+	}));
+
+	viewModel.manageWasteTypes = (dbCase.WasteTypes ?? []).map((wt) => ({
+		id: wt.id,
+		wasteTypeId: wt.wasteTypeId,
+		voidCapacity: wt.voidCapacity?.toNumber(),
+		voidCapacityUnitId: wt.voidCapacityUnitId ?? undefined,
+		maxAnnualThroughput: wt.maxAnnualThroughput?.toNumber(),
+		maxAnnualThroughputUnitId: wt.maxAnnualThroughputUnitId ?? undefined,
+		// The conditional radio stores each unit's amount under its own key, so the
+		// right input pre-fills on edit and the summary can find the value.
+		...(wt.voidCapacityUnitId && wt.voidCapacity
+			? { [`voidCapacityUnitId_${wt.voidCapacityUnitId}`]: String(wt.voidCapacity.toNumber()) }
+			: {}),
+		...(wt.maxAnnualThroughputUnitId && wt.maxAnnualThroughput
+			? { [`maxAnnualThroughputUnitId_${wt.maxAnnualThroughputUnitId}`]: String(wt.maxAnnualThroughput.toNumber()) }
+			: {})
 	}));
 
 	return viewModel;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@azure/storage-blob": "^12.33.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@ministryofjustice/frontend": "^9.0.0",
-        "@planning-inspectorate/dynamic-forms": "^3.15.4",
+        "@planning-inspectorate/dynamic-forms": "^3.15.5",
         "@prisma/adapter-mssql": "^7.9.1",
         "@prisma/client": "^7.9.1",
         "accessible-autocomplete": "^3.0.1",
@@ -1606,9 +1606,9 @@
       "link": true
     },
     "node_modules/@planning-inspectorate/dynamic-forms": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/@planning-inspectorate/dynamic-forms/-/dynamic-forms-3.15.4.tgz",
-      "integrity": "sha512-E7O+iCpnpunOUfMxybm29PPNZJ54EDp3VMZx2+bmTEUNy3RUJ6vJw+w5kQuwn5GcjBNT57WYLLyZx7Ij3GuDfA==",
+      "version": "3.15.5",
+      "resolved": "https://registry.npmjs.org/@planning-inspectorate/dynamic-forms/-/dynamic-forms-3.15.5.tgz",
+      "integrity": "sha512-vLEr/8hrAP6+vtLJBis05atEEt/CZGq3t+6NK9Iur1u2/WZxFjWlI48pjQcsmpbA9t2pdLNiSmAutCH/qSN6WA==",
       "dependencies": {
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@azure/storage-blob": "^12.33.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@ministryofjustice/frontend": "^9.0.0",
-    "@planning-inspectorate/dynamic-forms": "^3.15.4",
+    "@planning-inspectorate/dynamic-forms": "^3.15.5",
     "@prisma/adapter-mssql": "^7.9.1",
     "@prisma/client": "^7.9.1",
     "accessible-autocomplete": "^3.0.1",

--- a/packages/database/src/migrations/20260803132112_add_waste_tab/migration.sql
+++ b/packages/database/src/migrations/20260803132112_add_waste_tab/migration.sql
@@ -1,0 +1,65 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[S62aCase] ADD [isWasteManagementDevelopment] BIT,
+[wasteActivitiesDescription] NVARCHAR(1000);
+
+-- CreateTable
+CREATE TABLE [dbo].[S62aCaseWasteType] (
+    [id] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [S62aCaseWasteType_id_df] DEFAULT newid(),
+    [s62aCaseId] UNIQUEIDENTIFIER NOT NULL,
+    [wasteTypeId] NVARCHAR(1000) NOT NULL,
+    [voidCapacity] DECIMAL(18,2),
+    [voidCapacityUnitId] NVARCHAR(1000),
+    [maxAnnualThroughput] DECIMAL(18,2),
+    [maxAnnualThroughputUnitId] NVARCHAR(1000),
+    CONSTRAINT [S62aCaseWasteType_pkey] PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT [S62aCaseWasteType_s62aCaseId_wasteTypeId_key] UNIQUE NONCLUSTERED ([s62aCaseId],[wasteTypeId])
+);
+
+-- CreateTable
+CREATE TABLE [dbo].[S62aWasteType] (
+    [id] NVARCHAR(1000) NOT NULL,
+    [displayName] NVARCHAR(1000),
+    CONSTRAINT [S62aWasteType_pkey] PRIMARY KEY CLUSTERED ([id])
+);
+
+-- CreateTable
+CREATE TABLE [dbo].[S62aWasteUnit] (
+    [id] NVARCHAR(1000) NOT NULL,
+    [displayName] NVARCHAR(1000),
+    CONSTRAINT [S62aWasteUnit_pkey] PRIMARY KEY CLUSTERED ([id])
+);
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [S62aCaseWasteType_s62aCaseId_idx] ON [dbo].[S62aCaseWasteType]([s62aCaseId]);
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [S62aCaseWasteType_wasteTypeId_idx] ON [dbo].[S62aCaseWasteType]([wasteTypeId]);
+
+-- AddForeignKey
+ALTER TABLE [dbo].[S62aCaseWasteType] ADD CONSTRAINT [S62aCaseWasteType_s62aCaseId_fkey] FOREIGN KEY ([s62aCaseId]) REFERENCES [dbo].[S62aCase]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[S62aCaseWasteType] ADD CONSTRAINT [S62aCaseWasteType_wasteTypeId_fkey] FOREIGN KEY ([wasteTypeId]) REFERENCES [dbo].[S62aWasteType]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[S62aCaseWasteType] ADD CONSTRAINT [S62aCaseWasteType_voidCapacityUnitId_fkey] FOREIGN KEY ([voidCapacityUnitId]) REFERENCES [dbo].[S62aWasteUnit]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[S62aCaseWasteType] ADD CONSTRAINT [S62aCaseWasteType_maxAnnualThroughputUnitId_fkey] FOREIGN KEY ([maxAnnualThroughputUnitId]) REFERENCES [dbo].[S62aWasteUnit]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -274,6 +274,11 @@ model S62aCase {
   decisionOutcomeId String?
   DecisionOutcome   S62aDecisionOutcome? @relation(fields: [decisionOutcomeId], references: [id])
 
+  // Waste details
+  wasteActivitiesDescription   String?             @db.NVarChar(1000)
+  isWasteManagementDevelopment Boolean?
+  WasteTypes                   S62aCaseWasteType[]
+
   S62aEvent S62aEvent?
 
   Folders        Folder[]
@@ -368,6 +373,45 @@ model S62aEvent {
   siteVisitDate   DateTime?
   siteVisitTypeId String?
   SiteVisitType   S62aSiteVisitType? @relation(fields: [siteVisitTypeId], references: [id])
+}
+
+/// A waste type applicable to an S62A development, with its capacity and throughput
+model S62aCaseWasteType {
+  id         String   @id @default(dbgenerated("newid()")) @db.UniqueIdentifier
+  s62aCaseId String   @db.UniqueIdentifier
+  S62aCase   S62aCase @relation(fields: [s62aCaseId], references: [id], onUpdate: NoAction, onDelete: NoAction)
+
+  wasteTypeId String
+  WasteType   S62aWasteType @relation(fields: [wasteTypeId], references: [id], onUpdate: NoAction, onDelete: NoAction)
+
+  voidCapacity       Decimal?       @db.Decimal(18, 2)
+  voidCapacityUnitId String?
+  VoidCapacityUnit   S62aWasteUnit? @relation("voidCapacityUnit", fields: [voidCapacityUnitId], references: [id], onUpdate: NoAction, onDelete: NoAction)
+
+  maxAnnualThroughput       Decimal?       @db.Decimal(18, 2)
+  maxAnnualThroughputUnitId String?
+  MaxAnnualThroughputUnit   S62aWasteUnit? @relation("throughputUnit", fields: [maxAnnualThroughputUnitId], references: [id], onUpdate: NoAction, onDelete: NoAction)
+
+  @@unique([s62aCaseId, wasteTypeId])
+  @@index([s62aCaseId])
+  @@index([wasteTypeId])
+}
+
+/// The types of waste applicable to a development
+model S62aWasteType {
+  /// unique machine-readable name, not generated, e.g. "inert-landfill"
+  id             String              @id
+  displayName    String?
+  CaseWasteTypes S62aCaseWasteType[]
+}
+
+/// Units of measurement for waste capacity and throughput
+model S62aWasteUnit {
+  /// unique machine-readable name, not generated, e.g. "cubic-metres"
+  id                 String              @id
+  displayName        String?
+  VoidCapacityUsages S62aCaseWasteType[] @relation("voidCapacityUnit")
+  ThroughputUsages   S62aCaseWasteType[] @relation("throughputUnit")
 }
 
 /// The type of site visit taking place

--- a/packages/database/src/seed/data-static.ts
+++ b/packages/database/src/seed/data-static.ts
@@ -13,7 +13,9 @@ import {
 	PRE_APPLICATION_ADVICE,
 	OUTCOME_TYPES,
 	DECISION_OUTCOMES,
-	SITE_VISIT_TYPES
+	SITE_VISIT_TYPES,
+	WASTE_UNITS,
+	WASTE_TYPES
 } from './s62a/data-static.ts';
 
 export const APPLICATION_DECISION_OUTCOME = [
@@ -661,6 +663,14 @@ type UpsertReferenceDataArgs =
 	| {
 			delegate: Prisma.S62aSiteVisitTypeDelegate;
 			input: Prisma.S62aSiteVisitTypeCreateInput;
+	  }
+	| {
+			delegate: Prisma.S62aWasteTypeDelegate;
+			input: Prisma.S62aWasteTypeCreateInput;
+	  }
+	| {
+			delegate: Prisma.S62aWasteUnitDelegate;
+			input: Prisma.S62aWasteUnitCreateInput;
 	  };
 
 async function upsertReferenceData({ delegate, input }: UpsertReferenceDataArgs): Promise<void> {
@@ -798,6 +808,10 @@ export async function seedS62aStaticData(dbClient: PrismaClient) {
 	await Promise.all(
 		SITE_VISIT_TYPES.map((input) => upsertReferenceData({ delegate: dbClient.s62aSiteVisitType, input }))
 	);
+
+	await Promise.all(WASTE_UNITS.map((input) => upsertReferenceData({ delegate: dbClient.s62aWasteUnit, input })));
+
+	await Promise.all(WASTE_TYPES.map((input) => upsertReferenceData({ delegate: dbClient.s62aWasteType, input })));
 
 	console.log('S62A static data seed complete');
 }

--- a/packages/database/src/seed/s62a/data-static.ts
+++ b/packages/database/src/seed/s62a/data-static.ts
@@ -143,7 +143,8 @@ export const VIEW_TAB_ID = Object.freeze({
 	EVENT: 'event',
 	OUTCOME: 'outcome',
 	EIA: 'eia',
-	PRE_APPLICATION: 'pre-application'
+	PRE_APPLICATION: 'pre-application',
+	WASTE: 'waste'
 } as const);
 
 /**
@@ -196,6 +197,11 @@ export const VIEW_TABS = [
 	{
 		id: VIEW_TAB_ID.PRE_APPLICATION,
 		displayName: 'Pre-application'
+	},
+	{
+		id: VIEW_TAB_ID.WASTE,
+		displayName: 'Waste',
+		hide: PRE_APPLICATION_OR_APPLICATION_ID.PRE_APPLICATION
 	}
 ];
 
@@ -596,4 +602,97 @@ export const SITE_VISIT_TYPE_ID = Object.freeze({
 export const SITE_VISIT_TYPES = [
 	{ id: SITE_VISIT_TYPE_ID.ACCESS_REQUIRED, displayName: 'Access required site visit (ARSV)' },
 	{ id: SITE_VISIT_TYPE_ID.UNACCOMPANIED, displayName: 'Unaccompanied site visit (USV)' }
+];
+
+export const WASTE_UNIT_ID = Object.freeze({
+	CUBIC_METRES: 'cubic-metres',
+	TONNES: 'tonnes',
+	LITRES: 'litres'
+} as const);
+
+export const WASTE_UNITS = [
+	{ id: WASTE_UNIT_ID.CUBIC_METRES, displayName: 'Cubic metres' },
+	{ id: WASTE_UNIT_ID.TONNES, displayName: 'Tonnes for solid waste' },
+	{ id: WASTE_UNIT_ID.LITRES, displayName: 'Litres for liquid waste' }
+];
+
+export const WASTE_TYPE_ID = Object.freeze({
+	INERT_LANDFILL: 'inert-landfill',
+	NON_HAZARDOUS_LANDFILL: 'non-hazardous-landfill',
+	HAZARDOUS_LANDFILL: 'hazardous-landfill',
+	ENERGY_FROM_WASTE_INCINERATION: 'energy-from-waste-incineration',
+	OTHER_INCINERATION: 'other-incineration',
+	LANDFILL_GAS_GENERATION_PLANT: 'landfill-gas-generation-plant',
+	PYROLYSIS_GASIFICATION: 'pyrolysis-gasification',
+	METAL_RECYCLING_SITE: 'metal-recycling-site',
+	TRANSFER_STATIONS: 'transfer-stations',
+	MATERIAL_RECOVERY_RECYCLING: 'material-recovery-recycling-facilities',
+	HOUSEHOLD_CIVIC_AMENITY_SITES: 'household-civic-amenity-sites',
+	OPEN_WINDROW_COMPOSTING: 'open-windrow-composting',
+	IN_VESSEL_COMPOSTING: 'in-vessel-composting',
+	ANAEROBIC_DIGESTION: 'anaerobic-digestion',
+	COMBINED_MBT: 'combined-mbt',
+	SEWAGE_TREATMENT_WORKS: 'sewage-treatment-works',
+	OTHER_TREATMENT: 'other-treatment',
+	RECYCLING_FACILITIES_CDE: 'recycling-facilities-cde',
+	STORAGE_OF_WASTE: 'storage-of-waste',
+	OTHER_WASTE_MANAGEMENT: 'other-waste-management',
+	OTHER_DEVELOPMENTS: 'other-developments',
+	MUNICIPAL: 'municipal',
+	CONSTRUCTION_DEMOLITION_EXCAVATION: 'construction-demolition-excavation',
+	COMMERCIAL_AND_INDUSTRIAL: 'commercial-and-industrial',
+	HAZARDOUS: 'hazardous'
+} as const);
+
+export const WASTE_TYPES = [
+	{ id: WASTE_TYPE_ID.INERT_LANDFILL, displayName: 'Inert landfill' },
+	{ id: WASTE_TYPE_ID.NON_HAZARDOUS_LANDFILL, displayName: 'Non-hazardous landfill' },
+	{ id: WASTE_TYPE_ID.HAZARDOUS_LANDFILL, displayName: 'Hazardous landfill' },
+	{ id: WASTE_TYPE_ID.ENERGY_FROM_WASTE_INCINERATION, displayName: 'Energy from waste incineration' },
+	{ id: WASTE_TYPE_ID.OTHER_INCINERATION, displayName: 'Other incineration' },
+	{ id: WASTE_TYPE_ID.LANDFILL_GAS_GENERATION_PLANT, displayName: 'Landfill gas generation plant' },
+	{ id: WASTE_TYPE_ID.PYROLYSIS_GASIFICATION, displayName: 'Pyrolysis/gasification' },
+	{ id: WASTE_TYPE_ID.METAL_RECYCLING_SITE, displayName: 'Metal recycling site' },
+	{ id: WASTE_TYPE_ID.TRANSFER_STATIONS, displayName: 'Transfer stations' },
+	{
+		id: WASTE_TYPE_ID.MATERIAL_RECOVERY_RECYCLING,
+		displayName: 'Material recovery/recycling facilities (MRFs)'
+	},
+	{ id: WASTE_TYPE_ID.HOUSEHOLD_CIVIC_AMENITY_SITES, displayName: 'Household civic amenity sites' },
+	{ id: WASTE_TYPE_ID.OPEN_WINDROW_COMPOSTING, displayName: 'Open windrow composting' },
+	{ id: WASTE_TYPE_ID.IN_VESSEL_COMPOSTING, displayName: 'In-vessel composting' },
+	{ id: WASTE_TYPE_ID.ANAEROBIC_DIGESTION, displayName: 'Anaerobic digestion' },
+	{
+		id: WASTE_TYPE_ID.COMBINED_MBT,
+		displayName: 'Any combined mechanical, biological and/ or thermal treatment (MBT)'
+	},
+	{ id: WASTE_TYPE_ID.SEWAGE_TREATMENT_WORKS, displayName: 'Sewage treatment works' },
+	{ id: WASTE_TYPE_ID.OTHER_TREATMENT, displayName: 'Other treatment' },
+	{
+		id: WASTE_TYPE_ID.RECYCLING_FACILITIES_CDE,
+		displayName: 'Recycling facilities construction, demolition and excavation waste'
+	},
+	{ id: WASTE_TYPE_ID.STORAGE_OF_WASTE, displayName: 'Storage of waste' },
+	{ id: WASTE_TYPE_ID.OTHER_WASTE_MANAGEMENT, displayName: 'Other waste management' },
+	{ id: WASTE_TYPE_ID.OTHER_DEVELOPMENTS, displayName: 'Other developments' },
+	{ id: WASTE_TYPE_ID.MUNICIPAL, displayName: 'Municipal' },
+	{
+		id: WASTE_TYPE_ID.CONSTRUCTION_DEMOLITION_EXCAVATION,
+		displayName: 'Construction, demolition and excavation'
+	},
+	{ id: WASTE_TYPE_ID.COMMERCIAL_AND_INDUSTRIAL, displayName: 'Commercial and industrial' },
+	{ id: WASTE_TYPE_ID.HAZARDOUS, displayName: 'Hazardous' }
+];
+
+/**
+ * Waste types that skip the 'Total capacity of the void' question and go
+ * straight to maximum annual throughput.
+ *
+ * Any new waste type that should also skip that question must be added here.
+ */
+export const WASTE_TYPES_WITHOUT_VOID_CAPACITY: string[] = [
+	WASTE_TYPE_ID.MUNICIPAL,
+	WASTE_TYPE_ID.CONSTRUCTION_DEMOLITION_EXCAVATION,
+	WASTE_TYPE_ID.COMMERCIAL_AND_INDUSTRIAL,
+	WASTE_TYPE_ID.HAZARDOUS
 ];

--- a/packages/lib/forms/custom-components/index.ts
+++ b/packages/lib/forms/custom-components/index.ts
@@ -12,6 +12,11 @@ import {
 import type { CommonQuestionProps, QuestionProps, QuestionTypes } from '@planning-inspectorate/dynamic-forms';
 import HiddenRadioQuestion from './radio-with-hidden-options/question.ts';
 import ConditionalRadioQuestion from './conditional-radio/question.ts';
+import MultiConditionalRadioQuestion from './multi-conditional-radio/question.ts';
+import TableManageListQuestion from './manage-list/table/question.ts';
+import DefinedColumnsTableQuestion, {
+	type TableColumn
+} from './manage-list/table/defined-columns-list-table/question.ts';
 
 type CustomComponentTypes = (typeof CUSTOM_COMPONENTS)[keyof typeof CUSTOM_COMPONENTS];
 
@@ -121,6 +126,26 @@ type CustomMultiFieldInputQuestionProps = CrownCommonQuestionProps & {
 	)[];
 };
 
+type TableManageListQuestionProps = CrownCommonQuestionProps & {
+	type: typeof CUSTOM_COMPONENTS.MANAGE_LIST_TABLE;
+	titleSingular: string;
+	showAnswersInSummary?: boolean;
+	summaryLimit?: number;
+	hideRemoveOnLastItem?: boolean;
+	removalPrompt?: string;
+	emptyName?: string;
+	emptyNamePlural?: string;
+	hideCancel?: boolean;
+	hideBackLink?: boolean;
+	hideButtonsEmpty?: boolean;
+	warningText?: string;
+};
+
+type DefinedColumnsTableQuestionProps = Omit<TableManageListQuestionProps, 'type'> & {
+	type: typeof CUSTOM_COMPONENTS.DEFINED_COLUMNS_TABLE;
+	columns: TableColumn[];
+};
+
 export type CrownQuestionProps =
 	| QuestionProps
 	| RepresentationAttachmentsQuestionProps
@@ -130,7 +155,9 @@ export type CrownQuestionProps =
 	| CostsApplicationsCommentQuestionProps
 	| CustomManageListQuestionProps
 	| CustomMultiFieldInputQuestionProps
-	| DistressingContentQuestionProps;
+	| DistressingContentQuestionProps
+	| TableManageListQuestionProps
+	| DefinedColumnsTableQuestionProps;
 
 export const CUSTOM_COMPONENTS = Object.freeze({
 	REPRESENTATION_ATTACHMENTS: 'representation-attachments',
@@ -142,7 +169,10 @@ export const CUSTOM_COMPONENTS = Object.freeze({
 	CUSTOM_MULTI_FIELD_INPUT: 'custom-multi-field-input',
 	DISTRESSING_CONTENT: 'distressing-content',
 	RADIO_WITH_HIDDEN_OPTIONS: 'radio-with-hidden-options',
-	CONDITIONAL_RADIO: 'conditional-radio'
+	CONDITIONAL_RADIO: 'conditional-radio',
+	MULTI_CONDITIONAL_RADIO: 'multi-conditional-radio',
+	MANAGE_LIST_TABLE: 'manage-list-table',
+	DEFINED_COLUMNS_TABLE: 'defined-columns-table'
 } as const);
 
 export const CUSTOM_COMPONENT_CLASSES = Object.freeze({
@@ -155,5 +185,8 @@ export const CUSTOM_COMPONENT_CLASSES = Object.freeze({
 	[CUSTOM_COMPONENTS.CUSTOM_MULTI_FIELD_INPUT]: CustomMultiFieldInputQuestion,
 	[CUSTOM_COMPONENTS.DISTRESSING_CONTENT]: DistressingContentQuestion,
 	[CUSTOM_COMPONENTS.RADIO_WITH_HIDDEN_OPTIONS]: HiddenRadioQuestion,
-	[CUSTOM_COMPONENTS.CONDITIONAL_RADIO]: ConditionalRadioQuestion
+	[CUSTOM_COMPONENTS.CONDITIONAL_RADIO]: ConditionalRadioQuestion,
+	[CUSTOM_COMPONENTS.MULTI_CONDITIONAL_RADIO]: MultiConditionalRadioQuestion,
+	[CUSTOM_COMPONENTS.MANAGE_LIST_TABLE]: TableManageListQuestion,
+	[CUSTOM_COMPONENTS.DEFINED_COLUMNS_TABLE]: DefinedColumnsTableQuestion
 } as const);

--- a/packages/lib/forms/custom-components/manage-list/table/answer-summary-list.njk
+++ b/packages/lib/forms/custom-components/manage-list/table/answer-summary-list.njk
@@ -1,0 +1,32 @@
+{% macro listItem(item) %}
+	<li>
+		{% for value in item %}
+			{% if value.answer %}
+				{{ value.answer | safe }}{% if not loop.last %}<br>{% endif %}
+			{% endif %}
+		{% endfor %}
+	</li>
+{% endmacro %}
+
+{% if answers.length > limit %}
+	<div data-behaviour="toggle-list">
+		<ul class="govuk-list govuk-list--bullet">
+			{% for item in answers.slice(0, limit) %}
+				{{ listItem(item) }}
+			{% endfor %}
+		</ul>
+		{# Graceful degradation: JS unhides the toggle and hides the extra list on load #}
+		<button class="pins-button-link" hidden data-toggle>Show {{ answers.length - limit }} more</button>
+		<ul class="govuk-list govuk-list--bullet govuk-!-padding-top-4" data-show-more>
+			{% for item in answers.slice(limit) %}
+				{{ listItem(item) }}
+			{% endfor %}
+		</ul>
+	</div>
+{% else %}
+	<ul class="govuk-list {% if answers.length > 1 %}govuk-list--bullet{% endif %}">
+		{% for item in answers %}
+			{{ listItem(item) }}
+		{% endfor %}
+	</ul>
+{% endif %}

--- a/packages/lib/forms/custom-components/manage-list/table/confirm.njk
+++ b/packages/lib/forms/custom-components/manage-list/table/confirm.njk
@@ -1,0 +1,1 @@
+{% include "custom-components/manage-list/confirm.njk" %}

--- a/packages/lib/forms/custom-components/manage-list/table/defined-columns-list-table/question.test.ts
+++ b/packages/lib/forms/custom-components/manage-list/table/defined-columns-list-table/question.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import DefinedColumnsTableQuestion, { type TableColumn } from './question.ts';
+import DateQuestion from '@planning-inspectorate/dynamic-forms/src/components/date/question.js';
+import type { Question, QuestionViewModel } from '@planning-inspectorate/dynamic-forms/src/questions/question.js';
+
+/**
+ * formatItemAnswers is protected, so reach it through a narrow cast rather than
+ * widening the class's own visibility just for the test.
+ */
+type WithProtected = {
+	formatItemAnswers(answer: Record<string, unknown>): { question: string; answer: string }[];
+};
+
+describe('DefinedColumnsTableQuestion', () => {
+	let question: DefinedColumnsTableQuestion;
+	let mockViewModel: QuestionViewModel;
+
+	const formatItemAnswers = (answer: Record<string, unknown>) =>
+		(question as unknown as WithProtected).formatItemAnswers(answer);
+
+	beforeEach(() => {
+		question = new DefinedColumnsTableQuestion({
+			title: 'Defined Table',
+			fieldName: 'definedTable',
+			question: 'What details?',
+			titleSingular: 'Detail',
+			columns: [
+				{ header: 'Reference', fieldName: 'caseRef' },
+				{
+					header: 'Officer Name',
+					fieldName: 'officer',
+					format: (val: unknown) => `Formatted: ${val}`
+				},
+				{ header: 'Decision Date', fieldName: 'date', sortType: 'date' }
+			]
+		} as never);
+
+		question.section = {
+			questions: [
+				{
+					fieldName: 'caseRef',
+					formatAnswerForSummary: (_segment: string, _journey: unknown, val: string) => [{ value: val }]
+				},
+				{
+					fieldName: 'officer',
+					formatAnswerForSummary: (_segment: string, _journey: unknown, val: string) => [{ value: val }]
+				},
+				{
+					fieldName: 'date',
+					formatAnswerForSummary: (_segment: string, _journey: unknown, val: string) => [{ value: val }]
+				}
+			]
+		} as never;
+
+		mockViewModel = {
+			question: {
+				value: [{ id: '1', caseRef: 'ABC', officer: 'John', date: '2024-01-01' }],
+				firstQuestionUrl: 'ref-page'
+			},
+			originalUrl: '/my-url/',
+			util: {
+				trimTrailingSlash: (url: string) => url.replace(/\/$/, '')
+			}
+		} as unknown as QuestionViewModel;
+	});
+
+	describe('createHeaders()', () => {
+		it('should generate headers based on explicit columns plus Actions', () => {
+			const headers = question.createHeaders();
+
+			assert.strictEqual(headers.length, 4);
+			assert.strictEqual(headers[0].text, 'Reference');
+			assert.strictEqual(headers[1].text, 'Officer Name');
+			assert.strictEqual(headers[2].text, 'Decision Date');
+			assert.strictEqual(headers[3].text, 'Actions');
+			assert.strictEqual(headers[3].classes, 'govuk-!-width-one-quarter');
+		});
+
+		it('should add aria-sort to every column but Actions', () => {
+			const headers = question.createHeaders();
+
+			assert.deepStrictEqual(headers[0].attributes, { 'aria-sort': 'none' });
+			assert.strictEqual(headers[3].attributes, undefined);
+		});
+
+		it('should return only Actions when no columns are defined', () => {
+			question.columns = [];
+
+			const headers = question.createHeaders();
+
+			assert.strictEqual(headers.length, 1);
+			assert.strictEqual(headers[0].text, 'Actions');
+		});
+	});
+
+	describe('createRow()', () => {
+		it('should use the explicit format function when provided', () => {
+			const item = { id: '1', officer: 'Oscar' };
+
+			const cells = question.createRow(mockViewModel, item);
+
+			assert.strictEqual(cells[1].html, 'Formatted: Oscar');
+		});
+
+		it('should use the raw value when there is no formatter or linked question', () => {
+			question.section = { questions: [] } as never;
+			const item = { id: '1', caseRef: 'REF-001' };
+
+			const cells = question.createRow(mockViewModel, item);
+
+			assert.strictEqual(cells[0].html, 'REF-001');
+		});
+
+		it('should return an em-dash when the linked question is hidden', () => {
+			question.section!.questions[0].shouldDisplay = () => false;
+			const item = { id: '1', caseRef: 'HIDDEN' };
+
+			const cells = question.createRow(mockViewModel, item);
+
+			assert.strictEqual(cells[0].html, '-');
+		});
+
+		it('should fall back to a dash when the value is missing', () => {
+			const item = { id: '1' };
+
+			const cells = question.createRow(mockViewModel, item);
+
+			assert.strictEqual(cells[0].html, '-');
+		});
+
+		it('should append an actions cell after the column cells', () => {
+			const item = { id: 'item-9', caseRef: 'ABC' };
+
+			const cells = question.createRow(mockViewModel, item);
+
+			assert.strictEqual(cells.length, 4);
+			assert.ok(cells[3].html?.includes('href="/my-url/edit/item-9/ref-page"'));
+			assert.ok(cells[3].html?.includes('href="/my-url/remove/item-9/confirm"'));
+		});
+
+		it('should stringify a non-string raw value', () => {
+			question.section = { questions: [] } as never;
+			question.columns = [{ header: 'Count', fieldName: 'count' }];
+			const item = { id: '1', count: 42 };
+
+			const cells = question.createRow(mockViewModel, item);
+
+			assert.strictEqual(cells[0].html, '42');
+		});
+	});
+
+	describe('handleSorting()', () => {
+		it('should return a unix timestamp when the column sortType is date', () => {
+			const col = { header: 'Date', fieldName: 'date', sortType: 'date' } as TableColumn;
+
+			const result = question.handleSorting('', col, {} as Question, '2024-12-25');
+
+			assert.strictEqual(result, new Date('2024-12-25').getTime());
+		});
+
+		it('should fall through to the cell content when sortType is date but the value is empty', () => {
+			const col = { header: 'Date', fieldName: 'date', sortType: 'date' } as TableColumn;
+
+			const result = question.handleSorting('-', col, undefined, '');
+
+			assert.strictEqual(result, '-');
+		});
+
+		it('should parse the cell content when sortType is number', () => {
+			const col = { header: 'Capacity', fieldName: 'capacity', sortType: 'number' } as TableColumn;
+
+			const result = question.handleSorting('1000l', col, undefined, '1000');
+
+			assert.strictEqual(result, 1000);
+		});
+
+		it('should fall back to the cell content when a number cannot be parsed', () => {
+			const col = { header: 'Capacity', fieldName: 'capacity', sortType: 'number' } as TableColumn;
+
+			const result = question.handleSorting('-', col, undefined, undefined);
+
+			assert.strictEqual(result, '-');
+		});
+
+		it('should return a unix timestamp when the linked question is a DateQuestion', () => {
+			const col = { header: 'Date', fieldName: 'dob' } as TableColumn;
+			const dateQuestion = new DateQuestion({
+				fieldName: 'dob',
+				title: 'Date of birth',
+				question: 'What is the date of birth?'
+			} as never) as unknown as Question;
+
+			const result = question.handleSorting('01/01/2024', col, dateQuestion, '2024-01-01');
+
+			assert.strictEqual(result, new Date('01/01/2024').getTime());
+		});
+
+		it('should return the cell content as a fallback', () => {
+			const col = { header: 'Ref', fieldName: 'ref' } as TableColumn;
+
+			const result = question.handleSorting('ABC', col, {} as Question, 'ABC');
+
+			assert.strictEqual(result, 'ABC');
+		});
+	});
+
+	describe('formatItemAnswers()', () => {
+		it('should generate the summary list from the column definitions', () => {
+			const result = formatItemAnswers({ caseRef: 'REF-123', officer: 'John' });
+
+			assert.strictEqual(result.length, 3);
+			assert.strictEqual(result[0].question, 'Reference');
+			assert.strictEqual(result[0].answer, 'REF-123');
+			assert.strictEqual(result[1].question, 'Officer Name');
+			assert.strictEqual(result[1].answer, 'Formatted: John');
+		});
+
+		it('should show a dash for a column with no value', () => {
+			const result = formatItemAnswers({ caseRef: 'REF-123' });
+
+			assert.strictEqual(result[2].question, 'Decision Date');
+			assert.strictEqual(result[2].answer, '-');
+		});
+
+		it('should return an empty array when no columns are defined', () => {
+			question.columns = [];
+
+			assert.deepStrictEqual(formatItemAnswers({}), []);
+		});
+	});
+
+	describe('format() callback', () => {
+		it('should receive the raw value, the whole row and a getQuestion helper', () => {
+			let received: { value: unknown; row: Record<string, unknown>; linked?: Question } | undefined;
+
+			question.columns = [
+				{
+					header: 'Combined',
+					fieldName: 'officer',
+					format: (value, rowData, { getQuestion }) => {
+						received = { value, row: rowData, linked: getQuestion('caseRef') };
+						return 'ok';
+					}
+				}
+			];
+
+			const item = { id: '1', caseRef: 'ABC', officer: 'John' };
+			question.createRow(mockViewModel, item);
+
+			assert.strictEqual(received?.value, 'John');
+			assert.deepStrictEqual(received?.row, item);
+			assert.strictEqual(received?.linked?.fieldName, 'caseRef');
+		});
+	});
+});

--- a/packages/lib/forms/custom-components/manage-list/table/defined-columns-list-table/question.ts
+++ b/packages/lib/forms/custom-components/manage-list/table/defined-columns-list-table/question.ts
@@ -1,0 +1,196 @@
+import { DateQuestion } from '@planning-inspectorate/dynamic-forms';
+import type { CommonQuestionParams } from '@planning-inspectorate/dynamic-forms';
+import type { Journey } from '@planning-inspectorate/dynamic-forms/src/journey/journey.js';
+import type { Question, QuestionViewModel } from '@planning-inspectorate/dynamic-forms/src/questions/question.js';
+import TableManageListQuestion from '../question.ts';
+import type { TableHeadCell, TableManageListQuestionParameters, TableRowCell } from '../types.ts';
+
+export interface TableColumn {
+	header: string;
+	/** The item field this column reads. Also used to find the matching sub-question. */
+	fieldName: string;
+	/**
+	 * Builds the cell content. Takes priority over the sub-question's own
+	 * formatter, so a column can combine several fields.
+	 */
+	format?: (
+		value: unknown,
+		rowData: Record<string, unknown>,
+		params: {
+			getQuestion: (fieldName: string) => Question | undefined;
+			mockJourney: Journey;
+		}
+	) => string;
+	/** Defaults to sorting on the rendered cell content */
+	sortType?: 'date' | 'string' | 'number';
+}
+
+export type DefinedColumnsTableParams = TableManageListQuestionParameters &
+	CommonQuestionParams & {
+		columns: TableColumn[];
+	};
+
+/**
+ * A table manage list whose columns are declared explicitly rather than
+ * derived from the sub-questions.
+ *
+ * Each column either maps to a single field, or supplies a format() function
+ * so it can combine several - useful where an amount and its unit are stored
+ * separately but belong in one cell.
+ */
+export default class DefinedColumnsTableQuestion extends TableManageListQuestion {
+	columns: TableColumn[];
+
+	constructor(params: DefinedColumnsTableParams) {
+		super(params);
+		this.columns = params.columns ?? [];
+	}
+
+	/**
+	 * Creates headers from the columns parameter rather than the sub-questions
+	 */
+	override createHeaders(): TableHeadCell[] {
+		const headers: TableHeadCell[] = this.columns.map((col) => ({
+			text: col.header,
+			attributes: {
+				'aria-sort': 'none'
+			}
+		}));
+
+		headers.push({
+			text: 'Actions',
+			classes: 'govuk-!-width-one-quarter'
+		});
+
+		return headers;
+	}
+
+	/**
+	 * Creates a row, one cell per declared column
+	 */
+	override createRow(viewModel: QuestionViewModel, item: Record<string, unknown>): TableRowCell[] {
+		const cells: TableRowCell[] = this.columns.map((col) => {
+			const linkedQuestion = this.getQuestionByFieldName(col.fieldName);
+			const cellContent = this.getFormattedColumnValue(col, item, linkedQuestion, true);
+
+			return {
+				html: cellContent || '-',
+				classes: 'govuk-table__cell',
+				attributes: {
+					'data-sort-value': this.handleSorting(cellContent, col, linkedQuestion, item[col.fieldName])
+				}
+			};
+		});
+
+		cells.push({ html: this.generateActionsHtml(viewModel, item) });
+
+		return cells;
+	}
+
+	/**
+	 * Sorts on the rendered content, unless the value is a date, in which case
+	 * it needs converting to a timestamp so the order is chronological.
+	 */
+	handleSorting(
+		cellContent: string,
+		col: TableColumn,
+		linkedQuestion: Question | undefined,
+		rawValue: unknown
+	): string | number {
+		if (col.sortType === 'date' && rawValue) {
+			return new Date(rawValue as string | Date).getTime();
+		}
+
+		if (col.sortType === 'number') {
+			const numeric = parseFloat(cellContent);
+			return Number.isNaN(numeric) ? cellContent : numeric;
+		}
+
+		if (linkedQuestion instanceof DateQuestion) {
+			return new Date(cellContent).getTime();
+		}
+
+		return cellContent;
+	}
+
+	/**
+	 * Formats items for the tab summary list, using the columns rather than
+	 * the sub-questions so the summary matches the table.
+	 */
+	override formatItemAnswers(answer: Record<string, unknown>) {
+		if (this.columns.length === 0) {
+			return [];
+		}
+
+		return this.columns.map((col) => {
+			const linkedQuestion = this.getQuestionByFieldName(col.fieldName);
+
+			return {
+				question: col.header,
+				answer: this.getFormattedColumnValue(col, answer, linkedQuestion) || '-'
+			};
+		});
+	}
+
+	/**
+	 * Priority: the column's own formatter, then the linked question's
+	 * formatter, then the raw value.
+	 */
+	private getFormattedColumnValue(
+		col: TableColumn,
+		item: Record<string, unknown>,
+		linkedQuestion?: Question,
+		plain = false
+	): string {
+		const rawValue = item[col.fieldName];
+		const mockJourney = this.buildMockJourney(item);
+
+		if (col.format) {
+			return col.format(rawValue, item, {
+				mockJourney,
+				getQuestion: (fieldName: string) => this.getQuestionByFieldName(fieldName)
+			});
+		}
+
+		if (linkedQuestion) {
+			if (!this.shouldDisplayQuestion(linkedQuestion, item)) {
+				return '-';
+			}
+
+			// Table cells sit under a column header, so suppress the label and
+			// emphasis that the tab summary needs.
+			const q = linkedQuestion as Question & { plainFormatting?: boolean };
+			const previous = q.plainFormatting;
+			q.plainFormatting = plain;
+
+			try {
+				return linkedQuestion
+					.formatAnswerForSummary('', mockJourney, rawValue)
+					.map((a) => (typeof a.value === 'string' ? a.value : ''))
+					.filter(Boolean)
+					.join(', ');
+			} finally {
+				q.plainFormatting = previous;
+			}
+		}
+
+		if (rawValue === undefined || rawValue === null) {
+			return '-';
+		}
+
+		if (typeof rawValue === 'string') {
+			return rawValue;
+		}
+
+		if (typeof rawValue === 'number' || typeof rawValue === 'boolean') {
+			return String(rawValue);
+		}
+
+		return '-';
+	}
+
+	private getQuestionByFieldName(fieldName: string): Question | undefined {
+		const questions = (this.section?.questions ?? []) as Question[];
+		return questions.find((q) => q.fieldName === fieldName);
+	}
+}

--- a/packages/lib/forms/custom-components/manage-list/table/index.njk
+++ b/packages/lib/forms/custom-components/manage-list/table/index.njk
@@ -1,0 +1,74 @@
+{% extends layoutTemplate %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% block backLink %}
+	{% if not hideBackLink %}
+		{{ super() }}
+	{% endif %}
+{% endblock %}
+
+{% block dynQuestionContent %}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-full">
+			<form action="" method="post" novalidate>
+				{% if _csrf %}<input type="hidden" name="_csrf" value="{{ _csrf }}">{% endif %}
+
+				{# With no rows we show a placeholder and, optionally, hide the save/cancel buttons #}
+				{% set hasData = question.tableRows | length > 0 %}
+				{% set itemName = emptyName or (titleSingular | lower) %}
+				{% set itemNamePlural = emptyNamePlural or (itemName + "s") %}
+
+				<h1 class="govuk-heading-l">{{ question.question }}</h1>
+
+				{% if hasData and warningText %}
+					{{ govukWarningText({
+						text: warningText,
+						iconFallbackText: "Warning"
+					}) }}
+				{% endif %}
+
+				{% if hasData %}
+					{{ govukTable({
+						attributes: {
+							"data-module": "moj-sortable-table"
+						},
+						head: question.tableHead,
+						rows: question.tableRows
+					}) }}
+				{% else %}
+					<p class="govuk-body">Add one or more {{ itemNamePlural }}. No {{ itemName }} details have been added.</p>
+				{% endif %}
+
+				{{ govukButton({
+					text: addMoreButtonText,
+					href: util.trimTrailingSlash(originalUrl) + "/" + question.addAnotherLink,
+					classes: "" if (hideCancel and not hasData) else "govuk-button--secondary",
+					attributes: { "data-cy": "button-add-details" }
+				}) }}
+
+				{# Save and cancel are always shown, unless configured to appear only once there is data #}
+				{% if not hideButtonsEmpty or hasData %}
+					<div class="govuk-button-group">
+						{{ govukButton({
+							text: continueButtonText,
+							type: "submit",
+							attributes: { "data-cy": "button-save-and-continue" }
+						}) }}
+
+						{% if not hideCancel %}
+							{{ govukButton({
+								text: cancelButtonText,
+								href: backLinkUrl,
+								classes: "govuk-button--secondary",
+								attributes: { "data-cy": "button-cancel" }
+							}) }}
+						{% endif %}
+					</div>
+				{% endif %}
+			</form>
+		</div>
+	</div>
+{% endblock %}

--- a/packages/lib/forms/custom-components/manage-list/table/question.test.ts
+++ b/packages/lib/forms/custom-components/manage-list/table/question.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import TableManageListQuestion from './question.ts';
+import DateQuestion from '@planning-inspectorate/dynamic-forms/src/components/date/question.js';
+import type { Question, QuestionViewModel } from '@planning-inspectorate/dynamic-forms/src/questions/question.js';
+import type { Section } from '@planning-inspectorate/dynamic-forms';
+import type { Journey } from '@planning-inspectorate/dynamic-forms/src/journey/journey.js';
+
+type ActionLink = {
+	href?: string;
+	text?: string;
+	visuallyHiddenText?: string;
+};
+
+type SummaryListItem = {
+	key?: string;
+	value: string;
+	action?: unknown;
+};
+
+describe('TableManageListQuestion', () => {
+	let tableQuestion: TableManageListQuestion;
+	let mockViewModel: QuestionViewModel;
+
+	beforeEach(() => {
+		tableQuestion = new TableManageListQuestion({
+			title: 'Test Table',
+			fieldName: 'testTable',
+			titleSingular: 'Item',
+			question: 'What items do you want to add?'
+		} as any);
+
+		tableQuestion.section = {
+			questions: [
+				{ title: 'Name', viewData: { tableHeader: 'Full Name' }, fieldName: 'name' },
+				{ title: 'Date of Birth', fieldName: 'dob' }
+			]
+		} as unknown as Section;
+
+		mockViewModel = {
+			question: {
+				value: [
+					{ id: 'uuid-1', name: 'John Doe', dob: '1990-01-01' },
+					{ id: 'uuid-2', name: 'Jane Doe', dob: '1985-05-15' }
+				],
+				firstQuestionUrl: 'name-page'
+			},
+			originalUrl: '/my-url/',
+			util: {
+				trimTrailingSlash: (url: string) => url.replace(/\/$/, '')
+			}
+		} as unknown as QuestionViewModel;
+	});
+
+	describe('Constructor', () => {
+		it('should set the custom view folder', () => {
+			assert.strictEqual(tableQuestion.viewFolder, 'custom-components/manage-list/table');
+		});
+	});
+
+	describe('createHeaders()', () => {
+		it('should generate headers with aria-sort and an Actions column', () => {
+			const headers = tableQuestion.createHeaders();
+
+			assert.strictEqual(headers.length, 3);
+
+			assert.strictEqual(headers[0].text, 'Full Name');
+			assert.deepStrictEqual(headers[0].attributes, { 'aria-sort': 'none' });
+
+			assert.strictEqual(headers[1].text, 'Date of Birth');
+
+			assert.strictEqual(headers[2].text, 'Actions');
+			assert.strictEqual(headers[2].classes, 'govuk-!-width-one-quarter');
+		});
+	});
+
+	describe('createCell()', () => {
+		it('should return a dash if shouldDisplay returns false', () => {
+			const hiddenQuestion = {
+				fieldName: 'secret',
+				shouldDisplay: () => false
+			} as unknown as Question;
+
+			const result = tableQuestion.createCell(hiddenQuestion, { secret: 'hidden' });
+
+			assert.strictEqual(result.text, '-');
+			assert.strictEqual(result.html, undefined);
+		});
+
+		it('should render standard question values with text as sort value', () => {
+			const mockQuestion = {
+				fieldName: 'name',
+				formatAnswerForSummary: () => [{ value: 'John' }, { value: 'Doe' }]
+			} as unknown as Question;
+
+			const result = tableQuestion.createCell(mockQuestion, { name: 'John Doe' });
+
+			assert.strictEqual(result.html, 'John, Doe');
+			assert.strictEqual(result.classes, 'govuk-table__cell');
+			assert.deepStrictEqual(result.attributes, { 'data-sort-value': 'John, Doe' });
+		});
+
+		it('should convert DateQuestion values to a unix timestamp for sorting', () => {
+			const dateQuestion = new DateQuestion({
+				title: 'Date',
+				fieldName: 'dob',
+				question: 'What is the date of birth?'
+			} as any) as unknown as Question;
+
+			dateQuestion.formatAnswerForSummary = () => [{ value: '1990-01-01' }] as any;
+
+			const result = tableQuestion.createCell(dateQuestion, { dob: '1990-01-01' });
+
+			assert.strictEqual(result.html, '1990-01-01');
+			assert.strictEqual(result.attributes?.['data-sort-value'], new Date('1990-01-01').getTime());
+		});
+	});
+
+	describe('generateActionsHtml()', () => {
+		it('should generate correct edit and remove links with the originalUrl by default', () => {
+			const item = { id: 'item-123' };
+			const html = tableQuestion.generateActionsHtml(mockViewModel, item);
+
+			assert.ok(html.includes('href="/my-url/edit/item-123/name-page"'));
+			assert.ok(html.includes('href="/my-url/remove/item-123/confirm"'));
+			assert.ok(html.includes('Change<span class="govuk-visually-hidden"> row</span>'));
+			assert.ok(html.includes('Remove<span class="govuk-visually-hidden"> row</span>'));
+		});
+
+		it('should hide the remove link if hideRemoveOnLastItem is true and there is only 1 item left', () => {
+			tableQuestion.hideRemoveOnLastItem = true;
+			mockViewModel.question.value = [{ id: 'uuid-1', name: 'John Doe', dob: '1990-01-01' }];
+
+			const item = { id: 'uuid-1' };
+			const html = tableQuestion.generateActionsHtml(mockViewModel, item);
+
+			assert.ok(html.includes('href="/my-url/edit/uuid-1/name-page"'));
+			assert.strictEqual(html.includes('href="/my-url/remove/uuid-1/confirm"'), false);
+			assert.strictEqual(html.includes('Remove<span class="govuk-visually-hidden"> row</span>'), false);
+		});
+
+		it('should display the remove link if hideRemoveOnLastItem is true but there are multiple items', () => {
+			tableQuestion.hideRemoveOnLastItem = true;
+
+			const item = { id: 'uuid-1' };
+			const html = tableQuestion.generateActionsHtml(mockViewModel, item);
+
+			assert.ok(html.includes('href="/my-url/remove/uuid-1/confirm"'));
+		});
+
+		it('should display the remove link if there is only 1 item left but hideRemoveOnLastItem is false', () => {
+			tableQuestion.hideRemoveOnLastItem = false;
+			mockViewModel.question.value = [{ id: 'uuid-1', name: 'John Doe', dob: '1990-01-01' }];
+
+			const item = { id: 'uuid-1' };
+			const html = tableQuestion.generateActionsHtml(mockViewModel, item);
+
+			assert.ok(html.includes('href="/my-url/remove/uuid-1/confirm"'));
+		});
+	});
+
+	describe('addCustomDataToViewModel()', () => {
+		it('should populate viewModel with tableHead, tableRows, and button text', () => {
+			tableQuestion.section!.questions[0].shouldDisplay = () => true;
+			tableQuestion.section!.questions[1].shouldDisplay = () => true;
+
+			tableQuestion.section!.questions[0].formatAnswerForSummary = () => [{ value: 'Ans 1' } as SummaryListItem];
+			tableQuestion.section!.questions[1].formatAnswerForSummary = () => [{ value: 'Ans 2' } as SummaryListItem];
+
+			tableQuestion.addCustomDataToViewModel(mockViewModel);
+
+			assert.strictEqual(mockViewModel.continueButtonText, 'Save and continue');
+			assert.strictEqual(mockViewModel.addMoreButtonText, 'Add details');
+
+			assert.strictEqual(mockViewModel.question.tableHead?.length, 3);
+			assert.strictEqual(mockViewModel.question.tableRows?.length, 2);
+
+			assert.strictEqual(mockViewModel.question.tableRows[0].length, 3);
+			assert.strictEqual(mockViewModel.question.tableRows[0][0].html, 'Ans 1');
+		});
+
+		it('should throw an error if section is not set', () => {
+			tableQuestion.section = undefined as unknown as Section;
+
+			assert.throws(() => {
+				tableQuestion.addCustomDataToViewModel(mockViewModel);
+			}, /manage list section not set/);
+		});
+	});
+
+	describe('formatAnswerForSummary()', () => {
+		it('should return notStartedText when answer is an empty array', () => {
+			const mockJourney = {
+				getCurrentQuestionUrl: () => '/current-url'
+			} as unknown as Journey;
+			(tableQuestion as unknown as { notStartedText: string }).notStartedText = 'Not started yet';
+
+			const result = tableQuestion.formatAnswerForSummary('segment', mockJourney, []);
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].value, 'Not started yet');
+		});
+
+		it('should return notStartedText when answer is null', () => {
+			const mockJourney = {
+				getCurrentQuestionUrl: () => '/current-url'
+			} as unknown as Journey;
+			(tableQuestion as unknown as { notStartedText: string }).notStartedText = 'No items added';
+
+			const result = tableQuestion.formatAnswerForSummary('segment', mockJourney, null);
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].value, 'No items added');
+		});
+	});
+
+	describe('getAction()', () => {
+		it('should return an action with "Add" text when the answer array is empty', () => {
+			const mockJourney = {
+				getCurrentQuestionUrl: () => '/current-url'
+			} as unknown as Journey;
+
+			const result = tableQuestion.getAction('segment', mockJourney, []) as ActionLink;
+
+			assert.strictEqual(result?.text, 'Answer');
+			assert.strictEqual(result?.visuallyHiddenText, 'What items do you want to add?');
+		});
+
+		it('should return an action with "Change" text when the answer array has items', () => {
+			const mockJourney = {
+				getCurrentQuestionUrl: () => '/current-url'
+			} as unknown as Journey;
+
+			const result = tableQuestion.getAction('segment', mockJourney, [{ id: '123' }]) as ActionLink;
+
+			assert.strictEqual(result?.text, 'Change');
+			assert.strictEqual(result?.visuallyHiddenText, 'What items do you want to add?');
+		});
+
+		it('should return an action with "Add" text when the answer is null', () => {
+			const mockJourney = {
+				getCurrentQuestionUrl: () => '/current-url'
+			} as unknown as Journey;
+
+			const result = tableQuestion.getAction('segment', mockJourney, null) as ActionLink;
+
+			assert.strictEqual(result?.text, 'Answer');
+			assert.strictEqual(result?.visuallyHiddenText, 'What items do you want to add?');
+		});
+	});
+});

--- a/packages/lib/forms/custom-components/manage-list/table/question.ts
+++ b/packages/lib/forms/custom-components/manage-list/table/question.ts
@@ -1,0 +1,344 @@
+import { DateQuestion, ManageListQuestion } from '@planning-inspectorate/dynamic-forms';
+import type { CommonQuestionParams } from '@planning-inspectorate/dynamic-forms';
+import type { Journey } from '@planning-inspectorate/dynamic-forms/src/journey/journey.js';
+import type { JourneyResponse } from '@planning-inspectorate/dynamic-forms/src/journey/journey-response.js';
+import type { Section } from '@planning-inspectorate/dynamic-forms/src/section.js';
+import type { Question, QuestionViewModel } from '@planning-inspectorate/dynamic-forms/src/questions/question.js';
+import nunjucks from 'nunjucks';
+import type { Request } from 'express';
+import type { TableHeadCell, TableManageListQuestionParameters, TableRowCell } from './types.ts';
+
+type TableQuestionViewData = {
+	value?: Record<string, unknown>[];
+	firstQuestionUrl?: string;
+	tableHead?: TableHeadCell[];
+	tableRows?: TableRowCell[][];
+};
+
+/**
+ * A manage list rendered as a sortable table rather than a summary list.
+ *
+ * One column per sub-question, plus an actions column. For control over which
+ * columns appear and how cells are built, use DefinedColumnsTableQuestion.
+ *
+ * TODO: PEAS-XXX — this file carries a number of casts that only exist because
+ * dynamic-forms types several things as `any` or declares them differently from
+ * how the JavaScript behaves. Once those are fixed upstream the casts should be
+ * removed and getAction should return ActionView | ActionView[] | undefined like
+ * its parent. Each cast is commented at its site.
+ */
+export default class TableManageListQuestion extends ManageListQuestion {
+	viewFolder: string;
+	summaryLimit: number;
+	showAnswersInSummary: boolean;
+	hideRemoveOnLastItem: boolean;
+	confirmRemoveButtonText: string;
+	removalPrompt: string;
+
+	constructor(params: TableManageListQuestionParameters & CommonQuestionParams) {
+		super(params);
+
+		this.summaryLimit = params.summaryLimit ?? 2;
+		this.showAnswersInSummary = params.showAnswersInSummary ?? false;
+		this.hideRemoveOnLastItem = params.hideRemoveOnLastItem ?? false;
+		this.confirmRemoveButtonText = params.confirmRemoveButtonText || `Remove ${params.titleSingular?.toLowerCase()}`;
+		this.removalPrompt =
+			params.removalPrompt || `Are you sure you want to remove this ${params.titleSingular?.toLowerCase()}?`;
+
+		this.viewFolder = 'custom-components/manage-list/table';
+	}
+
+	/**
+	 * Override for parent.
+	 *
+	 * Only difference is that for payload we pass in the journey response answers.
+	 * This is because for manage list questions we don't have the data stored in
+	 * the body from an input like a regular question, so the body does not contain
+	 * anything useful and it won't repopulate the screen.
+	 */
+	checkForValidationErrors(
+		req: Request,
+		section: Section,
+		journey: Journey,
+		// The base declares this as the module namespace rather than the class,
+		// which is a JSDoc slip upstream. `never` keeps the override assignable.
+		manageListQuestion?: never
+	): QuestionViewModel | undefined {
+		const { originalUrl } = req;
+		const body = (req.body ?? {}) as {
+			errors?: Record<string, unknown>;
+			errorSummary?: unknown[];
+		};
+
+		const errors = body.errors ?? {};
+		const errorSummary = body.errorSummary ?? [];
+
+		if (Object.keys(errors).length > 0) {
+			return this.toViewModel({
+				// dynamic-forms' RouteParams is narrower than Express's ParamsDictionary
+				params: req.params as never,
+				section,
+				journey,
+				customViewData: {
+					errors,
+					errorSummary,
+					originalUrl
+				},
+				// Use stored answers instead of body for manage list repopulation
+				payload: journey.response.answers,
+				manageListQuestion
+			});
+		}
+	}
+
+	/**
+	 * Override to prepare table data (heads and rows)
+	 */
+	override addCustomDataToViewModel(viewModel: QuestionViewModel): void {
+		if (!this.section) {
+			throw new Error('Section not set for TableManageListQuestion');
+		}
+
+		super.addCustomDataToViewModel(viewModel);
+
+		this.addButtonText(viewModel);
+
+		// viewModel.question is typed `any` upstream
+		const question = viewModel.question as TableQuestionViewData;
+
+		question.tableHead = this.createHeaders();
+		question.tableRows = this.createRows(viewModel);
+
+		viewModel.confirmRemoveButtonText = this.confirmRemoveButtonText;
+		viewModel.removalPrompt = this.removalPrompt;
+	}
+
+	/**
+	 * Adds the text for the save, cancel and add buttons.
+	 *
+	 * At some point we may want to move this into the instantiation of the
+	 * classes so each one can have its own button text.
+	 */
+	private addButtonText(viewModel: QuestionViewModel): void {
+		viewModel.continueButtonText = this.viewData?.continueOnly ? 'Continue' : 'Save and continue';
+		viewModel.addMoreButtonText = 'Add details';
+		viewModel.cancelButtonText = 'Cancel';
+	}
+
+	/**
+	 * Creates the table rows
+	 */
+	private createRows(viewModel: QuestionViewModel): TableRowCell[][] {
+		const question = viewModel.question as TableQuestionViewData;
+		const answers = question.value ?? [];
+
+		return answers.map((item) => this.createRow(viewModel, item));
+	}
+
+	/**
+	 * Creates a table row based on the questions asked
+	 */
+	protected createRow(viewModel: QuestionViewModel, item: Record<string, unknown>): TableRowCell[] {
+		const questions = this.section?.questions ?? [];
+
+		const cells: TableRowCell[] = questions.map((question: Question) => this.createCell(question, item));
+
+		cells.push({ html: this.generateActionsHtml(viewModel, item) });
+
+		return cells;
+	}
+
+	/**
+	 * Creates the sortable table headers based on the questions asked
+	 */
+	createHeaders(): TableHeadCell[] {
+		const questions = (this.section?.questions ?? []) as Question[];
+
+		const headers: TableHeadCell[] = questions.map((question) => {
+			// viewData is typed `any` upstream
+			const viewData = question.viewData as { tableHeader?: string } | undefined;
+
+			return {
+				text: viewData?.tableHeader || question.title || question.question,
+				attributes: {
+					'aria-sort': 'none'
+				}
+			};
+		});
+
+		headers.push({
+			text: 'Actions',
+			// So that Actions always has enough room for its buttons
+			classes: 'govuk-!-width-one-quarter'
+		});
+
+		return headers;
+	}
+
+	createCell(question: Question, item: Record<string, unknown>): TableRowCell {
+		if (!this.shouldDisplayQuestion(question, item)) {
+			return { text: '-' };
+		}
+
+		const mockJourney = this.buildMockJourney(item);
+
+		const formatted = question.formatAnswerForSummary('', mockJourney, item[question.fieldName]);
+		const cellContent = formatted
+			.map((answer) => answer.value)
+			.filter((value): value is string => typeof value === 'string')
+			.join(', ');
+
+		// Most things sort by their cell content, but dates need converting to a timestamp
+		const sortValue = question instanceof DateQuestion ? new Date(cellContent).getTime() : cellContent;
+
+		return {
+			html: cellContent || '-',
+			classes: 'govuk-table__cell',
+			attributes: {
+				'data-sort-value': sortValue
+			}
+		};
+	}
+
+	/**
+	 * Generates the HTML for the actions cell containing the change and remove links
+	 */
+	generateActionsHtml(viewModel: QuestionViewModel, item: Record<string, unknown>): string {
+		const question = viewModel.question as TableQuestionViewData;
+		const util = viewModel.util as { trimTrailingSlash: (url: string) => string };
+		const originalUrl = viewModel.originalUrl as string;
+
+		const originalUrlTrimmed = util.trimTrailingSlash(originalUrl);
+
+		const itemId = typeof item.id === 'string' ? item.id : '';
+
+		const changeUrl = `${originalUrlTrimmed}/edit/${itemId}/${question.firstQuestionUrl}`;
+		const removeUrl = `${originalUrlTrimmed}/remove/${itemId}/confirm`;
+
+		const items = question.value;
+		const removeHtml =
+			items?.length === 1 && this.hideRemoveOnLastItem
+				? ''
+				: `
+					<li class="govuk-summary-list__actions-list-item">
+						<a class="govuk-link" href="${removeUrl}">
+							Remove<span class="govuk-visually-hidden"> row</span>
+						</a>
+					</li>
+				`;
+
+		return `
+			<ul class="govuk-summary-list__actions-list">
+				<li class="govuk-summary-list__actions-list-item">
+					<a class="govuk-link" href="${changeUrl}">
+						Change<span class="govuk-visually-hidden"> row</span>
+					</a>
+				</li>
+				${removeHtml}
+			</ul>`;
+	}
+
+	/**
+	 * Overrides parent. Behaves similarly, but passes a limit into the template
+	 * so the tab summary can hide and show items behind a toggle.
+	 */
+	formatAnswerForSummary(sectionSegment: string, journey: Journey, answer: unknown) {
+		const items = Array.isArray(answer) ? (answer as Record<string, unknown>[]) : null;
+
+		let formattedAnswer = this.notStartedText || 'Not started';
+
+		if (items && items.length) {
+			if (this.showAnswersInSummary) {
+				const answers = items.map((a) => this.formatItemAnswers(a));
+
+				formattedAnswer = nunjucks.render(`${this.viewFolder}/answer-summary-list.njk`, {
+					answers,
+					limit: this.summaryLimit
+				});
+			} else {
+				formattedAnswer = `${items.length} ${this.title}`;
+			}
+		}
+
+		return [
+			{
+				key: this.title ?? this.question,
+				value: formattedAnswer,
+				action: this.getAction(sectionSegment, journey, answer) as never
+			}
+		];
+	}
+
+	/**
+	 * Formats items to display in the tab summary list
+	 */
+	protected formatItemAnswers(answer: Record<string, unknown>) {
+		const questions = this.section?.questions ?? [];
+
+		if (questions.length === 0) {
+			return [];
+		}
+
+		const mockJourney = this.buildMockJourney(answer);
+
+		return questions
+			.filter((q: Question) => this.shouldDisplayQuestion(q, answer))
+			.map((q: Question) => ({
+				question: q.title,
+				answer: q
+					.formatAnswerForSummary('', mockJourney, answer[q.fieldName])
+					.map((a) => a.value)
+					.filter((value): value is string => typeof value === 'string')
+					.join(', ')
+			}));
+	}
+
+	/**
+	 * The base class declares shouldDisplay as taking no arguments, but it is
+	 * called with a JourneyResponse at runtime. Cast so the call typechecks.
+	 */
+	protected shouldDisplayQuestion(question: Question, answers: Record<string, unknown>): boolean {
+		const shouldDisplay = question.shouldDisplay as ((response: JourneyResponse) => boolean) | undefined;
+
+		if (!shouldDisplay) {
+			return true;
+		}
+
+		return shouldDisplay.call(question, this.buildMockResponse(answers));
+	}
+
+	/**
+	 * Sub-questions expect a journey, but within a manage list item the only
+	 * answers in scope are the item's own.
+	 */
+	protected buildMockJourney(answers: Record<string, unknown>): Journey {
+		return {
+			getCurrentQuestionUrl: () => '',
+			response: { answers },
+			answers
+		} as unknown as Journey;
+	}
+
+	/**
+	 * shouldDisplay expects a JourneyResponse, whose constructor takes no
+	 * arguments, so the shape is built by cast rather than instantiation.
+	 */
+	protected buildMockResponse(answers: Record<string, unknown>): JourneyResponse {
+		return { answers } as unknown as JourneyResponse;
+	}
+
+	/**
+	 * For an empty list, defer to the parent with null so the correct
+	 * "not started" text and add link are shown.
+	 *
+	 * TODO: PEAS-400 - should return ActionView | ActionView[] | undefined, but
+	 * that type does not resolve from the shipped declarations.
+	 */
+	getAction(sectionSegment: string, journey: Journey, answer: unknown): unknown {
+		if (Array.isArray(answer) && !answer.length) {
+			return super.getAction(sectionSegment, journey, null) as unknown;
+		}
+
+		return super.getAction(sectionSegment, journey, answer) as unknown;
+	}
+}

--- a/packages/lib/forms/custom-components/manage-list/table/types.ts
+++ b/packages/lib/forms/custom-components/manage-list/table/types.ts
@@ -1,0 +1,60 @@
+import type { Journey } from '@planning-inspectorate/dynamic-forms';
+
+export interface TableHeadCell {
+	text?: string;
+	html?: string;
+	format?: string;
+	classes?: string;
+	colspan?: number;
+	rowspan?: number;
+	attributes?: Record<string, unknown>;
+}
+
+export interface TableRowCell {
+	text?: string;
+	html?: string;
+	format?: string;
+	classes?: string;
+	colspan?: number;
+	rowspan?: number;
+	attributes?: Record<string, unknown>;
+}
+
+export interface TableManageListQuestionParameters {
+	titleSingular?: string;
+	showManageListQuestions?: boolean;
+	showAnswersInSummary?: boolean;
+	/** Number of items shown in the tab summary before the "Show more" toggle */
+	summaryLimit?: number;
+	hideRemoveOnLastItem?: boolean;
+	/** Singular noun used in the empty state, e.g. "waste type" */
+	emptyName?: string;
+	/** Plural form, where adding "s" is not correct */
+	emptyNamePlural?: string;
+	hideCancel?: boolean;
+	hideBackLink?: boolean;
+	/** Hide save/cancel until at least one item exists */
+	hideButtonsEmpty?: boolean;
+	/** Shown above the table when it has rows */
+	warningText?: string;
+	confirmRemoveButtonText?: string;
+	removalPrompt?: string;
+}
+
+export interface PreppedQuestion {
+	value: Record<string, unknown>;
+	question: string;
+	fieldName: string;
+	pageTitle: string;
+	description?: string;
+	html?: string;
+	firstQuestionUrl?: string;
+	shouldDisplay?: (params: { answers: Record<string, unknown> }) => boolean;
+	formatAnswerForSummary: (
+		sectionSegment: string,
+		journey: Journey,
+		answer: unknown
+	) => Array<{ key: string; value: string; action?: unknown }>;
+	tableHead?: TableHeadCell[];
+	tableRows?: TableRowCell[][];
+}

--- a/packages/lib/forms/custom-components/manage-list/table/validator.test.ts
+++ b/packages/lib/forms/custom-components/manage-list/table/validator.test.ts
@@ -1,0 +1,335 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import ManageListItemsCompleteValidator from './validator.ts';
+import type { JourneyResponse } from '@planning-inspectorate/dynamic-forms/src/journey/journey-response.js';
+import type ManageListQuestion from '@planning-inspectorate/dynamic-forms/src/components/manage-list/question.js';
+import { MANAGE_LIST_ACTIONS } from '@planning-inspectorate/dynamic-forms/src/components/manage-list/manage-list-actions.js';
+
+describe('ManageListItemsCompleteValidator', () => {
+	describe('validate()', () => {
+		it('should pass if the manage list has no items (empty array)', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				childName: 'Enter a name'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: { questions: [] }
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: { myList: [] }
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 0);
+		});
+
+		it('should pass if all required fields are present and valid', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				childName: 'Enter a name',
+				childAge: 'Enter an age'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [
+						{ fieldName: 'childName', shouldDisplay: () => true },
+						{ fieldName: 'childAge', shouldDisplay: () => true }
+					]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [
+						{ childName: 'John', childAge: 25 },
+						{ childName: 'Jane', childAge: 30 }
+					]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 0);
+		});
+
+		it('should fail and return the mapped error message if a required field is empty', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				childName: 'Child name'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [{ fieldName: 'childName', shouldDisplay: () => true }]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [{ childName: 'John' }, { childName: '' }]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 1);
+			assert.strictEqual(result.context.errors[0].msg, "Add 'Child name'");
+		});
+
+		it('should pass if a field is missing BUT shouldDisplay returns false (conditionally hidden)', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				childName: 'child name'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [{ fieldName: 'childName', shouldDisplay: () => false }]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [{}]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 0);
+		});
+
+		it('should aggregate and deduplicate multiple errors across rows and fields', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				childName: 'Name',
+				childAge: 'Age'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [
+						{ fieldName: 'childName', shouldDisplay: () => true },
+						{ fieldName: 'childAge', shouldDisplay: () => true }
+					]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [
+						{ childName: '', childAge: 25 },
+						{ childName: 'Jane', childAge: null },
+						{ childName: '', childAge: undefined }
+					]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 1);
+			assert.strictEqual(result.context.errors[0].msg, "Add 'Name', 'Age'");
+		});
+
+		it('should fail if the saved value is an object but all its values are empty (e.g. empty address)', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				childAddress: 'Address'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [{ fieldName: 'childAddress', shouldDisplay: () => true }]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [{ childAddress: { line1: '', postcode: null } }]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 1);
+			assert.strictEqual(result.context.errors[0].msg, "Add 'Address'");
+		});
+
+		it('should pass if at least one field in an OR group (|) is filled', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				'firstName|lastName': 'Name'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [
+						{ fieldName: 'firstName', shouldDisplay: () => true },
+						{ fieldName: 'lastName', shouldDisplay: () => true }
+					]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [
+						{ firstName: 'John', lastName: '' },
+						{ firstName: '', lastName: 'Doe' }
+					]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 0);
+		});
+
+		it('should fail if all visible fields in an OR group (|) are empty', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				'firstName|lastName': 'Name'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [
+						{ fieldName: 'firstName', shouldDisplay: () => true },
+						{ fieldName: 'lastName', shouldDisplay: () => true }
+					]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [{ firstName: '', lastName: null }]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 1);
+			assert.strictEqual(result.context.errors[0].msg, "Add 'Name'");
+		});
+
+		it('should correctly handle OR groups (|) when some fields are conditionally hidden', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				'firstName|lastName': 'Name'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [
+						// firstName is hidden, so it shouldn't count towards the OR logic at all
+						{ fieldName: 'firstName', shouldDisplay: () => false },
+						{ fieldName: 'lastName', shouldDisplay: () => true }
+					]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [
+						// Even though firstName has a value, it is hidden so it doesn't count
+						// and this should fail beccause there is no lastName
+						{ firstName: 'Ghost Value', lastName: '' }
+					]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 1);
+			assert.strictEqual(result.context.errors[0].msg, "Add 'Name'");
+		});
+
+		it('should pass an OR group (|) if all fields in the group are conditionally hidden', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				'firstName|lastName': 'Name'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [
+						{ fieldName: 'firstName', shouldDisplay: () => false },
+						{ fieldName: 'lastName', shouldDisplay: () => false }
+					]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [{ firstName: '', lastName: '' }]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {} };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 0);
+		});
+
+		it('should pass if request is a REMOVE even if the journey is incomplete / failing', async () => {
+			const validator = new ManageListItemsCompleteValidator({
+				'firstName|lastName': 'Enter a name'
+			});
+
+			const mockQuestion = {
+				fieldName: 'myList',
+				section: {
+					questions: [
+						{ fieldName: 'firstName', shouldDisplay: () => true },
+						{ fieldName: 'lastName', shouldDisplay: () => true }
+					]
+				}
+			} as unknown as ManageListQuestion;
+
+			const mockJourneyResponse = {
+				answers: {
+					myList: [{ firstName: '', lastName: null }]
+				}
+			} as unknown as JourneyResponse;
+
+			const validationChain = validator.validate(mockQuestion, mockJourneyResponse);
+			const req = { body: {}, params: { manageListAction: MANAGE_LIST_ACTIONS.REMOVE } };
+
+			const result = await validationChain.run(req);
+
+			assert.strictEqual(result.context.errors.length, 0);
+		});
+	});
+});

--- a/packages/lib/forms/custom-components/manage-list/table/validator.ts
+++ b/packages/lib/forms/custom-components/manage-list/table/validator.ts
@@ -1,0 +1,126 @@
+import { body } from 'express-validator';
+import BaseValidator from '@planning-inspectorate/dynamic-forms/src/validator/base-validator.js';
+import type ManageListQuestion from '@planning-inspectorate/dynamic-forms/src/components/manage-list/question.js';
+import { MANAGE_LIST_ACTIONS } from '@planning-inspectorate/dynamic-forms/src/components/manage-list/manage-list-actions.js';
+import type { JourneyResponse } from '@planning-inspectorate/dynamic-forms/src/journey/journey-response.js';
+import type { Question } from '@planning-inspectorate/dynamic-forms/src/questions/question.js';
+
+/**
+ * Validator for manage list questions.
+ *
+ * Given a map of required fields, checks that every row in the list has an
+ * answer for each. Rows are only checked against fields that are currently
+ * visible, so conditionally hidden sub-questions do not block a save.
+ *
+ * A key may name a single field ('contactName'), or several OR'd together
+ * ('firstName|lastName') where at least one must be answered.
+ */
+export default class ManageListItemsCompleteValidator extends BaseValidator {
+	requiredFields: Record<string, string>;
+
+	constructor(requiredFields: Record<string, string> = {}) {
+		super();
+		this.requiredFields = requiredFields;
+	}
+
+	/**
+	 * Entry point, called on submit of the check page.
+	 *
+	 * Skipped during a remove, so an incomplete row can always be deleted.
+	 */
+	validate(questionObj: ManageListQuestion, journeyResponse: JourneyResponse) {
+		return body().custom((_, { req }) => {
+			if (req.params?.manageListAction === MANAGE_LIST_ACTIONS.REMOVE) {
+				return true;
+			}
+
+			const answers = journeyResponse?.answers as Record<string, unknown> | undefined;
+			const listItems = (answers?.[questionObj.fieldName] as Record<string, unknown>[]) ?? [];
+
+			if (listItems.length === 0) {
+				return true;
+			}
+
+			const questions = (questionObj.section?.questions ?? []) as Question[];
+			const allErrors = this.getValidationErrors(listItems, questions);
+
+			if (allErrors.length > 0) {
+				const dedupedErrors = [...new Set(allErrors)];
+				throw new Error(`Add ${dedupedErrors.map((e) => `'${e}'`).join(', ')}`);
+			}
+
+			return true;
+		});
+	}
+
+	/**
+	 * Collects errors across every row
+	 */
+	private getValidationErrors(listItems: Record<string, unknown>[], questions: Question[]): string[] {
+		return listItems.flatMap((item) => this.validateSingleItem(item, questions));
+	}
+
+	/**
+	 * Checks one row against each required field or OR group
+	 */
+	private validateSingleItem(item: Record<string, unknown>, questions: Question[]): string[] {
+		const itemErrors: string[] = [];
+
+		for (const [key, customErrorMessage] of Object.entries(this.requiredFields)) {
+			const fieldNames = key.split('|');
+
+			const visibleFields = fieldNames.filter((fieldName) => {
+				const subQuestion = questions.find((q: Question) => q.fieldName === fieldName);
+				return subQuestion ? this.shouldDisplayQuestion(subQuestion, item) : true;
+			});
+
+			// Every field in this group is conditionally hidden, so nothing to require
+			if (visibleFields.length === 0) {
+				continue;
+			}
+
+			const areAllVisibleFieldsEmpty = visibleFields.every((fieldName) => this.isEmpty(item[fieldName]));
+
+			if (areAllVisibleFieldsEmpty) {
+				itemErrors.push(customErrorMessage);
+			}
+		}
+
+		return itemErrors;
+	}
+
+	/**
+	 * The base Question type declares shouldDisplay as taking no arguments, but
+	 * it is called with a JourneyResponse at runtime. Cast so the call typechecks.
+	 */
+	private shouldDisplayQuestion(question: Question, answers: Record<string, unknown>): boolean {
+		const shouldDisplay = question.shouldDisplay as ((response: JourneyResponse) => boolean) | undefined;
+
+		if (!shouldDisplay) {
+			return true;
+		}
+
+		return shouldDisplay.call(question, { answers } as unknown as JourneyResponse);
+	}
+
+	/**
+	 * Checks the various shapes an unanswered value can take
+	 */
+	private isEmpty(value: unknown): boolean {
+		if (value === undefined || value === null) return true;
+		if (typeof value === 'string' && value.trim() === '') return true;
+		if (Array.isArray(value)) return value.length === 0;
+
+		// A Date is an object, so without this it would fall to the check below
+		// and be treated as empty
+		if (value instanceof Date) {
+			return isNaN(value.getTime());
+		}
+
+		if (typeof value === 'object') {
+			return Object.values(value as Record<string, unknown>).every((val) => this.isEmpty(val));
+		}
+
+		return false;
+	}
+}

--- a/packages/lib/forms/custom-components/multi-conditional-radio/multi-conditional-numeric-validator.test.ts
+++ b/packages/lib/forms/custom-components/multi-conditional-radio/multi-conditional-numeric-validator.test.ts
@@ -1,0 +1,148 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { validationResult } from 'express-validator';
+import MultiConditionalNumericValidator from './multi-conditional-numeric-validator.ts';
+import type { OptionsQuestion } from '@planning-inspectorate/dynamic-forms';
+
+describe('MultiConditionalNumericValidator', () => {
+	const questionObj = {
+		fieldName: 'voidCapacityUnitId',
+		options: [
+			{ text: 'Cubic metres', value: 'cubic-metres', conditional: { fieldName: 'cubic-metres' } },
+			{ text: 'Tonnes', value: 'tonnes', conditional: { fieldName: 'tonnes' } },
+			{ text: 'Litres', value: 'litres', conditional: { fieldName: 'litres' } }
+		]
+	} as unknown as OptionsQuestion;
+
+	const buildValidator = () =>
+		new MultiConditionalNumericValidator({
+			regexMessage: 'Total capacity of the void must be a number'
+		});
+
+	const run = async (body: Record<string, unknown>, question: OptionsQuestion = questionObj) => {
+		const req = { body };
+		const chains = buildValidator().validate(question);
+
+		for (const chain of chains) {
+			await chain.run(req as never);
+		}
+
+		return validationResult(req as never);
+	};
+
+	it('passes when the selected unit has a whole number', async () => {
+		const result = await run({
+			voidCapacityUnitId: 'tonnes',
+			voidCapacityUnitId_tonnes: '55'
+		});
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('passes when the selected unit has a decimal', async () => {
+		const result = await run({
+			voidCapacityUnitId: 'litres',
+			voidCapacityUnitId_litres: '12.5'
+		});
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('fails when the selected unit has a non-numeric value', async () => {
+		const result = await run({
+			voidCapacityUnitId: 'tonnes',
+			voidCapacityUnitId_tonnes: 'abc'
+		});
+
+		assert.strictEqual(result.isEmpty(), false);
+
+		const errors = result.mapped();
+		assert.strictEqual(errors['voidCapacityUnitId_tonnes'].msg, 'Total capacity of the void must be a number');
+	});
+
+	it('ignores non-numeric values in the units that were not selected', async () => {
+		// Hidden reveals still submit their inputs, so all three arrive on every post
+		const result = await run({
+			voidCapacityUnitId: 'tonnes',
+			'voidCapacityUnitId_cubic-metres': 'nonsense',
+			voidCapacityUnitId_tonnes: '55',
+			voidCapacityUnitId_litres: 'also nonsense'
+		});
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('does not report an empty value, leaving that to ConditionalRequiredValidator', async () => {
+		const result = await run({
+			voidCapacityUnitId: 'tonnes',
+			voidCapacityUnitId_tonnes: ''
+		});
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('passes when no unit was selected', async () => {
+		const result = await run({
+			voidCapacityUnitId_tonnes: 'abc'
+		});
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('rejects a negative number', async () => {
+		const result = await run({
+			voidCapacityUnitId: 'tonnes',
+			voidCapacityUnitId_tonnes: '-5'
+		});
+
+		assert.strictEqual(result.isEmpty(), false);
+	});
+
+	it('rejects a value with a thousands separator', async () => {
+		const result = await run({
+			voidCapacityUnitId: 'tonnes',
+			voidCapacityUnitId_tonnes: '1,000'
+		});
+
+		assert.strictEqual(result.isEmpty(), false);
+	});
+
+	it('honours a custom regex', async () => {
+		const validator = new MultiConditionalNumericValidator({
+			regex: /^\d+$/,
+			regexMessage: 'Must be a whole number'
+		});
+
+		const req = { body: { voidCapacityUnitId: 'tonnes', voidCapacityUnitId_tonnes: '12.5' } };
+		for (const chain of validator.validate(questionObj)) {
+			await chain.run(req as never);
+		}
+
+		const result = validationResult(req as never);
+		assert.strictEqual(result.isEmpty(), false);
+		assert.strictEqual(result.mapped()['voidCapacityUnitId_tonnes'].msg, 'Must be a whole number');
+	});
+
+	it('builds no chains when no option has a conditional', async () => {
+		const plainQuestion = {
+			fieldName: 'someRadio',
+			options: [
+				{ text: 'Yes', value: 'yes' },
+				{ text: 'No', value: 'no' }
+			]
+		} as unknown as OptionsQuestion;
+
+		const chains = buildValidator().validate(plainQuestion);
+
+		assert.strictEqual(chains.length, 0);
+	});
+
+	it('handles an array value, as submitted by checkboxes', async () => {
+		const result = await run({
+			voidCapacityUnitId: ['tonnes'],
+			voidCapacityUnitId_tonnes: 'abc'
+		});
+
+		assert.strictEqual(result.isEmpty(), false);
+	});
+});

--- a/packages/lib/forms/custom-components/multi-conditional-radio/multi-conditional-numeric-validator.ts
+++ b/packages/lib/forms/custom-components/multi-conditional-radio/multi-conditional-numeric-validator.ts
@@ -1,0 +1,60 @@
+import { body, type ValidationChain } from 'express-validator';
+import BaseValidator from '@planning-inspectorate/dynamic-forms/src/validator/base-validator.js';
+import type { OptionsQuestion, Option } from '@planning-inspectorate/dynamic-forms';
+
+export type MultiConditionalNumericValidatorParams = {
+	/** Pattern the revealed value must match. Defaults to a positive number. */
+	regex?: RegExp;
+	/** Error shown when the value does not match the pattern. */
+	regexMessage: string;
+};
+
+/**
+ * Enforces that the revealed input for the selected radio option is numeric.
+ *
+ * Complements ConditionalRequiredValidator, which already handles the
+ * "must not be empty" case for every conditional option. Only the input
+ * belonging to the selected option is checked - hidden reveals still submit
+ * their (empty) values, so unconditional validation would fail them all.
+ */
+export class MultiConditionalNumericValidator extends BaseValidator {
+	private regex: RegExp;
+	private regexMessage: string;
+
+	constructor({ regex = /^\d+(\.\d+)?$/, regexMessage }: MultiConditionalNumericValidatorParams) {
+		super();
+		this.regex = regex;
+		this.regexMessage = regexMessage;
+	}
+
+	validate(questionObj: OptionsQuestion): ValidationChain[] {
+		return questionObj.options.reduce<ValidationChain[]>((schema, option) => {
+			if (option.conditional) {
+				const fieldName = this.getConditionalFieldName(questionObj, option);
+
+				schema.push(
+					body(fieldName)
+						.if(this.isValueIncluded(questionObj, option.value))
+						// skip when empty - ConditionalRequiredValidator reports that case
+						.if(body(fieldName).notEmpty())
+						.matches(this.regex)
+						.withMessage(this.regexMessage)
+				);
+			}
+			return schema;
+		}, []);
+	}
+
+	private getConditionalFieldName(questionObj: OptionsQuestion, option: Option): string {
+		return `${questionObj.fieldName}_${option.conditional!.fieldName}`;
+	}
+
+	private isValueIncluded(questionObj: OptionsQuestion, value: string): ValidationChain {
+		return body(questionObj.fieldName).custom((existingValues) => {
+			const values = Array.isArray(existingValues) ? existingValues : [existingValues];
+			return values.includes(value);
+		});
+	}
+}
+
+export default MultiConditionalNumericValidator;

--- a/packages/lib/forms/custom-components/multi-conditional-radio/question.test.ts
+++ b/packages/lib/forms/custom-components/multi-conditional-radio/question.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import MultiConditionalRadioQuestion, { type MultiConditionalRadioQuestionProps } from './question.ts';
+import { JourneyResponse, type Journey } from '@planning-inspectorate/dynamic-forms';
+
+let mockJourney: Journey;
+let question: MultiConditionalRadioQuestion;
+
+const questionParams = {
+	title: 'Total capacity of void',
+	question: 'What is the total capacity of the void?',
+	fieldName: 'voidCapacityUnitId',
+	summaryLabel: 'Capacity',
+	summarySuffixes: {
+		'cubic-metres': 'm³',
+		tonnes: 't',
+		litres: 'l'
+	},
+	options: [
+		{ text: 'Cubic metres', value: 'cubic-metres', conditional: { fieldName: 'cubic-metres' } },
+		{ text: 'Tonnes for solid waste', value: 'tonnes', conditional: { fieldName: 'tonnes' } },
+		{ text: 'Litres for liquid waste', value: 'litres', conditional: { fieldName: 'litres' } }
+	]
+};
+
+const buildQuestion = (overrides: Record<string, unknown> = {}) => {
+	const q = new MultiConditionalRadioQuestion({
+		...questionParams,
+		...overrides
+	} as unknown as MultiConditionalRadioQuestionProps);
+
+	q.getAction = () => ({ href: '#', text: 'Change' });
+
+	return q;
+};
+
+const withAnswers = (answers: Record<string, unknown>) =>
+	({
+		response: { answers } as unknown as JourneyResponse
+	}) as unknown as Journey;
+
+describe('MultiConditionalRadioQuestion', () => {
+	beforeEach(() => {
+		mockJourney = withAnswers({});
+		question = buildQuestion();
+	});
+
+	describe('constructor', () => {
+		it('defaults boldSummaryValue and plainFormatting to false', () => {
+			assert.strictEqual(question.boldSummaryValue, false);
+			assert.strictEqual(question.plainFormatting, false);
+		});
+
+		it('stores the summary label and suffixes', () => {
+			assert.strictEqual(question.summaryLabel, 'Capacity');
+			assert.strictEqual(question.summarySuffixes?.tonnes, 't');
+		});
+	});
+
+	describe('conditionalAnswerKey', () => {
+		it('prefixes the conditional field name with the question field name', () => {
+			assert.strictEqual(question.conditionalAnswerKey('tonnes'), 'voidCapacityUnitId_tonnes');
+		});
+	});
+
+	describe('formatAnswerForSummary', () => {
+		it('combines the label, the revealed value and the unit suffix', () => {
+			mockJourney = withAnswers({ voidCapacityUnitId_tonnes: '55' });
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'tonnes');
+
+			assert.strictEqual(result[0].value, 'Capacity: 55t');
+			assert.strictEqual(result[0].key, 'Total capacity of void');
+		});
+
+		it('falls back to the option text as the label when none is given', () => {
+			question = buildQuestion({ summaryLabel: undefined });
+			mockJourney = withAnswers({ voidCapacityUnitId_litres: '12' });
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'litres');
+
+			assert.strictEqual(result[0].value, 'Litres for liquid waste: 12l');
+		});
+
+		it('omits the suffix when the option has none configured', () => {
+			question = buildQuestion({ summarySuffixes: undefined });
+			mockJourney = withAnswers({ voidCapacityUnitId_tonnes: '55' });
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'tonnes');
+
+			assert.strictEqual(result[0].value, 'Capacity: 55');
+		});
+
+		it('shows only the option text when the revealed value is missing', () => {
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'tonnes');
+
+			assert.strictEqual(result[0].value, 'Tonnes for solid waste');
+		});
+
+		it('reads only the key belonging to the selected option', () => {
+			// Hidden reveals still submit their inputs, so all three arrive
+			mockJourney = withAnswers({
+				'voidCapacityUnitId_cubic-metres': '999',
+				voidCapacityUnitId_tonnes: '55',
+				voidCapacityUnitId_litres: '12'
+			});
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'tonnes');
+
+			assert.strictEqual(result[0].value, 'Capacity: 55t');
+		});
+
+		it('shows a dash when no option is selected', () => {
+			const result = question.formatAnswerForSummary('segment', mockJourney, undefined);
+
+			assert.strictEqual(result[0].value, '-');
+		});
+
+		it('shows a dash when the answer matches no option', () => {
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'not-a-unit');
+
+			assert.strictEqual(result[0].value, '-');
+		});
+
+		it('works for an option with no conditional at all', () => {
+			question = buildQuestion({
+				summaryLabel: undefined,
+				options: [{ text: 'Inert landfill', value: 'inert-landfill' }]
+			});
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'inert-landfill');
+
+			assert.strictEqual(result[0].value, 'Inert landfill');
+		});
+	});
+
+	describe('plainFormatting', () => {
+		it('drops the label but keeps the value and suffix', () => {
+			mockJourney = withAnswers({ voidCapacityUnitId_tonnes: '55' });
+			question.plainFormatting = true;
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'tonnes');
+
+			assert.strictEqual(result[0].value, '55t');
+		});
+
+		it('suppresses the bold wrapper', () => {
+			question = buildQuestion({ boldSummaryValue: true });
+			question.plainFormatting = true;
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'tonnes');
+
+			assert.strictEqual(result[0].value, 'Tonnes for solid waste');
+		});
+	});
+
+	describe('boldSummaryValue', () => {
+		it('wraps the value in strong tags', () => {
+			question = buildQuestion({ boldSummaryValue: true });
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'tonnes');
+
+			assert.strictEqual(result[0].value, '<strong>Tonnes for solid waste</strong>');
+		});
+
+		it('wraps the combined label and value', () => {
+			question = buildQuestion({ boldSummaryValue: true });
+			mockJourney = withAnswers({ voidCapacityUnitId_tonnes: '55' });
+
+			const result = question.formatAnswerForSummary('segment', mockJourney, 'tonnes');
+
+			assert.strictEqual(result[0].value, '<strong>Capacity: 55t</strong>');
+		});
+	});
+});

--- a/packages/lib/forms/custom-components/multi-conditional-radio/question.ts
+++ b/packages/lib/forms/custom-components/multi-conditional-radio/question.ts
@@ -1,0 +1,80 @@
+import { RadioQuestion } from '@planning-inspectorate/dynamic-forms';
+import type { Question, OptionsQuestionParameters } from '@planning-inspectorate/dynamic-forms';
+import { escapeHtml } from '../../../util/string.ts';
+
+export type MultiConditionalRadioQuestionProps = OptionsQuestionParameters & {
+	/** Prefix for the summary value, e.g. "Capacity". Defaults to the selected option's text. */
+	summaryLabel?: string;
+	/** Suffix appended to the value, keyed by option value, e.g. { litres: 'l' } */
+	summarySuffixes?: Record<string, string>;
+	/** Wraps the summary value in <strong>, e.g. where it heads a manage-list item */
+	boldSummaryValue?: boolean;
+};
+
+/**
+ * A radio question where every option can reveal its own conditional input.
+ *
+ * Unlike ConditionalRadioQuestion, which supports a single trigger value, each
+ * option here carries its own `conditional.fieldName`. The revealed value is
+ * stored under `${fieldName}_${conditional.fieldName}` so the answers stay flat.
+ */
+export default class MultiConditionalRadioQuestion extends RadioQuestion {
+	summaryLabel?: string;
+	summarySuffixes?: Record<string, string>;
+	boldSummaryValue: boolean;
+	/**
+	 * Set by the caller while building table cells, where the column header
+	 * already names the value and emphasis would be arbitrary.
+	 */
+	plainFormatting = false;
+
+	constructor({ summaryLabel, summarySuffixes, boldSummaryValue, ...params }: MultiConditionalRadioQuestionProps) {
+		super(params);
+		this.summaryLabel = summaryLabel;
+		this.summarySuffixes = summarySuffixes;
+		this.boldSummaryValue = boldSummaryValue ?? false;
+	}
+
+	/**
+	 * The answers key holding the revealed value for a given option.
+	 */
+	conditionalAnswerKey(conditionalFieldName: string): string {
+		return `${this.fieldName}_${conditionalFieldName}`;
+	}
+
+	formatAnswerForSummary(
+		...args: Parameters<Question['formatAnswerForSummary']>
+	): ReturnType<Question['formatAnswerForSummary']> {
+		const [sectionSegment, journey, answer] = args;
+
+		const selectedOption = this.options.find((opt) => opt.value === answer);
+		let displayValue = selectedOption ? selectedOption.text : '-';
+
+		const conditionalFieldName = selectedOption?.conditional?.fieldName;
+
+		if (conditionalFieldName) {
+			const conditionalValue = journey.response.answers[this.conditionalAnswerKey(conditionalFieldName)] as
+				string | undefined;
+
+			if (conditionalValue) {
+				const suffix = this.summarySuffixes?.[answer as string] ?? '';
+				const label = this.plainFormatting ? null : (this.summaryLabel ?? selectedOption.text);
+
+				displayValue = label ? `${label}: ${conditionalValue}${suffix}` : `${conditionalValue}${suffix}`;
+			}
+		}
+
+		if (this.boldSummaryValue && !this.plainFormatting) {
+			// The manage-list templates render values with `| safe`, so this survives.
+			displayValue = `<strong>${escapeHtml(displayValue)}</strong>`;
+		}
+
+		return [
+			{
+				key: `${this.title}`,
+				value: displayValue,
+				action: this.getAction(sectionSegment, journey, answer)
+			}
+		];
+	}
+}

--- a/packages/lib/validators/unique-list-field-validator.test.ts
+++ b/packages/lib/validators/unique-list-field-validator.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { validationResult } from 'express-validator';
+import UniqueListFieldValidator from './unique-list-field-validator.ts';
+import type { Question } from '@planning-inspectorate/dynamic-forms/src/questions/question.js';
+
+describe('UniqueListFieldValidator', () => {
+	const questionObj = { fieldName: 'wasteTypeId' } as unknown as Question;
+
+	const buildValidator = () =>
+		new UniqueListFieldValidator({
+			listFieldName: 'manageWasteTypes',
+			displayNameFor: (id) => (id === 'inert-landfill' ? 'Inert landfill' : id),
+			buildErrorMessage: (name) =>
+				`You have already added ${name}. Select a different waste type or change the existing entry`
+		});
+
+	const buildReq = (items: Record<string, unknown>[], body: Record<string, unknown>, params = {}) => ({
+		body,
+		params,
+		res: {
+			locals: {
+				journeyResponse: {
+					answers: { manageWasteTypes: items }
+				}
+			}
+		}
+	});
+
+	const run = async (req: unknown) => {
+		await buildValidator()
+			.validate(questionObj)
+			.run(req as never);
+		return validationResult(req as never);
+	};
+
+	it('passes when the value is not already in the list', async () => {
+		const req = buildReq(
+			[{ id: 'row-1', wasteTypeId: 'inert-landfill' }],
+			{ wasteTypeId: 'hazardous-landfill' },
+			{ manageListItemId: 'row-2' }
+		);
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('fails when another item already has the value', async () => {
+		const req = buildReq(
+			[{ id: 'row-1', wasteTypeId: 'inert-landfill' }],
+			{ wasteTypeId: 'inert-landfill' },
+			{ manageListItemId: 'row-2' }
+		);
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), false);
+
+		const [error] = result.array();
+		assert.strictEqual(
+			error.msg,
+			'You have already added Inert landfill. Select a different waste type or change the existing entry'
+		);
+		assert.strictEqual(error.type, 'field');
+		assert.strictEqual((error as { path: string }).path, 'wasteTypeId');
+	});
+
+	it('passes when editing an item and leaving its own value unchanged', async () => {
+		const req = buildReq(
+			[
+				{ id: 'row-1', wasteTypeId: 'inert-landfill' },
+				{ id: 'row-2', wasteTypeId: 'hazardous-landfill' }
+			],
+			{ wasteTypeId: 'inert-landfill' },
+			{ manageListItemId: 'row-1' }
+		);
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('fails when editing an item to a value another item already has', async () => {
+		const req = buildReq(
+			[
+				{ id: 'row-1', wasteTypeId: 'inert-landfill' },
+				{ id: 'row-2', wasteTypeId: 'hazardous-landfill' }
+			],
+			{ wasteTypeId: 'hazardous-landfill' },
+			{ manageListItemId: 'row-1' }
+		);
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), false);
+	});
+
+	it('passes when the list is empty', async () => {
+		const req = buildReq([], { wasteTypeId: 'inert-landfill' }, { manageListItemId: 'row-1' });
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('passes when the list is missing from the answers', async () => {
+		const req = {
+			body: { wasteTypeId: 'inert-landfill' },
+			params: { manageListItemId: 'row-1' },
+			res: { locals: { journeyResponse: { answers: {} } } }
+		};
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('passes when there is no journeyResponse on the request', async () => {
+		const req = {
+			body: { wasteTypeId: 'inert-landfill' },
+			params: {},
+			res: { locals: {} }
+		};
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('passes when no value was submitted, leaving that to the required validator', async () => {
+		const req = buildReq([{ id: 'row-1', wasteTypeId: 'inert-landfill' }], { wasteTypeId: '' });
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('ignores items that have not yet answered the field', async () => {
+		const req = buildReq(
+			[{ id: 'row-1' }, { id: 'row-2', wasteTypeId: undefined }],
+			{ wasteTypeId: 'inert-landfill' },
+			{ manageListItemId: 'row-3' }
+		);
+
+		const result = await run(req);
+
+		assert.strictEqual(result.isEmpty(), true);
+	});
+
+	it('falls back to the raw value when no displayNameFor is given', async () => {
+		const validator = new UniqueListFieldValidator({
+			listFieldName: 'manageWasteTypes',
+			buildErrorMessage: (name) => `Already added ${name}`
+		});
+
+		const req = buildReq([{ id: 'row-1', wasteTypeId: 'inert-landfill' }], { wasteTypeId: 'inert-landfill' });
+
+		await validator.validate(questionObj).run(req as never);
+		const result = validationResult(req as never);
+
+		assert.strictEqual(result.array()[0].msg, 'Already added inert-landfill');
+	});
+});

--- a/packages/lib/validators/unique-list-field-validator.ts
+++ b/packages/lib/validators/unique-list-field-validator.ts
@@ -1,0 +1,59 @@
+import { body } from 'express-validator';
+import BaseValidator from '@planning-inspectorate/dynamic-forms/src/validator/base-validator.js';
+import type { Question } from '@planning-inspectorate/dynamic-forms/src/questions/question.js';
+
+export interface UniqueListFieldValidatorParams {
+	/** The manage list question's fieldName, e.g. 'manageWasteTypes' */
+	listFieldName: string;
+	/** Builds the error message from the duplicate's display name */
+	buildErrorMessage: (displayName: string) => string;
+	/** Resolves a stored value to something readable */
+	displayNameFor?: (value: string) => string;
+}
+
+/**
+ * Blocks a manage-list item reusing a value another item already has.
+ *
+ * When editing, the item being edited is excluded so leaving its value
+ * unchanged does not fail against itself.
+ */
+export default class UniqueListFieldValidator extends BaseValidator {
+	private listFieldName: string;
+	private buildErrorMessage: (displayName: string) => string;
+	private displayNameFor: (value: string) => string;
+
+	constructor({ listFieldName, buildErrorMessage, displayNameFor }: UniqueListFieldValidatorParams) {
+		super();
+		this.listFieldName = listFieldName;
+		this.buildErrorMessage = buildErrorMessage;
+		this.displayNameFor = displayNameFor ?? ((value) => value);
+	}
+
+	validate(questionObj: Question) {
+		return body(questionObj.fieldName).custom((value, { req }) => {
+			if (typeof value !== 'string' || !value) {
+				return true;
+			}
+
+			// express-validator types req as `any` inside custom validators
+			const typedReq = req as {
+				params?: { manageListItemId?: string };
+				res?: { locals?: { journeyResponse?: { answers?: Record<string, unknown> } } };
+			};
+
+			const answers = typedReq.res?.locals?.journeyResponse?.answers ?? {};
+			const items = (answers[this.listFieldName] as Record<string, unknown>[] | undefined) ?? [];
+
+			// The item being added or edited is already in the list, so skip it
+			const currentItemId = typedReq.params?.manageListItemId;
+
+			const isDuplicate = items.some((item) => item.id !== currentItemId && item[questionObj.fieldName] === value);
+
+			if (isDuplicate) {
+				throw new Error(this.buildErrorMessage(this.displayNameFor(value)));
+			}
+
+			return true;
+		});
+	}
+}


### PR DESCRIPTION
## Describe your changes
Adds the Waste tab to the S62A case view, with a sortable table for waste types and their capacity and throughput.

- Ported TableManageListQuestion - manage list as a table
- New DefinedColumnsTableQuestion - explicit columns and cell formatters
- New MultiConditionalRadioQuestion - unit choice with per-option amount input
- New MultiConditionalNumericValidator and UniqueListFieldValidator
- Ported ManageListItemsCompleteValidator
- First use of withCondition inside a manage list
- Void capacity skipped for four waste types
- Three new lookup tables

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PEAS-231

<img width="949" height="666" alt="Screenshot 2026-08-05 at 15 24 37" src="https://github.com/user-attachments/assets/f86553b6-1db1-4090-a3bc-8ff59531bbe3" />
<img width="928" height="787" alt="Screenshot 2026-08-05 at 15 24 43" src="https://github.com/user-attachments/assets/416109b9-7ae5-45ef-9781-2496920e6f37" />
<img width="850" height="435" alt="Screenshot 2026-08-05 at 15 24 50" src="https://github.com/user-attachments/assets/0197e472-0969-4d06-b305-97a5a911e05d" />
<img width="681" height="430" alt="Screenshot 2026-08-05 at 15 25 03" src="https://github.com/user-attachments/assets/660600d9-201d-4bfa-8722-c02084fcea97" />
<img width="741" height="468" alt="Screenshot 2026-08-05 at 15 25 10" src="https://github.com/user-attachments/assets/072bad6a-88d8-4db6-ac12-ad46f8121502" />
<img width="660" height="378" alt="Screenshot 2026-08-05 at 15 25 31" src="https://github.com/user-attachments/assets/5b85b279-79df-4b03-9a18-45e5f096d1b3" />

