### PR TITLE
feat(monetary): add monetary field resolvers for application fees and related amounts

### DIFF
--- a/apps/manage/src/app/audit/resolvers/field-resolver.test.ts
+++ b/apps/manage/src/app/audit/resolvers/field-resolver.test.ts
@@ -286,5 +286,57 @@ describe('Field Resolver', () => {
 				}
 			});
 		});
+
+		describe('monetary field resolvers', () => {
+			it('should format previous number and new number to a monetary strings', () => {
+				const previousCase = { applicationFee: 1.23 };
+				const newAnswer = 1000.0;
+
+				const { oldValue, newValue } = resolveFieldValues('applicationFee', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '£1.23');
+				assert.strictEqual(newValue, '£1000.00');
+			});
+
+			it('should format integers', () => {
+				const previousCase = { applicationFee: 1 };
+				const newAnswer = 1000;
+
+				const { oldValue, newValue } = resolveFieldValues('applicationFee', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '£1.00');
+				assert.strictEqual(newValue, '£1000.00');
+			});
+
+			it('should return "-" for null previous monetary value', () => {
+				const previousCase = { applicationFee: null };
+				const newAnswer = 1000.0;
+
+				const { oldValue, newValue } = resolveFieldValues('applicationFee', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '-');
+				assert.strictEqual(newValue, '£1000.00');
+			});
+
+			it('should return "-" for null new monetary value', () => {
+				const previousCase = { applicationFee: 1000.0 };
+				const newAnswer = null;
+
+				const { oldValue, newValue } = resolveFieldValues('applicationFee', previousCase, newAnswer);
+
+				assert.strictEqual(oldValue, '£1000.00');
+				assert.strictEqual(newValue, '-');
+			});
+
+			it('should handle all registered monetary fields without falling back to default resolver', () => {
+				const monetaryFields = ['cilAmount', 'applicationFee', 'applicationFeeRefundAmount'];
+
+				for (const fieldName of monetaryFields) {
+					const { oldValue, newValue } = resolveFieldValues(fieldName, { [fieldName]: 1000 }, 2000);
+					assert.strictEqual(oldValue, '£1000.00', `${fieldName}: expected oldValue '£1000.00'`);
+					assert.strictEqual(newValue, '£2000.00', `${fieldName}: expected newValue '£2000.00'`);
+				}
+			});
+		});
 	});
 });

--- a/apps/manage/src/app/audit/resolvers/field-resolver.ts
+++ b/apps/manage/src/app/audit/resolvers/field-resolver.ts
@@ -153,6 +153,17 @@ function createLookupResolver(fieldName: string, displayNameMap: Map<string, str
 	};
 }
 
+function monetaryResolver(fieldName: string): FieldResolver {
+	return {
+		resolve(previousCase, newAnswer) {
+			return {
+				oldValue: previousCase[fieldName] ? `£${(previousCase[fieldName] as number).toFixed(2)}` : '-',
+				newValue: newAnswer ? `£${(newAnswer as number).toFixed(2)}` : '-'
+			};
+		}
+	};
+}
+
 /**
  * Registry of field-specific resolvers.
  *
@@ -229,7 +240,17 @@ const FIELD_RESOLVERS: Record<string, FieldResolver> = {
 	applicationReceivedDateEmailSent: booleanResolver('applicationReceivedDateEmailSent'),
 	lpaQuestionnaireSpecialEmailSent: booleanResolver('lpaQuestionnaireSpecialEmailSent'),
 	lpaQuestionnaireReceivedEmailSent: booleanResolver('lpaQuestionnaireReceivedEmailSent'),
-	notNationallyImportantEmailSent: booleanResolver('notNationallyImportantEmailSent')
+	notNationallyImportantEmailSent: booleanResolver('notNationallyImportantEmailSent'),
+
+	// ── Monetary fields ────────────────────────────────────────────────────────
+	// Values need to be formatted with currency '£' as a prefix
+
+	/** Community Infrastructure Levy (CIL) amount */
+	cilAmount: monetaryResolver('cilAmount'),
+	/** Application fee amount */
+	applicationFee: monetaryResolver('applicationFee'),
+	/** Application fee refund amount */
+	applicationFeeRefundAmount: monetaryResolver('applicationFeeRefundAmount')
 };
 
 /**

--- a/apps/manage/src/app/views/cases/view/update-case.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.ts
@@ -105,7 +105,12 @@ const AUDITABLE_SCALAR_FIELDS = new Set([
 	'eligibleForFeeRefund',
 	'cilLiable',
 	'bngExempt',
-	'hasCostsApplications'
+	'hasCostsApplications',
+
+	// Monetary fields
+	'cilAmount',
+	'applicationFee',
+	'applicationFeeRefundAmount'
 ]);
 
 type ErrorWithSummary = Error & { errorSummary: ErrorSummaryItem[] };


### PR DESCRIPTION
## Describe your changes
This pull request adds support for correctly formatting and displaying monetary fields in the audit trail. It introduces a dedicated resolver for monetary fields, updates the resolver registry, and ensures these fields are included in the auditable fields set. Comprehensive tests have also been added to verify the new behavior.

**Monetary field formatting and support:**

* Added a `monetaryResolver` function to format monetary field values with a '£' prefix and two decimal places, returning '-' for null values. (`apps/manage/src/app/audit/resolvers/field-resolver.ts`)
* Registered the monetary resolver for `cilAmount`, `applicationFee`, and `applicationFeeRefundAmount` in the `FIELD_RESOLVERS` registry. (`apps/manage/src/app/audit/resolvers/field-resolver.ts`)
* Included `cilAmount`, `applicationFee`, and `applicationFeeRefundAmount` in the `AUDITABLE_SCALAR_FIELDS` set to ensure they are tracked in the audit system. (`apps/manage/src/app/views/cases/view/update-case.ts`)

**Testing:**

* Added a suite of tests to verify correct formatting, handling of integers and nulls, and coverage for all registered monetary fields. (`apps/manage/src/app/audit/resolvers/field-resolver.test.ts`)
## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1640