### PR TITLE
fix(manage): record audit entry with 'Unknown-user' when userId is missing

### DIFF
--- a/apps/manage/src/app/views/cases/view/update-case.test.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.test.ts
@@ -2737,7 +2737,7 @@ describe('audit recording', () => {
 		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 0);
 	});
 
-	it('should skip audit and log warning when userId is undefined', async () => {
+	it('should record audit entry when userId is not present', async () => {
 		const logger = mockLogger();
 		const mockAudit = createMockAudit();
 		const mockDb = buildDbForAudit({ siteArea: null });
@@ -2745,7 +2745,7 @@ describe('audit recording', () => {
 		const updateCase = buildUpdateCase({ db: mockDb, logger, audit: mockAudit });
 		const mockReq = {
 			params: { id: 'case-1' },
-			session: {} // No account/localAccountId
+			session: { account: { localAccountId: '' } }
 		};
 		const mockRes = { locals: {} };
 		const data = {
@@ -2756,12 +2756,15 @@ describe('audit recording', () => {
 
 		await updateCase({ req: asReq(mockReq), res: asRes(mockRes), data } as any);
 
-		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 0);
-
-		assert.strictEqual((logger as any).warn.mock.callCount(), 1);
-		const warnCall = (logger as any).warn.mock.calls[0];
-		assert.strictEqual(warnCall.arguments[0].caseId, 'case-1');
-		assert.strictEqual(warnCall.arguments[1], 'Skipping audit: no userId available');
+		assert.strictEqual(mockAudit.recordMany.mock.callCount(), 1);
+		const entries = (mockAudit.recordMany.mock.calls[0] as any).arguments[0];
+		assert.strictEqual(entries.length, 1);
+		assert.strictEqual(entries[0].caseId, 'case-1');
+		assert.strictEqual(entries[0].action, AUDIT_ACTIONS.FIELD_SET);
+		assert.strictEqual(entries[0].userId, 'Unknown-user');
+		assert.strictEqual(entries[0].metadata.fieldName, 'Site area (ha)');
+		assert.strictEqual(entries[0].metadata.oldValue, '-');
+		assert.strictEqual(entries[0].metadata.newValue, '10.5');
 	});
 
 	it('should record audit entry for hearingVenue field', async () => {

--- a/apps/manage/src/app/views/cases/view/update-case.ts
+++ b/apps/manage/src/app/views/cases/view/update-case.ts
@@ -470,9 +470,9 @@ async function recordAuditEntries(
 ): Promise<void> {
 	// Bail out early if userId is missing — audit.recordMany requires a userId for every entry
 	// and will throw/log when missing. This avoids noisy error logs and wasted work.
+	const auditUserId = userId || 'Unknown-user';
 	if (!userId) {
-		logger.warn({ caseId, updatedFieldNames }, 'Skipping audit: no userId available');
-		return;
+		logger.warn({ caseId, updatedFieldNames }, 'Recording audit with unknown-user: no userId available');
 	}
 
 	try {
@@ -504,7 +504,7 @@ async function recordAuditEntries(
 			allAuditEntries.push({
 				caseId,
 				action,
-				userId,
+				userId: auditUserId,
 				metadata: {
 					fieldName: getFieldDisplayName(fieldName),
 					oldValue,


### PR DESCRIPTION
## Describe your changes
This pull request improves the audit logging behavior in the case update workflow to ensure that audit entries are always recorded, even when a user ID is missing. Previously, audit entries would be skipped if the user ID was not present, but now a placeholder value is used and a warning is logged. The changes also add a new test to confirm this behavior.

**Audit logging improvements:**

* Changed the audit logging logic in `update-case.ts` to use `'Unknown-user'` as the `userId` when it is missing, ensuring audit entries are always recorded and logging a warning instead of skipping the entry. [[1]](diffhunk://#diff-6e26e0918f33a6815dfe31b2f9f6330d01a493c8d7442ae5515860b08f50f381R473-R475) [[2]](diffhunk://#diff-6e26e0918f33a6815dfe31b2f9f6330d01a493c8d7442ae5515860b08f50f381L507-R507)

**Testing enhancements:**

* Added a test in `update-case.test.ts` to verify that an audit entry is recorded with `userId: 'Unknown-user'` when the user ID is not present.


## Issue ticket number and link
https://pins-ds.atlassian.net/browse/CROWN-1705
<img width="1235" height="534" alt="image" src="https://github.com/user-attachments/assets/93ad07fe-cedd-417b-bcb1-f495def1e1ec" />

