### PR TITLE
chore: adds the moj frontend package to the s62a package json

### DIFF
--- a/apps/s62a-portal/package.json
+++ b/apps/s62a-portal/package.json
@@ -12,6 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@ministryofjustice/frontend": "*",
     "@pins/crowndev-database": "^0.0.0",
     "@pins/crowndev-lib": "^0.0.0",
     "body-parser": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@ministryofjustice/frontend": "*",
         "@pins/crowndev-database": "^0.0.0",
         "@pins/crowndev-lib": "^0.0.0",
         "body-parser": "*",


### PR DESCRIPTION
## Describe your changes
- moj frontend package wasn't defined in the s62a portal app package.json
