### PR TITLE
fix(manage): peas 386 rename s62a manage header value

### DIFF
--- a/apps/manage/src/util/config-middleware.js
+++ b/apps/manage/src/util/config-middleware.js
@@ -9,7 +9,7 @@ export function addLocalsConfiguration({ appName }) {
 
 		const s62aLinks = [
 			{
-				text: 'Home',
+				text: 'All cases',
 				href: '/s62a/cases'
 			},
 			{


### PR DESCRIPTION
## Describe your changes
Changes Section 62A back office "Home" header field to read "All cases" as specified in the original ticket (PEAS-242)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PEAS-386